### PR TITLE
Fix golangci-lint precommit hook

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,6 @@ linters:
     - goimports
     - dupl
     - unparam
-    - revive
     - staticcheck
     - gosimple
     - unconvert

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,9 @@
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.58.1
+    rev: v1.55.2
     hooks:
       - id: golangci-lint
+        entry: golangci-lint run
         args: [--timeout=5m]
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.34.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.55.2
+    rev: v1.60.3
     hooks:
       - id: golangci-lint
         entry: golangci-lint run

--- a/cluster_health.go
+++ b/cluster_health.go
@@ -100,7 +100,7 @@ func clusterImageRegistryCheck(clientset kubernetes.Interface) bool {
 		return false
 	}
 	if deployment.Status.AvailableReplicas > 0 {
-		log.Debugf("Deployment image-regsitry in namespace openshift-image-registry is available with %d replicas", deployment.Status.AvailableReplicas)
+		log.Debugf("Deployment image-registry in namespace openshift-image-registry is available with %d replicas", deployment.Status.AvailableReplicas)
 		return true
 	}
 	return false

--- a/egressip.go
+++ b/egressip.go
@@ -102,19 +102,18 @@ func getFirstUsableAddr(cidr string) uint32 {
 	baseAddrInt, err := ipconv.IPv4ToInt(firstUsableIP)
 	if err != nil {
 		log.Fatal("Error converting IP to int: ", err)
-		os.Exit(1)
 	}
 	return baseAddrInt
 }
 
-// egress IPs and node IPs will be in same cidr. So we need to exclude node IPs from CIDR to generate list of avaialble egress IPs.
+// egress IPs and node IPs will be in same cidr. So we need to exclude node IPs from CIDR to generate list of available egress IPs.
 func generateEgressIPs(numJobIterations int, addressesPerIteration int, externalServerIP string) {
 
 	nodeIPs, egressIPCidr := getEgressIPCidrNodeIPs()
 	// Add external server ip to nodeIPs to get excluded while creating egress ip list
 	nodeIPs = append(nodeIPs, externalServerIP)
 	baseAddrInt := getFirstUsableAddr(egressIPCidr)
-	// list to host avaialble egress IPs
+	// list to host available egress IPs
 	addrSlice := make([]string, 0, (numJobIterations * addressesPerIteration))
 
 	// map to store nodeIPs
@@ -123,7 +122,6 @@ func generateEgressIPs(numJobIterations int, addressesPerIteration int, external
 		nodeipuint32, err := ipconv.IPv4ToInt(net.ParseIP(nodeip))
 		if err != nil {
 			log.Fatal("Error: ", err)
-			os.Exit(1)
 		}
 		nodeMap[nodeipuint32] = true
 	}

--- a/index.go
+++ b/index.go
@@ -15,17 +15,17 @@
 package ocp
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
-	"encoding/json"
 	"time"
-	"fmt"
 
 	"github.com/cloud-bulldozer/go-commons/indexers"
-	"github.com/cloud-bulldozer/go-commons/version"
 	ocpmetadata "github.com/cloud-bulldozer/go-commons/ocp-metadata"
-	"github.com/kube-burner/kube-burner/pkg/config"
+	"github.com/cloud-bulldozer/go-commons/version"
 	"github.com/kube-burner/kube-burner/pkg/burner"
+	"github.com/kube-burner/kube-burner/pkg/config"
 	"github.com/kube-burner/kube-burner/pkg/prometheus"
 	"github.com/kube-burner/kube-burner/pkg/util/metrics"
 	"github.com/kube-burner/kube-burner/pkg/workloads"
@@ -133,17 +133,17 @@ func NewIndex(metricsEndpoint *string, ocpMetaAgent *ocpmetadata.Metadata) *cobr
 				break
 			}
 			jobSummary := burner.JobSummary{
-				Timestamp: time.Unix(start, 0).UTC(),
+				Timestamp:    time.Unix(start, 0).UTC(),
 				EndTimestamp: time.Unix(end, 0).UTC(),
-				ElapsedTime: time.Unix(end, 0).UTC().Sub(time.Unix(start, 0).UTC()).Round(time.Second).Seconds(),
-				UUID: uuid,
+				ElapsedTime:  time.Unix(end, 0).UTC().Sub(time.Unix(start, 0).UTC()).Round(time.Second).Seconds(),
+				UUID:         uuid,
 				JobConfig: config.Job{
 					Name: jobName,
 				},
-				Metadata: metricsScraper.Metadata,
+				Metadata:   metricsScraper.Metadata,
 				MetricName: "jobSummary",
-				Version: fmt.Sprintf("%v@%v", version.Version, version.GitCommit),
-				Passed: rc == 0,
+				Version:    fmt.Sprintf("%v@%v", version.Version, version.GitCommit),
+				Passed:     rc == 0,
 			}
 			burner.IndexJobSummary([]burner.JobSummary{jobSummary}, indexerValue)
 		},


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The previous hook wasn't working as expected as it was relying on this configuration https://github.com/golangci/golangci-lint/blob/master/.pre-commit-hooks.yaml#L1-L8 `golangci-lint run --new-from-rev HEAD --fix`, the hook's command basically fixes linting errors when the current code is different from HEAD (so no action is taken when changes are committed), this is not what we actually need, we want to report and hang on linting errors caused by a PR.

Also fixing some pieces of code to meet linting.

## Related Tickets & Documents

- Related Issue #
- Closes #
