### PR TITLE
[web-burner] Add explicit frr local-address

### DIFF
--- a/cmd/config/web-burner-init/pod_serving.yml
+++ b/cmd/config/web-burner-init/pod_serving.yml
@@ -48,7 +48,7 @@ spec:
           - >-
              sysctl -w net.ipv4.ip_forward=1 &&
              cp /config/* /etc/frr/ &&
-             for i in $(kubectl get node --selector='!node-role.kubernetes.io/worker-spk' -o jsonpath='{.items[*].status.addresses[0].address}'); do echo " peer $i" >> /etc/frr/frr.conf; done &&
+             for i in $(kubectl get node --selector='!node-role.kubernetes.io/worker-spk' -o jsonpath='{.items[*].status.addresses[0].address}'); do echo " peer $i local-address $(ifconfig net1 | awk -F ' *|:' '/inet /{print $3}')" >> /etc/frr/frr.conf; done &&
              echo "  no shutdown" >> /etc/frr/frr.conf &&
              echo " !" >> /etc/frr/frr.conf &&
              echo "! subnets for each node" >> /etc/frr/frr.conf &&


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When we bumped FRR version from 8.0 to 8.5 as part of the multiarch effort FRR BFD **LocalAdress** field got populated to 0.0.0.0, breaking the readiness probe conditions:
```
sh-5.1# vtysh -c 'show bfd peers brief'
Session count: 2
SessionId  LocalAddress                             PeerAddress                             Status
=========  ============                             ===========                             ======
3980134474 192.168.219.1                            192.168.216.2                           up
1176606216 unknown                                  192.168.216.4                           down
sh-5.1# rpm -aq frr
frr-8.0-5.el9.x86_64
```

```
sh-5.1# vtysh -c 'show bfd peers brief'
Session count: 2
SessionId  LocalAddress                             PeerAddress                             Status
=========  ============                             ===========                             ======
1524679135 0.0.0.0                                  192.168.216.4                           down
2653925215 0.0.0.0                                  192.168.216.2                           up
sh-5.1# rpm -aq frr
frr-8.5.3-4.el9.x86_64
```
