### PR TITLE
Add missing kube-burner-service-latency namespace in networkpolicy

### DIFF
--- a/cmd/config/cluster-density-v2/np-allow-from-clients.yml
+++ b/cmd/config/cluster-density-v2/np-allow-from-clients.yml
@@ -14,6 +14,9 @@ spec:
       podSelector:
         matchLabels:
           app: client
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-burner-service-latency
     ports:
     - protocol: TCP
       port: 8080


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

W/o this rule, the measurement fails in cdv2

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
