### PR TITLE
Maximum metrics for CPU/latency in the report profile

### DIFF
--- a/cmd/config/metrics-report.yml
+++ b/cmd/config/metrics-report.yml
@@ -4,15 +4,27 @@
   metricName: avg-ro-apicalls-latency
   instant: true
 
+- query: max_over_time(histogram_quantile(0.99, sum(irate(apiserver_request_duration_seconds_bucket{apiserver="kube-apiserver", verb=~"LIST|GET", subresource!~"log|exec|portforward|attach|proxy"}[2m])) by (le, resource, verb, scope))[{{.elapsed}}:]) > 0
+  metricName: max-ro-apicalls-latency
+  instant: true
+
 - query: avg_over_time(histogram_quantile(0.99, sum(irate(apiserver_request_duration_seconds_bucket{apiserver="kube-apiserver", verb=~"POST|PUT|DELETE|PATCH", subresource!~"log|exec|portforward|attach|proxy"}[2m])) by (le, resource, verb, scope))[{{.elapsed}}:]) > 0
   metricName: avg-mutating-apicalls-latency
   instant: true
 
+- query: max_over_time(histogram_quantile(0.99, sum(irate(apiserver_request_duration_seconds_bucket{apiserver="kube-apiserver", verb=~"POST|PUT|DELETE|PATCH", subresource!~"log|exec|portforward|attach|proxy"}[2m])) by (le, resource, verb, scope))[{{.elapsed}}:]) > 0
+  metricName: max-mutating-apicalls-latency
+  instant: true
+
   # Kubelet & CRI-O
 
-# Average of the CPU usage from all worker's kubelet
+# Average and max of the CPU usage from all worker's kubelet
 - query: avg(avg_over_time(irate(process_cpu_seconds_total{service="kubelet",job="kubelet"}[2m])[{{.elapsed}}:]) and on (node) kube_node_role{role="worker"})
   metricName: cpu-kubelet
+  instant: true
+
+- query: max(max_over_time(irate(process_cpu_seconds_total{service="kubelet",job="kubelet"}[2m])[{{.elapsed}}:]) and on (node) kube_node_role{role="worker"})
+  metricName: max-cpu-kubelet
   instant: true
 
 # Average of the memory usage from all worker's kubelet
@@ -29,9 +41,13 @@
   metricName: max-memory-sum-kubelet
   instant: true
 
-# Average of the CPU usage from all worker's CRI-O
+# Average and max of the CPU usage from all worker's CRI-O
 - query: avg(avg_over_time(irate(process_cpu_seconds_total{service="kubelet",job="crio"}[2m])[{{.elapsed}}:]) and on (node) kube_node_role{role="worker"})
   metricName: cpu-crio
+  instant: true
+
+- query: max(max_over_time(irate(process_cpu_seconds_total{service="kubelet",job="crio"}[2m])[{{.elapsed}}:]) and on (node) kube_node_role{role="worker"})
+  metricName: max-cpu-crio
   instant: true
 
 # Average of the memory usage from all worker's CRI-O
@@ -54,18 +70,34 @@
   metricName: 99thEtcdDiskBackendCommit
   instant: true
 
+- query: max(max_over_time(histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[2m]))[{{.elapsed}}:]))
+  metricName: max-99thEtcdDiskBackendCommit
+  instant: true
+
 - query: avg(avg_over_time(histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket[2m]))[{{.elapsed}}:]))
   metricName: 99thEtcdDiskWalFsync
+  instant: true
+
+- query: max(max_over_time(histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket[2m]))[{{.elapsed}}:]))
+  metricName: max-99thEtcdDiskWalFsync
   instant: true
 
 - query: avg(avg_over_time(histogram_quantile(0.99, irate(etcd_network_peer_round_trip_time_seconds_bucket[2m]))[{{.elapsed}}:]))
   metricName: 99thEtcdRoundTripTime
   instant: true
 
+- query: max(max_over_time(histogram_quantile(0.99, irate(etcd_network_peer_round_trip_time_seconds_bucket[2m]))[{{.elapsed}}:]))
+  metricName: max-99thEtcdRoundTripTime
+  instant: true
+
 # Control-plane
 
 - query: avg(avg_over_time(topk(1, sum(irate(container_cpu_usage_seconds_total{name!="", namespace="openshift-kube-controller-manager"}[2m])) by (pod))[{{.elapsed}}:]))
   metricName: cpu-kube-controller-manager
