### PR TITLE
add PostRun for workloads

### DIFF
--- a/crd-scale.go
+++ b/crd-scale.go
@@ -26,6 +26,7 @@ import (
 func NewCrdScale(wh *workloads.WorkloadHelper) *cobra.Command {
 	var iterations int
 	var metricsProfiles []string
+	var rc int
 	cmd := &cobra.Command{
 		Use:          "crd-scale",
 		Short:        "Runs crd-scale workload",
@@ -35,7 +36,10 @@ func NewCrdScale(wh *workloads.WorkloadHelper) *cobra.Command {
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			setMetrics(cmd, metricsProfiles)
-			wh.Run(cmd.Name())
+			rc = wh.Run(cmd.Name())
+		},
+		PostRun: func(cmd *cobra.Command, args []string) {
+			os.Exit(rc)
 		},
 	}
 	cmd.Flags().IntVar(&iterations, "iterations", 0, "Number of CRDs to create")

--- a/custom-workload.go
+++ b/custom-workload.go
@@ -31,6 +31,7 @@ func CustomWorkload(wh *workloads.WorkloadHelper) *cobra.Command {
 	var churnDelay, churnDuration, podReadyThreshold time.Duration
 	var configFile, churnDeletionStrategy string
 	var iterations, churnPercent, churnCycles, iterationsPerNamespace, podsPerNode int
+	var rc int
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Runs custom workload",
@@ -67,7 +68,10 @@ func CustomWorkload(wh *workloads.WorkloadHelper) *cobra.Command {
 				log.Fatalf("Error reading custom configuration file: %v", err.Error())
 			}
 			configFileName := strings.Split(configFile, ".")[0]
-			wh.Run(configFileName)
+			rc = wh.Run(configFileName)
+		},
+		PostRun: func(cmd *cobra.Command, args []string) {
+			os.Exit(rc)
 		},
 	}
 	cmd.Flags().StringVarP(&configFile, "config", "c", "", "Config file path or url")

--- a/egressip.go
+++ b/egressip.go
@@ -150,6 +150,7 @@ func NewEgressIP(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 	var externalServerIP string
 	var podReadyThreshold time.Duration
 	var metricsProfiles []string
+	var rc int
 	cmd := &cobra.Command{
 		Use:   variant,
 		Short: fmt.Sprintf("Runs %v workload", variant),
@@ -162,7 +163,10 @@ func NewEgressIP(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			setMetrics(cmd, metricsProfiles)
-			wh.Run(cmd.Name())
+			rc = wh.Run(cmd.Name())
+		},
+		PostRun: func(cmd *cobra.Command, args []string) {
+			os.Exit(rc)
 		},
 	}
 	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 2*time.Minute, "Pod ready timeout threshold")

--- a/networkpolicy.go
+++ b/networkpolicy.go
@@ -30,6 +30,7 @@ func NewNetworkPolicy(wh *workloads.WorkloadHelper, variant string) *cobra.Comma
 	var churnDelay, churnDuration time.Duration
 	var churnDeletionStrategy string
 	var metricsProfiles []string
+	var rc int
 	cmd := &cobra.Command{
 		Use:   variant,
 		Short: fmt.Sprintf("Runs %v workload", variant),
@@ -44,7 +45,10 @@ func NewNetworkPolicy(wh *workloads.WorkloadHelper, variant string) *cobra.Comma
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			setMetrics(cmd, metricsProfiles)
-			wh.Run(cmd.Name())
+			rc = wh.Run(cmd.Name())
+		},
+		PostRun: func(cmd *cobra.Command, args []string) {
+			os.Exit(rc)
 		},
 	}
 	cmd.Flags().IntVar(&iterations, "iterations", 0, fmt.Sprintf("%v iterations", variant))

--- a/node-density-cni.go
+++ b/node-density-cni.go
@@ -33,6 +33,7 @@ func NewNodeDensityCNI(wh *workloads.WorkloadHelper) *cobra.Command {
 	var podReadyThreshold time.Duration
 	var iterationsPerNamespace int
 	var metricsProfiles []string
+	var rc int
 	cmd := &cobra.Command{
 		Use:          "node-density-cni",
 		Short:        "Runs node-density-cni workload",
@@ -51,7 +52,10 @@ func NewNodeDensityCNI(wh *workloads.WorkloadHelper) *cobra.Command {
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			setMetrics(cmd, metricsProfiles)
-			wh.Run(cmd.Name())
+			rc = wh.Run(cmd.Name())
+		},
+		PostRun: func(cmd *cobra.Command, args []string) {
+			os.Exit(rc)
 		},
 	}
 	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 1*time.Minute, "Pod ready timeout threshold")

