### PR TITLE
Remove etcd leader change metric

### DIFF
--- a/cmd/config/metrics-aggregated.yml
+++ b/cmd/config/metrics-aggregated.yml
@@ -70,9 +70,6 @@
 
 # Etcd metrics
 
-- query: sum(rate(etcd_server_leader_changes_seen_total[2m]))
-  metricName: etcdLeaderChangesRate
-
 - query: histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[2m]))
   metricName: 99thEtcdDiskBackendCommitDurationSeconds
 

--- a/cmd/config/metrics-egressip.yml
+++ b/cmd/config/metrics-egressip.yml
@@ -82,9 +82,6 @@
 
 # Etcd metrics
 
-- query: sum(rate(etcd_server_leader_changes_seen_total[2m]))
-  metricName: etcdLeaderChangesRate
-
 - query: histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[2m]))
   metricName: 99thEtcdDiskBackendCommitDurationSeconds
 

--- a/cmd/config/metrics.yml
+++ b/cmd/config/metrics.yml
@@ -61,9 +61,6 @@
 
 # Etcd metrics
 
-- query: sum(rate(etcd_server_leader_changes_seen_total[2m]))
-  metricName: etcdLeaderChangesRate
-
 - query: histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[2m]))
   metricName: 99thEtcdDiskBackendCommitDurationSeconds
 


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

This KPI is already tracked by alerts, there's no need to index it.
Here
https://github.com/kube-burner/kube-burner-ocp/blob/b2e40016e49ccbd9512862d2de556b5cb48ceb3b/cmd/config/alerts.yml#L11-L13
and here
https://github.com/kube-burner/kube-burner-ocp/blob/b2e40016e49ccbd9512862d2de556b5cb48ceb3b/cmd/config/alerts.yml#L58-L61