+  instant: true
+
+- query: max(max_over_time(topk(1, sum(irate(container_cpu_usage_seconds_total{name!="", namespace="openshift-kube-controller-manager"}[2m])) by (pod))[{{.elapsed}}:]))
+  metricName: max-cpu-kube-controller-manager
   instant: true
 
 - query: avg(avg_over_time(topk(1, sum(container_memory_rss{name!="", namespace="openshift-kube-controller-manager"}) by (pod))[{{.elapsed}}:]))
@@ -84,6 +116,10 @@
   metricName: cpu-kube-apiserver
   instant: true
 
+- query: max(max_over_time(topk(3, sum(irate(container_cpu_usage_seconds_total{name!="", namespace="openshift-kube-apiserver"}[2m])) by (pod))[{{.elapsed}}:]))
+  metricName: max-cpu-kube-apiserver
+  instant: true
+
 - query: avg(avg_over_time(topk(3, sum(container_memory_rss{name!="", namespace="openshift-kube-apiserver"}) by (pod))[{{.elapsed}}:]))
   metricName: memory-kube-apiserver
   instant: true
@@ -98,6 +134,10 @@
 
 - query: avg(avg_over_time(topk(3, sum(irate(container_cpu_usage_seconds_total{name!="", namespace="openshift-apiserver"}[2m])) by (pod))[{{.elapsed}}:]))
   metricName: cpu-openshift-apiserver
+  instant: true
+
+- query: max(max_over_time(topk(3, sum(irate(container_cpu_usage_seconds_total{name!="", namespace="openshift-apiserver"}[2m])) by (pod))[{{.elapsed}}:]))
+  metricName: max-cpu-openshift-apiserver
   instant: true
 
 - query: avg(avg_over_time(topk(3, sum(container_memory_rss{name!="", namespace="openshift-apiserver"}) by (pod))[{{.elapsed}}:]))
@@ -116,6 +156,10 @@
   metricName: cpu-etcd
   instant: true
 
+- query: max(max_over_time(topk(3, sum(irate(container_cpu_usage_seconds_total{name!="", namespace="openshift-etcd"}[2m])) by (pod))[{{.elapsed}}:]))
+  metricName: max-cpu-etcd
+  instant: true
+
 - query: avg(avg_over_time(topk(3,sum(container_memory_rss{name!="", namespace="openshift-etcd"}) by (pod))[{{.elapsed}}:]))
   metricName: memory-etcd
   instant: true
@@ -132,6 +176,10 @@
   metricName: cpu-openshift-controller-manager
   instant: true
 
+- query: max(max_over_time(topk(1, sum(irate(container_cpu_usage_seconds_total{name!="", namespace="openshift-controller-manager"}[2m])) by (pod))[{{.elapsed}}:]))
+  metricName: max-cpu-openshift-controller-manager
+  instant: true
+
 - query: avg(avg_over_time(topk(1, sum(container_memory_rss{name!="", namespace="openshift-controller-manager"}) by (pod))[{{.elapsed}}:]))
   metricName: memory-openshift-controller-manager
   instant: true
@@ -144,6 +192,10 @@
 
 - query: avg(avg_over_time(irate(container_cpu_usage_seconds_total{name!="", namespace="openshift-multus", pod=~"(multus).+", container!="POD"}[2m])[{{.elapsed}}:])) by (container)
   metricName: cpu-multus
+  instant: true
+
+- query: max(max_over_time(irate(container_cpu_usage_seconds_total{name!="", namespace="openshift-multus", pod=~"(multus).+", container!="POD"}[2m])[{{.elapsed}}:])) by (container)
+  metricName: max-cpu-multus
   instant: true
 
 - query: avg(avg_over_time(container_memory_rss{name!="", namespace="openshift-multus", pod=~"(multus).+", container!="POD"}[{{.elapsed}}:])) by (container)
@@ -160,6 +212,10 @@
   metricName: cpu-ovn-control-plane
   instant: true
 
+- query: max(max_over_time(irate(container_cpu_usage_seconds_total{name!="", namespace="openshift-ovn-kubernetes", pod=~"(ovnkube-master|ovnkube-control-plane).+", container!="POD"}[2m])[{{.elapsed}}:])) by (container)
+  metricName: max-cpu-ovn-control-plane
+  instant: true
+
 - query: avg(avg_over_time(container_memory_rss{name!="", namespace="openshift-ovn-kubernetes", pod=~"(ovnkube-master|ovnkube-control-plane).+", container!="POD"}[{{.elapsed}}:])) by (container)
   metricName: memory-ovn-control-plane
   instant: true