--- a/node-density-heavy.go
+++ b/node-density-heavy.go
@@ -32,6 +32,7 @@ func NewNodeDensityHeavy(wh *workloads.WorkloadHelper) *cobra.Command {
 	var namespacedIterations bool
 	var iterationsPerNamespace int
 	var metricsProfiles []string
+	var rc int
 	cmd := &cobra.Command{
 		Use:          "node-density-heavy",
 		Short:        "Runs node-density-heavy workload",
@@ -51,7 +52,10 @@ func NewNodeDensityHeavy(wh *workloads.WorkloadHelper) *cobra.Command {
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			setMetrics(cmd, metricsProfiles)
-			wh.Run(cmd.Name())
+			rc = wh.Run(cmd.Name())
+		},
+		PostRun: func(cmd *cobra.Command, args []string) {
+			os.Exit(rc)
 		},
 	}
 	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 2*time.Minute, "Pod ready timeout threshold")

--- a/node-density.go
+++ b/node-density.go
@@ -31,6 +31,7 @@ func NewNodeDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 	var podReadyThreshold time.Duration
 	var containerImage string
 	var metricsProfiles []string
+	var rc int
 	cmd := &cobra.Command{
 		Use:          "node-density",
 		Short:        "Runs node-density workload",
@@ -47,7 +48,10 @@ func NewNodeDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			setMetrics(cmd, metricsProfiles)
-			wh.Run(cmd.Name())
+			rc = wh.Run(cmd.Name())
+		},
+		PostRun: func(cmd *cobra.Command, args []string) {
+			os.Exit(rc)
 		},
 	}
 	cmd.Flags().IntVar(&podsPerNode, "pods-per-node", 245, "Pods per node")

--- a/pvc-density.go
+++ b/pvc-density.go
@@ -42,6 +42,7 @@ func NewPVCDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 	var storageProvisioners, metricsProfiles []string
 	var claimSize string
 	var containerImage string
+	var rc int
 	provisioner := "aws"
 
 	cmd := &cobra.Command{
@@ -65,7 +66,10 @@ func NewPVCDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			setMetrics(cmd, metricsProfiles)
-			wh.Run(cmd.Name())
+			rc = wh.Run(cmd.Name())
+		},
+		PostRun: func(cmd *cobra.Command, args []string) {
+			os.Exit(rc)
 		},
 	}
 

--- a/udn-density-l3-pods.go
+++ b/udn-density-l3-pods.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/kube-burner/kube-burner/pkg/workloads"
-
 	"github.com/spf13/cobra"
 )
 
@@ -31,6 +30,7 @@ func NewUDNDensityL3Pods(wh *workloads.WorkloadHelper) *cobra.Command {
 	var churnDelay, churnDuration, podReadyThreshold time.Duration
 	var churnDeletionStrategy string
 	var metricsProfiles []string
+	var rc int
 	cmd := &cobra.Command{
 		Use:          "udn-density-l3-pods",
 		Short:        "Runs node-density-udn workload",
@@ -47,7 +47,10 @@ func NewUDNDensityL3Pods(wh *workloads.WorkloadHelper) *cobra.Command {
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			setMetrics(cmd, metricsProfiles)
-			wh.Run(cmd.Name())
+			rc = wh.Run(cmd.Name())
+		},
+		PostRun: func(cmd *cobra.Command, args []string) {
+			os.Exit(rc)
 		},
 	}
 	cmd.Flags().BoolVar(&churn, "churn", true, "Enable churning")

--- a/web-burner.go
+++ b/web-burner.go
@@ -30,6 +30,7 @@ func NewWebBurner(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 	var bridge string
 	var podReadyThreshold time.Duration
 	var metricsProfiles []string
+	var rc int
 	cmd := &cobra.Command{
 		Use:   variant,
 		Short: fmt.Sprintf("Runs %v workload", variant),
@@ -46,7 +47,10 @@ func NewWebBurner(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			setMetrics(cmd, metricsProfiles)
-			wh.Run(cmd.Name())
+			rc = wh.Run(cmd.Name())
+		},
+		PostRun: func(cmd *cobra.Command, args []string) {
+			os.Exit(rc)
 		},
 	}
 	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 2*time.Minute, "Pod ready timeout threshold")

--- a/workers-scale.go
+++ b/workers-scale.go
@@ -55,7 +55,6 @@ func NewWorkersScale(metricsEndpoint *string, ocpMetaAgent *ocpmetadata.Metadata
 		Long:         "If no other indexer is specified, local indexer is used by default",
 		SilenceUsage: true,
 		PostRun: func(cmd *cobra.Command, args []string) {
-			log.Info("👋 Exiting kube-burner ", uuid)
 			os.Exit(rc)
 		},
 		Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
os.exit() is removed from kube-burner helpers Run() method with the PR https://github.com/kube-burner/kube-burner/pull/704

kube-burner-ocp workloads now explicitly define PostRun and call os.exit().

This change helps workloads to do any cleanup as part of PostRun once kube-burner finishes execution.

Note: This patch depends on kube-burner PR
https://github.com/kube-burner/kube-burner/pull/704

