### PR TITLE
Don't call health-check twice

### DIFF
--- a/cmd/ocp.go
+++ b/cmd/ocp.go
@@ -72,7 +72,7 @@ func openShiftCmd() *cobra.Command {
 			}
 			os.Exit(0)
 		}
-		if checkHealth {
+		if checkHealth && cmd.Name() != "cluster-health" {
 			ocp.ClusterHealthCheck()
 		}
 		workloadConfig.ConfigDir = configDir


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When running `kube-burner-ocp cluster-health`, cluster health was being called twice, one from the subcommand and another one from the root cmd PersistentPreRun hook

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
