### PR TITLE
Append extra metrics file

### DIFF
--- a/common.go
+++ b/common.go
@@ -44,8 +44,8 @@ func setMetrics(cmd *cobra.Command, metricsProfile string) {
 	if ok {
 		log.Info("Found EXTRA_METRICS=", val)
 		metricsProfiles = append(metricsProfiles, val)
+		log.Info("Appended EXTRA_METRICS to metrics list: ", strings.Join(metricsProfiles, ","))
 	}
-	log.Info("Setting METRICS=", strings.Join(metricsProfiles, ","))
 	os.Setenv("METRICS", strings.Join(metricsProfiles, ","))
 }
 


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

If env var EXTRA_METRICS is set, append the value to the METRICS list that will be used by kube-burner configuration. This will allow adding a custom-metrics.yml file at kube-burner-ocp execution for additional prometheus metrics to scrape and index (adding to the existing metrics and not replacing them).

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
