### PR TITLE
Baremetal was broken due to incorrect np

### DIFF
--- a/cmd/config/cluster-density-v2/np-allow-from-ingress.yml
+++ b/cmd/config/cluster-density-v2/np-allow-from-ingress.yml
@@ -7,7 +7,7 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          kubernetes.io/metadata.name: openshift-ingress
+          network.openshift.io/policy-group: ingress
     ports:
     - protocol: TCP
       port: 8080


### PR DESCRIPTION

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
After / Before -

```
[root@e24-h01-000-r640 ~]# oc get namespace -l network.openshift.io/policy-group=ingress
NAME                     STATUS   AGE
openshift-host-network   Active   24h
openshift-ingress        Active   24h
[root@e24-h01-000-r640 ~]# oc get namespace -l kubernetes.io/metadata.name=openshift-ingress
NAME                STATUS   AGE
openshift-ingress   Active   24h
[root@e24-h01-000-r640 ~]#
```

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
