### PR TITLE
jobIterations issue adjustment in web-burner-cluster-density

### DIFF
--- a/cmd/config/web-burner-cluster-density/web-burner-cluster-density.yml
+++ b/cmd/config/web-burner-cluster-density/web-burner-cluster-density.yml
@@ -145,8 +145,11 @@ jobs:
 
   - name: app-job-3
     jobType: create
+{{ if eq "1" .LIMITCOUNT }}
     jobIterations: 1
+{{ else }}
     jobIterations: {{ mul 2 .SCALE }}
+{{ end }}
     qps: {{ .QPS }}
     burst: {{ .BURST }}
     namespacedIterations: true


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
When limitount is greater than 1:
```
time="2024-06-18 12:59:45" level=fatal msg="error decoding configuration file: yaml: unmarshal errors:\n  line 163: mapping key \"jobIterations\" already defined at line 162" file="helpers.go:85"
```

This PR fixes this.