### PR TITLE
Adding wait conditions to crd-scale

### DIFF
--- a/cmd/config/crd-scale/crd-scale.yml
+++ b/cmd/config/crd-scale/crd-scale.yml
@@ -27,9 +27,10 @@ jobs:
     qps: {{.QPS}}
     burst: {{.BURST}}
     namespacedIterations: false
-    waitWhenFinished: false
+    waitWhenFinished: true
     objects:
-
       - objectTemplate: example-crd.yml
         replicas: 1
+        waitOptions:
+          forCondition: Established        
 


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Adding `waitOptions` to crd-scale workload, to wait for all crd to be in `Established` state before cleanup. 

Without wait 
```
time="2024-07-23 16:58:37" level=info msg="Verifying created objects" file="utils.go:85"
time="2024-07-23 16:58:38" level=info msg="customresourcedefinitions found: 20 Expected: 20" file="utils.go:118"
time="2024-07-23 16:58:38" level=info msg="Job crd-scale took 1s" file="job.go:197"
time="2024-07-23 16:58:38" level=info msg="Indexing metric jobSummary" file="metadata.go:58"
time="2024-07-23 16:58:38" level=info msg="Deleting non-namespace CustomResourceDefinition with selector kube-burner-job=crd-scale" file="namespaces.go:59"
```

With wait
```
time="2024-07-23 16:50:49" level=info msg="Waiting up to 4h0m0s for actions to be completed" file="create.go:178"
time="2024-07-23 16:50:50" level=debug msg="Waiting for customresourcedefinitions to be ready" file="waiters.go:288"
time="2024-07-23 16:51:00" level=info msg="Actions in namespace  completed" file="waiters.go:80"
time="2024-07-23 16:51:00" level=info msg="Verifying created objects" file="utils.go:85"
time="2024-07-23 16:51:00" level=info msg="customresourcedefinitions found: 20 Expected: 20" file="utils.go:118"
time="2024-07-23 16:51:00" level=info msg="Job crd-scale took 11s" file="job.go:196"
```

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
