### PR TITLE
Bug fix for autoscaler calculation in self-managed

### DIFF
--- a/pkg/workerscale/autoscaler.go
+++ b/pkg/workerscale/autoscaler.go
@@ -49,7 +49,7 @@ func (awsAutoScalerScenario *AutoScalerScenario) OrchestrateWorkload(scaleConfig
 	setupMetrics(scaleConfig.UUID, scaleConfig.Metadata, kubeClientProvider)
 	measurements.Start()
 	createMachineAutoscalers(dynamicClient, machineSetsToEdit)
-	createAutoScaler(dynamicClient, len(prevMachineDetails)+scaleConfig.AdditionalWorkerNodes)
+	createAutoScaler(dynamicClient, autoScalerBuffer+len(prevMachineDetails)+scaleConfig.AdditionalWorkerNodes)
 	triggerJob, triggerTime := createBatchJob(clientSet)
 	// Delay for the clusterautoscaler resources to come up
 	time.Sleep(5 * time.Minute)

--- a/pkg/workerscale/constants.go
+++ b/pkg/workerscale/constants.go
@@ -21,6 +21,7 @@ const JobName = "workers-scale"
 const machineNamespace = "openshift-machine-api"
 const defaultNamespace = "default"
 const defaultClusterAutoScaler = "default"
+const autoScalerBuffer = 10
 
 // Measurement constants
 const measurementName = "nodeLatency"

--- a/pkg/workerscale/machines.go
+++ b/pkg/workerscale/machines.go
@@ -45,6 +45,7 @@ func getMachines(machineClient *machinev1beta1.MachineV1beta1Client, scaleEventE
 
 	for _, machine := range machines.Items {
 		if _, ok := machine.Labels["machine.openshift.io/cluster-api-machine-role"]; ok &&
+			machine.Labels["machine.openshift.io/cluster-api-machine-role"] != "master" &&
 			machine.Labels["machine.openshift.io/cluster-api-machine-role"] != "infra" &&
 			machine.Labels["machine.openshift.io/cluster-api-machine-role"] != "workload" {
 			if machine.Status.Phase != nil && *machine.Status.Phase == "Running" && machine.CreationTimestamp.Time.UTC().Unix() > scaleEventEpoch {


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description
Bug fix for autoscaler calculation in self-managed platforms. Fixes this failure: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/58074/rehearse-58074-periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.16-nightly-x86-kube-burner-workers-autoscale-24nodes/1849037236960497664 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
