### PR TITLE
added image-registry check

### DIFF
--- a/cluster-density.go
+++ b/cluster-density.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/kube-burner/kube-burner/pkg/config"
 	"github.com/kube-burner/kube-burner/pkg/workloads"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -52,6 +53,11 @@ func NewClusterDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Comm
 			os.Setenv("INGRESS_DOMAIN", ingressDomain)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
+			kubeClientProvider := config.NewKubeClientProvider("", "")
+			clientset, _ := kubeClientProvider.ClientSet(0, 0)
+			if !clusterImageRegistryCheck(clientset) {
+				log.Errorf("image-registry deployment is not deployed")
+			}
 			setMetrics(cmd, "metrics-aggregated.yml")
 			wh.Run(cmd.Name())
 		},

--- a/cluster-density.go
+++ b/cluster-density.go
@@ -53,10 +53,12 @@ func NewClusterDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Comm
 			os.Setenv("INGRESS_DOMAIN", ingressDomain)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			kubeClientProvider := config.NewKubeClientProvider("", "")
-			clientset, _ := kubeClientProvider.ClientSet(0, 0)
-			if !clusterImageRegistryCheck(clientset) {
-				log.Errorf("image-registry deployment is not deployed")
+			if cmd.Name() == "cluster-density-v2" {
+				kubeClientProvider := config.NewKubeClientProvider("", "")
+				clientset, _ := kubeClientProvider.ClientSet(0, 0)
+				if !clusterImageRegistryCheck(clientset) {
+					log.Errorf("image-registry deployment is not deployed")
+				}
 			}
 			setMetrics(cmd, "metrics-aggregated.yml")
 			wh.Run(cmd.Name())

--- a/cluster_health.go
+++ b/cluster_health.go
@@ -63,6 +63,12 @@ func isClusterHealthy(clientset kubernetes.Interface, openshiftClientset *versio
 		log.Errorf("Error retrieving Cluster Operators: %v", err)
 		os.Exit(1)
 	}
+	imageRegistryisPresent := clusterImageRegistryCheck(openshiftClientset)
+
+	if !imageRegistryisPresent {
+		log.Errorf("image-registry is not installed")
+		isHealthy = false
+	}
 
 	for _, operator := range operators.Items {
 		// Check availability conditions
@@ -91,4 +97,20 @@ func isClusterHealthy(clientset kubernetes.Interface, openshiftClientset *versio
 		}
 	}
 	return isHealthy
+}
+
+func clusterImageRegistryCheck(openshiftClientset *versioned.Clientset) bool {
+	log.Infof("Checking for image-registry")
+	clusterOperator, err := openshiftClientset.ConfigV1().ClusterOperators().Get(context.TODO(), "image-registry", metav1.GetOptions{})
+	if err != nil {
+		log.Errorf("Failed to get ClusterOperator image-registry: %v", err)
+		return false
+	}
+
+	if clusterOperator.Status.Conditions == nil {
+		log.Errorf("ClusterOperator image-registry status conditions are nil")
+		return false
+	}
+	//check for operator availability status is done in isClusterHealthy
+	return true
 }

--- a/cluster_health.go
+++ b/cluster_health.go
@@ -100,7 +100,7 @@ func clusterImageRegistryCheck(clientset kubernetes.Interface) bool {
 		return false
 	}
 	if deployment.Status.AvailableReplicas > 0 {
-		log.Infof("Deployment image-regsitry in namespace openshift-image-registry is available with %d replicas", deployment.Status.AvailableReplicas)
+		log.Debugf("Deployment image-regsitry in namespace openshift-image-registry is available with %d replicas", deployment.Status.AvailableReplicas)
 		return true
 	}
 	return false


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Added image registry check for kube-burner-ocp, this can be used for bare-metal instances where image-registry co is not present by default.

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #79
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
