### PR TITLE
Service latency flag

### DIFF
--- a/cluster-density.go
+++ b/cluster-density.go
@@ -17,6 +17,7 @@ package ocp
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/kube-burner/kube-burner/pkg/workloads"
@@ -27,7 +28,7 @@ import (
 // NewClusterDensity holds cluster-density workload
 func NewClusterDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 	var iterations, churnPercent int
-	var churn bool
+	var churn, svcLatency bool
 	var churnDelay, churnDuration time.Duration
 	var churnDeletionStrategy string
 	var podReadyThreshold time.Duration
@@ -46,6 +47,7 @@ func NewClusterDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Comm
 			os.Setenv("CHURN_PERCENT", fmt.Sprint(churnPercent))
 			os.Setenv("CHURN_DELETION_STRATEGY", churnDeletionStrategy)
 			os.Setenv("POD_READY_THRESHOLD", fmt.Sprintf("%v", podReadyThreshold))
+			os.Setenv("SVC_LATENCY", strconv.FormatBool(svcLatency))
 			ingressDomain, err := wh.MetadataAgent.GetDefaultIngressDomain()
 			if err != nil {
 				log.Fatal("Error obtaining default ingress domain: ", err.Error())
@@ -63,6 +65,7 @@ func NewClusterDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Comm
 	cmd.Flags().DurationVar(&churnDelay, "churn-delay", 2*time.Minute, "Time to wait between each churn")
 	cmd.Flags().IntVar(&churnPercent, "churn-percent", 10, "Percentage of job iterations that kube-burner will churn each round")
 	cmd.Flags().StringVar(&churnDeletionStrategy, "churn-deletion-strategy", "default", "Churn deletion strategy to use")
+	cmd.Flags().BoolVar(&svcLatency, "service-latency", false, "Enable service latency measurement")
 	cmd.MarkFlagRequired("iterations")
 	return cmd
 }

--- a/cmd/config/cluster-density-v2/cluster-density-v2.yml
+++ b/cmd/config/cluster-density-v2/cluster-density-v2.yml
@@ -13,6 +13,10 @@ global:
         - conditionType: Ready
           metric: P99
           threshold: {{.POD_READY_THRESHOLD}}
+{{ if eq .SVC_LATENCY "true" }}
+    - name: serviceLatency
+      svcTimeout: 10s
+{{ end }}
 jobs:
   - name: cluster-density-v2
     namespace: cluster-density-v2

--- a/cmd/config/node-density-cni/node-density-cni.yml
+++ b/cmd/config/node-density-cni/node-density-cni.yml
@@ -13,6 +13,10 @@ global:
         - conditionType: Ready
           metric: P99
           threshold: {{.POD_READY_THRESHOLD}}
+{{ if eq .SVC_LATENCY "true" }}
+    - name: serviceLatency
+      svcTimeout: 10s
+{{ end }}
 jobs:
   - name: node-density-cni
     namespace: node-density-cni

--- a/node-density-cni.go
+++ b/node-density-cni.go
@@ -17,6 +17,7 @@ package ocp
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/kube-burner/kube-burner/pkg/workloads"
@@ -28,7 +29,7 @@ import (
 // NewNodeDensity holds node-density-cni workload
 func NewNodeDensityCNI(wh *workloads.WorkloadHelper) *cobra.Command {
 	var podsPerNode int
-	var namespacedIterations bool
+	var namespacedIterations, svcLatency bool
 	var podReadyThreshold time.Duration
 	var iterationsPerNamespace int
 	cmd := &cobra.Command{
@@ -46,6 +47,7 @@ func NewNodeDensityCNI(wh *workloads.WorkloadHelper) *cobra.Command {
 			os.Setenv("NAMESPACED_ITERATIONS", fmt.Sprint(namespacedIterations))
 			os.Setenv("ITERATIONS_PER_NAMESPACE", fmt.Sprint(iterationsPerNamespace))
 			os.Setenv("POD_READY_THRESHOLD", fmt.Sprintf("%v", podReadyThreshold))
+			os.Setenv("SVC_LATENCY", strconv.FormatBool(svcLatency))
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			wh.Run(cmd.Name(), getMetrics(cmd, "metrics.yml"), alertsProfiles)
@@ -55,5 +57,6 @@ func NewNodeDensityCNI(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().IntVar(&podsPerNode, "pods-per-node", 245, "Pods per node")
 	cmd.Flags().BoolVar(&namespacedIterations, "namespaced-iterations", true, "Namespaced iterations")
 	cmd.Flags().IntVar(&iterationsPerNamespace, "iterations-per-namespace", 1000, "Iterations per namespace")
+	cmd.Flags().BoolVar(&svcLatency, "service-latency", false, "Enable service latency measurement")
 	return cmd
 }

--- a/test/test-ocp.bats
+++ b/test/test-ocp.bats
@@ -44,9 +44,9 @@ teardown_file() {
   check_metric_value clusterMetadata jobSummary podLatencyMeasurement podLatencyQuantilesMeasurement
 }
 
-@test "cluster-density-v2: profile-type=both; user-metadata=true; es-indexing=true; churning=true" {
-  run_cmd kube-burner-ocp cluster-density-v2 --iterations=5 --churn-duration=1m --churn-delay=5s --profile-type=both ${COMMON_FLAGS} --user-metadata=user-metadata.yml
-  check_metric_value cpu-kubelet clusterMetadata jobSummary podLatencyMeasurement podLatencyQuantilesMeasurement etcdVersion
+@test "cluster-density-v2: profile-type=both; user-metadata=true; es-indexing=true; churning=true; svcLatency=true" {
+  run_cmd kube-burner-ocp cluster-density-v2 --iterations=5 --churn-duration=1m --churn-delay=5s --profile-type=both ${COMMON_FLAGS} --user-metadata=user-metadata.yml --service-latency
+  check_metric_value cpu-kubelet clusterMetadata jobSummary podLatencyMeasurement podLatencyQuantilesMeasurement svcLatencyMeasurement svcLatencyQuantilesMeasurement etcdVersion 
 }
 
 @test "cluster-density-v2: churn-deletion-strategy=gvr" {


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adding `service-latency` flag, by default false, to node-density-cni and cluster-density workloads
