### PR TITLE
Disable default cluster health check in BYOWL workloads

### DIFF
--- a/cluster-density.go
+++ b/cluster-density.go
@@ -20,9 +20,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/kube-burner/kube-burner/pkg/config"
 	"github.com/kube-burner/kube-burner/pkg/workloads"
-	"github.com/openshift/client-go/config/clientset/versioned"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -38,15 +36,6 @@ func NewClusterDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Comm
 		Use:   variant,
 		Short: fmt.Sprintf("Runs %v workload", variant),
 		PreRun: func(cmd *cobra.Command, args []string) {
-			kubeClientProvider := config.NewKubeClientProvider("", "")
-			clientSet, restConfig := kubeClientProvider.ClientSet(0, 0)
-			openshiftClientset, err := versioned.NewForConfig(restConfig)
-			if err != nil {
-				log.Fatalf("Error creating OpenShift clientset: %v", err)
-			}
-			if !ClusterHealthyOcp(clientSet, openshiftClientset) {
-				os.Exit(1)
-			}
 			wh.Metadata.Benchmark = cmd.Name()
 			os.Setenv("JOB_ITERATIONS", fmt.Sprint(iterations))
 			os.Setenv("CHURN", fmt.Sprint(churn))

--- a/custom-workload.go
+++ b/custom-workload.go
@@ -18,9 +18,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/kube-burner/kube-burner/pkg/config"
 	"github.com/kube-burner/kube-burner/pkg/workloads"
-	"github.com/openshift/client-go/config/clientset/versioned"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -31,15 +29,6 @@ func CustomWorkload(wh *workloads.WorkloadHelper) *cobra.Command {
 		Use:   "init",
 		Short: "Runs custom workload",
 		PreRun: func(cmd *cobra.Command, args []string) {
-			kubeClientProvider := config.NewKubeClientProvider("", "")
-			clientSet, restConfig := kubeClientProvider.ClientSet(0, 0)
-			openshiftClientset, err := versioned.NewForConfig(restConfig)
-			if err != nil {
-				log.Fatalf("Error creating OpenShift clientset: %v", err)
-			}
-			if !ClusterHealthyOcp(clientSet, openshiftClientset) {
-				os.Exit(1)
-			}
 			wh.Metadata.Benchmark = benchmarkName
 		},
 		Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Cluster health check shouldn't be executed in custom-workload and cluster-density by default. A user should opt-out this functionally with the flags.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
