### PR TITLE
pods-per-node and iterations shouln't have default values higher than 0

### DIFF
--- a/custom-workload.go
+++ b/custom-workload.go
@@ -77,11 +77,11 @@ func CustomWorkload(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().StringVar(&churnDeletionStrategy, "churn-deletion-strategy", "default", "Churn deletion strategy to use")
 	cmd.Flags().DurationVar(&churnDuration, "churn-duration", 5*time.Minute, "Churn duration")
 	cmd.Flags().IntVar(&churnPercent, "churn-percent", 10, "Percentage of job iterations that kube-burner will churn each round")
-	cmd.Flags().IntVar(&iterations, "iterations", 1, "Job iterations. Mutually exclusive with '--pods-per-node'")
+	cmd.Flags().IntVar(&iterations, "iterations", 0, "Job iterations. Mutually exclusive with '--pods-per-node'")
 	cmd.Flags().IntVar(&iterationsPerNamespace, "iterations-per-namespace", 1, "Iterations per namespace")
 	// Adding a super set of flags from other commands so users can decide if they want to use them
 	cmd.Flags().BoolVar(&namespacedIterations, "namespaced-iterations", true, "Namespaced iterations")
-	cmd.Flags().IntVar(&podsPerNode, "pods-per-node", 50, "Pods per node. Mutually exclusive with '--iterations'")
+	cmd.Flags().IntVar(&podsPerNode, "pods-per-node", 0, "Pods per node. Mutually exclusive with '--iterations'")
 	cmd.Flags().BoolVar(&svcLatency, "service-latency", false, "Enable service latency measurement")
 	// pods-per-node calculates iterations, thus the two are mutually exclusive.
 	cmd.MarkFlagsMutuallyExclusive("iterations", "pods-per-node")


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

These two flags should have a null default value, that is causing that the value of pods-per-node=50 takes precedence over the value configured in --iterations, as they are mutually exclusive, it's not possible to set iterations to a value different than pods-per-node.

w/o patch:
```yaml
rsevilla@wonderland ~/labs/kube-burner-ocp/test/ocp (main) $ cat ^C
rsevilla@wonderland ~/labs/kube-burner-ocp/test/ocp (main) $ cat  custom-workload.yml 
---
jobs:
  - name: node-density
    namespace: node-density
    jobIterations: {{.JOB_ITERATIONS}}
    qps: {{.QPS}}
    burst: {{.BURST}}
    namespacedIterations: false
    podWait: false
    waitWhenFinished: true
    preLoadImages: true
    preLoadPeriod: 10s
    namespaceLabels:
      security.openshift.io/scc.podSecurityLabelSync: false
      pod-security.kubernetes.io/enforce: privileged
      pod-security.kubernetes.io/audit: privileged
      pod-security.kubernetes.io/warn: privileged
    objects:

      - objectTemplate: pod.yaml
        replicas: 1
        inputVars:
          containerImage: registry.k8s.io/pause:3.1
```

```shell
rsevilla@wonderland ~/labs/kube-burner-ocp/test/ocp (main) $ ../../bin/amd64/kube-burner-ocp init -c custom-workload.yml --iterations=10
time="2024-09-11 17:45:55" level=info msg="❤️  Checking for Cluster Health" file="cluster_health.go:45"
time="2024-09-11 17:45:56" level=info msg="Cluster is Healthy" file="cluster_health.go:53"
time="2024-09-11 17:45:59" level=info msg="Config file custom-workload.yml available in the current directory, using it" file="helpers.go:61"
time="2024-09-11 17:45:59" level=fatal msg="Job node-density has < 1 iterations" file="config.go:148"
```
Patched version
```shell
rsevilla@wonderland ~/labs/kube-burner-ocp/test/ocp (fix-custom-workload) $ ../../bin/amd64/kube-burner-ocp init -c custom-workload.yml --iterations=10

time="2024-09-11 17:46:37" level=info msg="❤️  Checking for Cluster Health" file="cluster_health.go:45"
time="2024-09-11 17:46:38" level=info msg="Cluster is Healthy" file="cluster_health.go:53"
time="2024-09-11 17:46:40" level=info msg="Config file custom-workload.yml available in the current directory, using it" file="helpers.go:61"
time="2024-09-11 17:46:40" level=info msg="🔥 Starting kube-burner (fix-custom-workload@da099b5ea193172004967f1ef3981c717806cfe1) with UUID 421ad6b8-ee0d-4f80-bc40-092d3253f362" file="job.go:106"
time="2024-09-11 17:46:40" level=info msg="Job node-density: 10 iterations with 1 Pod replicas" file="create.go:92"
time="2024-09-11 17:46:40" level=info msg="Pre-load: images from job node-density" file="pre_load.go:45"
time="2024-09-11 17:46:41" level=info msg="Pre-load: Creating DaemonSet using images [gcr.io/google_containers/pause:3.1] in namespace preload-kube-burner" file="pre_load.go:155"
time="2024-09-11 17:46:41" level=info msg="Pre-load: Sleeping for 10s" file="pre_load.go:58"

```


cc: @josecastillolema 

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