@@ -170,6 +226,10 @@
 
 - query: avg(avg_over_time(irate(container_cpu_usage_seconds_total{name!="", namespace="openshift-ovn-kubernetes", pod=~"ovnkube-node.+", container!="POD"}[2m])[{{.elapsed}}:])) by (container)
   metricName: cpu-ovnkube-node
+  instant: true
+
+- query: max(max_over_time(irate(container_cpu_usage_seconds_total{name!="", namespace="openshift-ovn-kubernetes", pod=~"ovnkube-node.+", container!="POD"}[2m])[{{.elapsed}}:])) by (container)
+  metricName: max-cpu-ovnkube-node
   instant: true
 
 - query: avg(avg_over_time(container_memory_rss{name!="", namespace="openshift-ovn-kubernetes", pod=~"ovnkube-node.+", container!="POD"}[{{.elapsed}}:])) by (container)
@@ -184,6 +244,10 @@
 
 - query: avg(avg_over_time(sum(irate(node_cpu_seconds_total{mode!="idle", mode!="steal"}[2m]) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")) by (instance)[{{.elapsed}}:]))
   metricName: cpu-masters
+  instant: true
+
+- query: max(max_over_time(sum(irate(node_cpu_seconds_total{mode!="idle", mode!="steal"}[2m]) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")) by (instance)[{{.elapsed}}:]))
+  metricName: max-cpu-masters
   instant: true
 
 - query: avg(avg_over_time((node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes)[{{.elapsed}}:]) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)"))
@@ -202,6 +266,10 @@
   metricName: cpu-workers
   instant: true
 
+- query: max(max_over_time(sum(irate(node_cpu_seconds_total{mode!="idle", mode!="steal"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (instance)[{{.elapsed}}:]))
+  metricName: max-cpu-workers
+  instant: true
+
 - query: avg(avg_over_time((node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes)[{{.elapsed}}:]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)"))
   metricName: memory-workers
   instant: true
@@ -216,6 +284,10 @@
 
 - query: avg(avg_over_time(sum(irate(node_cpu_seconds_total{mode!="idle", mode!="steal"}[2m]) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) by (instance)[{{.elapsed}}:]))
   metricName: cpu-infra
+  instant: true
+
+- query: max(max_over_time(sum(irate(node_cpu_seconds_total{mode!="idle", mode!="steal"}[2m]) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) by (instance)[{{.elapsed}}:]))
+  metricName: max-cpu-infra
   instant: true
 
 - query: avg(avg_over_time((node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes)[{{.elapsed}}:]) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)"))
@@ -236,6 +308,10 @@
   metricName: cpu-prometheus
   instant: true
 
+- query: max(max_over_time(sum(irate(container_cpu_usage_seconds_total{name!="", namespace="openshift-monitoring", pod=~"prometheus-k8s.+"}[2m])) by (pod)[{{.elapsed}}:]))
+  metricName: max-cpu-prometheus
+  instant: true
+
 - query: avg(avg_over_time(sum(container_memory_rss{name!="", namespace="openshift-monitoring", pod=~"prometheus-k8s.+"}) by (pod)[{{.elapsed}}:]))
   metricName: memory-prometheus
   instant: true
@@ -246,6 +322,10 @@
 
 - query: avg(avg_over_time(sum(irate(container_cpu_usage_seconds_total{name!="", namespace="openshift-ingress", pod=~"router-default.+"}[2m])) by (pod)[{{.elapsed}}:]))
   metricName: cpu-router
+  instant: true
+
+- query: max(max_over_time(sum(irate(container_cpu_usage_seconds_total{name!="", namespace="openshift-ingress", pod=~"router-default.+"}[2m])) by (pod)[{{.elapsed}}:]))
+  metricName: max-cpu-router
   instant: true
 
 - query: avg(avg_over_time(sum(container_memory_rss{name!="", namespace="openshift-ingress", pod=~"router-default.+"}) by (pod)[{{.elapsed}}:]))


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

For telco use cases _maximum_ is more relevant than _average_. Nowadays the reporting profile only includes maximum metrics for memory, but not for CPU and latency. This PR adds _maximum_ for the missing metrics.

## Related Tickets & Documents

- Related Issue https://github.com/kube-burner/kube-burner-ocp/issues/50
- Closes https://github.com/kube-burner/kube-burner-ocp/issues/50

## Checklist before requesting a review

- [x] I have performed a self-review of my code.

## Internal note
If/when merged we should change the grafana **_kube-burner/Kube-burner report mode_** dashboard for **_Jose/Kube-burner report telco_**