### PR TITLE
Fixing cluster-density network policies

### DIFF
--- a/cmd/config/cluster-density-v2/np-allow-from-clients.yml
+++ b/cmd/config/cluster-density-v2/np-allow-from-clients.yml
@@ -13,7 +13,7 @@ spec:
           kubernetes.io/metadata.name: cluster-density-v2-{{.Iteration}}
       podSelector:
         matchLabels:
-          name: client
-  - ports:
+          app: client
+    ports:
     - protocol: TCP
       port: 8080

--- a/cmd/config/cluster-density-v2/np-allow-from-ingress.yml
+++ b/cmd/config/cluster-density-v2/np-allow-from-ingress.yml
@@ -7,10 +7,7 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          network.openshift.io/policy-group: ingress
-  - ports:
+          kubernetes.io/metadata.name: openshift-ingress
+    ports:
     - protocol: TCP
       port: 8080
-  podSelector: {}
-  policyTypes:
-  - Ingress


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Network policies in cluster-density-v2 weren't 100% correct and were allowing traffic to all ports to come in.

Before this change:
```
$ oc describe networkpolicy allow-from-clients                                                                                                                                   
Name:         allow-from-clients                                                                                                                                                                                                              
Namespace:    default                                                                                                                                                                                             
Created on:   2024-02-09 13:00:22 +0100 CET                                                                                                                                                                                                   
Labels:       <none>                                                                                                                                                                                                                          
Annotations:  <none>                                                                                                                                                                                                                          
Spec:                                                                                                                                                                                                                                         
  PodSelector:     app=nginx                                                                                                                                                                                                                  
  Allowing ingress traffic:                                                                                                                                                                                                                   
    To Port: <any> (traffic allowed to all ports)           <------------ Here                                                                                                                                                                                                          
    From:                                                                                                                                                                                                                                     
      NamespaceSelector: kubernetes.io/metadata.name=cluster-density-v2                                                                                                                                                                       
      PodSelector: name=client                                                                                                                                                                                                                
    ----------                                                                                                                                                                                                                                
    To Port: 8080/TCP                                                                                                                                                                                                                         
    From: <any> (traffic not restricted by source)                                                                                                                                                                                            
  Not affecting egress traffic                                                                                                                                                                                                                
  Policy Types: Ingress                                               
```

After:
```
$ oc describe networkpolicy allow-from-clients             
Name:         allow-from-clients                                                                                                                                                                                                              
Namespace:    default                                                                                                                                                                                
Created on:   2024-02-09 13:00:22 +0100 CET                                                                                                                                                                                                   
Labels:       <none>                                                                                                   
Annotations:  <none>                                                                                                                                                                                                                          
Spec:                                                                                                                                                                                                                                         
  PodSelector:     app=nginx                                                                                           
  Allowing ingress traffic:                                                                                            
    To Port: 8080/TCP                                      <-------------- Only 8080/TCP now                                                                                                                                                                                   
    From:                                                                                                                                                                                                                                     
      NamespaceSelector: kubernetes.io/metadata.name=cluster-density-v2                                                                                                                                                                       
      PodSelector: name=client                                                                                                                                                                                                                
  Not affecting egress traffic                                                                                                                                                                                                                
  Policy Types: Ingress     
```
Same applies for the allow-from-ingress network policy

Also updating the namespaceSelector labels to the standard ones in k8s, which are going to be more stable going forward

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
