### PR TITLE
Skip PersistentPreRun on version subcmd

### DIFF
--- a/cmd/ocp.go
+++ b/cmd/ocp.go
@@ -63,6 +63,9 @@ func openShiftCmd() *cobra.Command {
 	ocpCmd.MarkFlagsRequiredTogether("es-server", "es-index")
 	ocpCmd.MarkFlagsMutuallyExclusive("es-server", "local-indexing")
 	ocpCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		if cmd.Name() == "version" {
+			return
+		}
 		util.ConfigureLogging(cmd)
 		if *extract {
 			if err := workloads.ExtractWorkload(ocpConfig, configDir, cmd.Name(), "alerts.yml", "metrics.yml", "metrics-aggregated.yml", "metrics-report.yml"); err != nil {


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--- Describe your changes in detail -->

Skipping PersistentPreRun() when using the version subcmd

- Related Issue #
- Closes #10
