### PR TITLE
Make crd-scale Namespaced scope

### DIFF
--- a/cmd/config/crd-scale/example-crd.yml
+++ b/cmd/config/crd-scale/example-crd.yml
@@ -19,7 +19,7 @@ spec:
                   type: string
                 iterations:
                   type: integer
-  scope: Cluster
+  scope: Namespaced
   names:
     plural: kubeburners{{.Iteration}}
     singular: kubeburner{{.Iteration}}


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Namespaced CRDs allow better to chunking into namespaces for a variety of purposes. When they are cluster scoped, their application can be less flexible.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
