### PR TITLE
Use embedded metrics-profiles in index subcmd

### DIFF
--- a/cmd/ocp.go
+++ b/cmd/ocp.go
@@ -32,8 +32,6 @@ import (
 //go:embed config/*
 var ocpConfig embed.FS
 
-const configDir = "config"
-
 func openShiftCmd() *cobra.Command {
 	var workloadConfig workloads.Config
 	var wh workloads.WorkloadHelper
@@ -68,7 +66,7 @@ func openShiftCmd() *cobra.Command {
 		util.ConfigureLogging(cmd)
 		util.SetupLogging("ocp-" + workloadConfig.UUID)
 		if extract {
-			if err := workloads.ExtractWorkload(ocpConfig, configDir, cmd.Name(), "alerts.yml", "metrics.yml", "metrics-aggregated.yml", "metrics-report.yml"); err != nil {
+			if err := workloads.ExtractWorkload(ocpConfig, ocp.ConfigDir, cmd.Name(), "alerts.yml", "metrics.yml", "metrics-aggregated.yml", "metrics-report.yml"); err != nil {
 				log.Fatal(err.Error())
 			}
 			os.Exit(0)
@@ -76,7 +74,7 @@ func openShiftCmd() *cobra.Command {
 		if checkHealth && cmd.Name() != "cluster-health" {
 			ocp.ClusterHealthCheck()
 		}
-		workloadConfig.ConfigDir = configDir
+		workloadConfig.ConfigDir = ocp.ConfigDir
 		kubeClientProvider := config.NewKubeClientProvider("", "")
 		wh = workloads.NewWorkloadHelper(workloadConfig, ocpConfig, kubeClientProvider)
 		envVars := map[string]string{
@@ -114,8 +112,8 @@ func openShiftCmd() *cobra.Command {
 		ocp.NewNodeDensity(&wh),
 		ocp.NewNodeDensityHeavy(&wh),
 		ocp.NewNodeDensityCNI(&wh),
-		ocp.NewUDNDensityPods(&wh),
-		ocp.NewIndex(&wh.MetricsEndpoint, &wh.MetadataAgent),
+		ocp.NewUDNDensityL3Pods(&wh),
+		ocp.NewIndex(&wh.MetricsEndpoint, &wh.MetadataAgent, ocpConfig),
 		ocp.NewWorkersScale(&wh.MetricsEndpoint, &wh.MetadataAgent),
 		ocp.NewPVCDensity(&wh),
 		ocp.NewRDSCore(&wh),

--- a/cmd/ocp.go
+++ b/cmd/ocp.go
@@ -32,6 +32,8 @@ import (
 //go:embed config/*
 var ocpConfig embed.FS
 
+const configDir = "config"
+
 func openShiftCmd() *cobra.Command {
 	var workloadConfig workloads.Config
 	var wh workloads.WorkloadHelper
@@ -66,7 +68,7 @@ func openShiftCmd() *cobra.Command {
 		util.ConfigureLogging(cmd)
 		util.SetupLogging("ocp-" + workloadConfig.UUID)
 		if extract {
-			if err := workloads.ExtractWorkload(ocpConfig, ocp.ConfigDir, cmd.Name(), "alerts.yml", "metrics.yml", "metrics-aggregated.yml", "metrics-report.yml"); err != nil {
+			if err := workloads.ExtractWorkload(ocpConfig, configDir, cmd.Name(), "alerts.yml", "metrics.yml", "metrics-aggregated.yml", "metrics-report.yml"); err != nil {
 				log.Fatal(err.Error())
 			}
 			os.Exit(0)
@@ -74,7 +76,7 @@ func openShiftCmd() *cobra.Command {
 		if checkHealth && cmd.Name() != "cluster-health" {
 			ocp.ClusterHealthCheck()
 		}
-		workloadConfig.ConfigDir = ocp.ConfigDir
+		workloadConfig.ConfigDir = configDir
 		kubeClientProvider := config.NewKubeClientProvider("", "")
 		wh = workloads.NewWorkloadHelper(workloadConfig, ocpConfig, kubeClientProvider)
 		envVars := map[string]string{
@@ -112,8 +114,8 @@ func openShiftCmd() *cobra.Command {
 		ocp.NewNodeDensity(&wh),
 		ocp.NewNodeDensityHeavy(&wh),
 		ocp.NewNodeDensityCNI(&wh),
-		ocp.NewUDNDensityL3Pods(&wh),
-		ocp.NewIndex(&wh.MetricsEndpoint, &wh.MetadataAgent, ocpConfig),
+		ocp.NewUDNDensityPods(&wh),
+		ocp.NewIndex(&wh, ocpConfig),
 		ocp.NewWorkersScale(&wh.MetricsEndpoint, &wh.MetadataAgent),
 		ocp.NewPVCDensity(&wh),
 		ocp.NewRDSCore(&wh),

--- a/common.go
+++ b/common.go
@@ -28,6 +28,8 @@ import (
 
 var clusterMetadata ocpmetadata.ClusterMetadata
 
+const ConfigDir = "config"
+
 func setMetrics(cmd *cobra.Command, metricsProfiles []string) {
 	profileType, _ := cmd.Root().PersistentFlags().GetString("profile-type")
 	switch ProfileType(profileType) {

--- a/common.go
+++ b/common.go
@@ -28,8 +28,6 @@ import (
 
 var clusterMetadata ocpmetadata.ClusterMetadata
 
-const ConfigDir = "config"
-
 func setMetrics(cmd *cobra.Command, metricsProfiles []string) {
 	profileType, _ := cmd.Root().PersistentFlags().GetString("profile-type")
 	switch ProfileType(profileType) {


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

With this PR, the index subcmd will be able to use metrics profiles embedded in the `kube-burner-ocp` binary, ~~when the flag --embedded is passed~~

Using an embedded profile
```shell
$ kube-burner-ocp index --metrics-profile metrics.yml  --check-health=false
time="2024-11-07 17:02:32" level=info msg="📁 Creating local indexer: indexer-0" file="metrics.go:67"
time="2024-11-07 17:02:32" level=info msg="👽 Initializing prometheus client with URL: https://prometheus-k8s-openshift-monitoring.apps.kube-burner-ocp.perfscale.devcluster.openshift.com" file="prometheus.go:47"
time="2024-11-07 17:02:32" level=info msg="🔍 Endpoint: https://prometheus-k8s-openshift-monitoring.apps.kube-burner-ocp.perfscale.devcluster.openshift.com; profile: config/metrics.yml start: 2024-11-07T16:02:26+01:00 end: 2024-11-07T17:12:26+01:00; job: kube-burner-ocp-indexing" file="prometheus.go:70"
```

Using a local file as profile:
```shell
$ ./bin/amd64/kube-burner-ocp index --metrics-profile custom-metrics.yml  --check-health=false
time="2024-11-07 17:04:57" level=info msg="📁 Creating local indexer: indexer-0" file="metrics.go:67"
time="2024-11-07 17:04:57" level=info msg="👽 Initializing prometheus client with URL: https://prometheus-k8s-openshift-monitoring.apps.kube-burner-ocp.perfscale.devcluster.openshift.com" file="prometheus.go:47"
time="2024-11-07 17:04:58" level=info msg="Embedded config doesn't contain metrics profile config/custom-metrics.yml. Falling back to original path" file="prometheus.go:139"
time="2024-11-07 17:04:58" level=info msg="🔍 Endpoint: https://prometheus-k8s-openshift-monitoring.apps.kube-burner-ocp.perfscale.devcluster.openshift.com; profile: custom-metrics.yml start: 2024-11-07T16:04:52+01:00 end: 2024-11-07T17:14:52+01:00; job: kube-burner-ocp-indexing" file="prometheus.go:70"
``


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
