### PR TITLE
Arrange deployments that depend on secrets and configmaps to be created after said resources

### DIFF
--- a/cmd/config/cluster-density-ms/cluster-density-ms.yml
+++ b/cmd/config/cluster-density-ms/cluster-density-ms.yml
@@ -53,11 +53,6 @@ jobs:
       - objectTemplate: imagestream.yml
         replicas: 1
 
-      - objectTemplate: deployment.yml
-        replicas: 4
-        inputVars:
-          podReplicas: 2
-
       - objectTemplate: service.yml
         replicas: 2
         
@@ -69,3 +64,8 @@ jobs:
 
       - objectTemplate: configmap.yml
         replicas: 10
+
+      - objectTemplate: deployment.yml
+        replicas: 4
+        inputVars:
+          podReplicas: 2

--- a/cmd/config/cluster-density-v2/cluster-density-v2.yml
+++ b/cmd/config/cluster-density-v2/cluster-density-v2.yml
@@ -60,17 +60,6 @@ jobs:
       - objectTemplate: build.yml
         replicas: 1
 
-      - objectTemplate: deployment-server.yml
-        replicas: 3
-        inputVars:
-          podReplicas: 2
-
-      - objectTemplate: deployment-client.yml
-        replicas: 2
-        inputVars:
-          podReplicas: 2
-          ingressDomain: {{.INGRESS_DOMAIN}}
-
       - objectTemplate: service.yml
         replicas: 5
         
@@ -91,3 +80,14 @@ jobs:
 
       - objectTemplate: np-allow-from-ingress.yml
         replicas: 1
+
+      - objectTemplate: deployment-server.yml
+        replicas: 3
+        inputVars:
+          podReplicas: 2
+
+      - objectTemplate: deployment-client.yml
+        replicas: 2
+        inputVars:
+          podReplicas: 2
+          ingressDomain: {{.INGRESS_DOMAIN}}


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

The cluster-density deployments are created before the secrets and configmaps they depend on.
This can cause scheduling delays and in some cases cause errors in the apiserver.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
