### PR TITLE
Deprecate --profile-type flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Flags:
       --gc-metrics                Collect metrics during garbage collection
       --local-indexing            Enable local indexing
       --metrics-endpoint string   YAML file with a list of metric endpoints
-      --profile-type string       Metrics profile to use, supported options are: regular, reporting or both (default "both")
       --qps int                   QPS (default 20)
       --timeout duration          Benchmark timeout (default 4h0m0s)
       --user-metadata string      User provided metadata file, in YAML format
@@ -441,23 +440,24 @@ Usage:
   kube-burner-ocp index [flags]
 
 Flags:
-  -m, --metrics-profile string     Metrics profile file (default "metrics.yml")
+  -m, --metrics-profile strings    Comma separated list of metrics profiles to use (default [metrics.yml])
       --metrics-directory string   Directory to dump the metrics files in, when using default local indexing (default "collected-metrics")
   -s, --step duration              Prometheus step size (default 30s)
       --start int                  Epoch start time
       --end int                    Epoch end time
   -j, --job-name string            Indexing job name (default "kube-burner-ocp-indexing")
       --user-metadata string       User provided metadata file, in YAML format
+      --tarball-name string        Dump collected metrics into a tarball with the given name, requires local indexing
   -h, --help                       help for index
 ```
 
-## Metrics-profile type
+## Metrics profile
 
-By specifying `--profile-type`, kube-burner can use two different metrics profiles when scraping metrics from prometheus. By default is configured with `both`, meaning that it will use the regular metrics profiles bound to the workload in question and the reporting metrics profile.
+`kube-burner-ocp` ships with multiple metrics-profiles, they can be normally specified with the flag `--metrics-profile`
+When using the regular profiles ([metrics-aggregated](https://github.com/kube-burner/kube-burner-ocp/blob/main/cmd/config/metrics-aggregated.yml) or [metrics](https://github.com/kube-burner/kube-burner-ocp/blob/main/cmd/config/metrics.yml)), kube-burner scrapes and indexes metrics timeseries.
 
-When using the regular profiles ([metrics-aggregated](https://github.com/kube-burner/kube-burner-ocp/blob/master/cmd/config/metrics-aggregated.yml) or [metrics](https://github.com/kube-burner/kube-burner-ocp/blob/master/cmd/config/metrics.yml)), kube-burner scrapes and indexes metrics timeseries.
+The [reporting profile](https://github.com/kube-burner/kube-burner-ocp/blob/main/cmd/config/metrics-report.yml)) is very useful to reduce the number of documents sent to the configured indexer. Thanks to the combination of aggregations and instant queries for prometheus metrics, only a few documents resulting from these queries will be indexed per benchmark.
 
-The reporting profile is very useful to reduce the number of documents sent to the configured indexer. Thanks to the combination of aggregations and instant queries for prometheus metrics, and 4 summaries for latency measurements, only a few documents will be indexed per benchmark. This flag makes possible to specify one or both of these profiles indistinctly.
 
 ## Customizing workloads
 

--- a/cluster-density.go
+++ b/cluster-density.go
@@ -34,7 +34,6 @@ func NewClusterDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Comm
 	var churnDeletionStrategy string
 	var podReadyThreshold time.Duration
 	var metricsProfiles []string
-	var rc int
 	cmd := &cobra.Command{
 		Use:   variant,
 		Short: fmt.Sprintf("Runs %v workload", variant),
@@ -53,8 +52,6 @@ func NewClusterDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Comm
 				log.Fatal("Error obtaining default ingress domain: ", err.Error())
 			}
 			os.Setenv("INGRESS_DOMAIN", ingressDomain)
-		},
-		Run: func(cmd *cobra.Command, args []string) {
 			if cmd.Name() == "cluster-density-v2" {
 				kubeClientProvider := config.NewKubeClientProvider("", "")
 				clientset, _ := kubeClientProvider.ClientSet(0, 0)
@@ -62,11 +59,6 @@ func NewClusterDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Comm
 					log.Errorf("image-registry deployment is not deployed")
 				}
 			}
-			setMetrics(cmd, metricsProfiles)
-			rc = wh.Run(cmd.Name())
-		},
-		PostRun: func(cmd *cobra.Command, args []string) {
-			os.Exit(rc)
 		},
 	}
 	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 2*time.Minute, "Pod ready timeout threshold")

--- a/cmd/ocp.go
+++ b/cmd/ocp.go
@@ -58,6 +58,7 @@ func openShiftCmd() *cobra.Command {
 	ocpCmd.PersistentFlags().BoolVar(&gcMetrics, "gc-metrics", false, "Collect metrics during garbage collection")
 	ocpCmd.PersistentFlags().StringVar(&workloadConfig.UserMetadata, "user-metadata", "", "User provided metadata file, in YAML format")
 	ocpCmd.PersistentFlags().BoolVar(&extract, "extract", false, "Extract workload in the current directory")
+	ocpCmd.PersistentFlags().SortFlags = false
 	ocpCmd.MarkFlagsRequiredTogether("es-server", "es-index")
 	ocpCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		if cmd.Name() == "version" {
@@ -106,19 +107,19 @@ func openShiftCmd() *cobra.Command {
 	ocpCmd.AddCommand(
 		ocp.NewWorkload(ocp.NewClusterDensity(&wh, "cluster-density-v2"), wh),
 		ocp.NewWorkload(ocp.NewClusterDensity(&wh, "cluster-density-ms"), wh),
-		ocp.NewWorkload(ocp.NewCrdScale(&wh), wh),
-		ocp.NewWorkload(ocp.NewNetworkPolicy(&wh, "networkpolicy-multitenant"), wh),
-		ocp.NewWorkload(ocp.NewNetworkPolicy(&wh, "networkpolicy-matchlabels"), wh),
-		ocp.NewWorkload(ocp.NewNetworkPolicy(&wh, "networkpolicy-matchexpressions"), wh),
+		ocp.NewWorkload(ocp.NewCrdScale(), wh),
+		ocp.NewWorkload(ocp.NewNetworkPolicy("networkpolicy-multitenant"), wh),
+		ocp.NewWorkload(ocp.NewNetworkPolicy("networkpolicy-matchlabels"), wh),
+		ocp.NewWorkload(ocp.NewNetworkPolicy("networkpolicy-matchexpressions"), wh),
 		ocp.NewWorkload(ocp.NewNodeDensity(&wh), wh),
 		ocp.NewWorkload(ocp.NewNodeDensityHeavy(&wh), wh),
 		ocp.NewWorkload(ocp.NewNodeDensityCNI(&wh), wh),
-		ocp.NewWorkload(ocp.NewPVCDensity(&wh), wh),
+		ocp.NewWorkload(ocp.NewPVCDensity(), wh),
 		ocp.NewWorkload(ocp.NewRDSCore(&wh), wh),
-		ocp.NewWorkload(ocp.NewWebBurner(&wh, "web-burner-init"), wh),
-		ocp.NewWorkload(ocp.NewWebBurner(&wh, "web-burner-node-density"), wh),
-		ocp.NewWorkload(ocp.NewWebBurner(&wh, "web-burner-cluster-density"), wh),
-		ocp.NewWorkload(ocp.NewEgressIP(&wh, "egressip"), wh),
+		ocp.NewWorkload(ocp.NewWebBurner("web-burner-init"), wh),
+		ocp.NewWorkload(ocp.NewWebBurner("web-burner-node-density"), wh),
+		ocp.NewWorkload(ocp.NewWebBurner("web-burner-cluster-density"), wh),
+		ocp.NewWorkload(ocp.NewEgressIP("egressip"), wh),
 		ocp.NewWorkload(ocp.NewUDNDensityPods(&wh), wh),
 		ocp.CustomWorkload(&wh),
 		ocp.NewWorkersScale(&wh.MetricsEndpoint, &wh.MetadataAgent),

--- a/cmd/ocp.go
+++ b/cmd/ocp.go
@@ -37,7 +37,6 @@ const configDir = "config"
 func openShiftCmd() *cobra.Command {
 	var workloadConfig workloads.Config
 	var wh workloads.WorkloadHelper
-	var metricsProfileType string
 	var esServer, esIndex string
 	var QPS, burst int
 	var gc, gcMetrics, alerting, checkHealth, localIndexing, extract bool
@@ -59,7 +58,6 @@ func openShiftCmd() *cobra.Command {
 	ocpCmd.PersistentFlags().BoolVar(&gcMetrics, "gc-metrics", false, "Collect metrics during garbage collection")
 	ocpCmd.PersistentFlags().StringVar(&workloadConfig.UserMetadata, "user-metadata", "", "User provided metadata file, in YAML format")
 	ocpCmd.PersistentFlags().BoolVar(&extract, "extract", false, "Extract workload in the current directory")
-	ocpCmd.PersistentFlags().StringVar(&metricsProfileType, "profile-type", "both", "Metrics profile to use, supported options are: regular, reporting or both")
 	ocpCmd.MarkFlagsRequiredTogether("es-server", "es-index")
 	ocpCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		if cmd.Name() == "version" {
@@ -106,26 +104,26 @@ func openShiftCmd() *cobra.Command {
 		}
 	}
 	ocpCmd.AddCommand(
-		ocp.NewClusterDensity(&wh, "cluster-density-v2"),
-		ocp.NewClusterDensity(&wh, "cluster-density-ms"),
-		ocp.NewCrdScale(&wh),
-		ocp.NewNetworkPolicy(&wh, "networkpolicy-multitenant"),
-		ocp.NewNetworkPolicy(&wh, "networkpolicy-matchlabels"),
-		ocp.NewNetworkPolicy(&wh, "networkpolicy-matchexpressions"),
-		ocp.NewNodeDensity(&wh),
-		ocp.NewNodeDensityHeavy(&wh),
-		ocp.NewNodeDensityCNI(&wh),
-		ocp.NewUDNDensityPods(&wh),
-		ocp.NewIndex(&wh.MetricsEndpoint, &wh.MetadataAgent),
-		ocp.NewWorkersScale(&wh.MetricsEndpoint, &wh.MetadataAgent),
-		ocp.NewPVCDensity(&wh),
-		ocp.NewRDSCore(&wh),
-		ocp.NewWebBurner(&wh, "web-burner-init"),
-		ocp.NewWebBurner(&wh, "web-burner-node-density"),
-		ocp.NewWebBurner(&wh, "web-burner-cluster-density"),
-		ocp.NewEgressIP(&wh, "egressip"),
-		ocp.ClusterHealth(),
+		ocp.NewWorkload(ocp.NewClusterDensity(&wh, "cluster-density-v2"), wh),
+		ocp.NewWorkload(ocp.NewClusterDensity(&wh, "cluster-density-ms"), wh),
+		ocp.NewWorkload(ocp.NewCrdScale(&wh), wh),
+		ocp.NewWorkload(ocp.NewNetworkPolicy(&wh, "networkpolicy-multitenant"), wh),
+		ocp.NewWorkload(ocp.NewNetworkPolicy(&wh, "networkpolicy-matchlabels"), wh),
+		ocp.NewWorkload(ocp.NewNetworkPolicy(&wh, "networkpolicy-matchexpressions"), wh),
+		ocp.NewWorkload(ocp.NewNodeDensity(&wh), wh),
+		ocp.NewWorkload(ocp.NewNodeDensityHeavy(&wh), wh),
+		ocp.NewWorkload(ocp.NewNodeDensityCNI(&wh), wh),
+		ocp.NewWorkload(ocp.NewPVCDensity(&wh), wh),
+		ocp.NewWorkload(ocp.NewRDSCore(&wh), wh),
+		ocp.NewWorkload(ocp.NewWebBurner(&wh, "web-burner-init"), wh),
+		ocp.NewWorkload(ocp.NewWebBurner(&wh, "web-burner-node-density"), wh),
+		ocp.NewWorkload(ocp.NewWebBurner(&wh, "web-burner-cluster-density"), wh),
+		ocp.NewWorkload(ocp.NewEgressIP(&wh, "egressip"), wh),
+		ocp.NewWorkload(ocp.NewUDNDensityPods(&wh), wh),
 		ocp.CustomWorkload(&wh),
+		ocp.NewWorkersScale(&wh.MetricsEndpoint, &wh.MetadataAgent),
+		ocp.NewIndex(&wh.MetricsEndpoint, &wh.MetadataAgent),
+		ocp.ClusterHealth(),
 	)
 	util.SetupCmd(ocpCmd)
 	return ocpCmd

--- a/cmd/ocp.go
+++ b/cmd/ocp.go
@@ -58,7 +58,6 @@ func openShiftCmd() *cobra.Command {
 	ocpCmd.PersistentFlags().BoolVar(&gcMetrics, "gc-metrics", false, "Collect metrics during garbage collection")
 	ocpCmd.PersistentFlags().StringVar(&workloadConfig.UserMetadata, "user-metadata", "", "User provided metadata file, in YAML format")
 	ocpCmd.PersistentFlags().BoolVar(&extract, "extract", false, "Extract workload in the current directory")
-	ocpCmd.PersistentFlags().SortFlags = false
 	ocpCmd.MarkFlagsRequiredTogether("es-server", "es-index")
 	ocpCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		if cmd.Name() == "version" {
@@ -105,22 +104,22 @@ func openShiftCmd() *cobra.Command {
 		}
 	}
 	ocpCmd.AddCommand(
-		ocp.NewWorkload(ocp.NewClusterDensity(&wh, "cluster-density-v2"), wh),
-		ocp.NewWorkload(ocp.NewClusterDensity(&wh, "cluster-density-ms"), wh),
-		ocp.NewWorkload(ocp.NewCrdScale(), wh),
-		ocp.NewWorkload(ocp.NewNetworkPolicy("networkpolicy-multitenant"), wh),
-		ocp.NewWorkload(ocp.NewNetworkPolicy("networkpolicy-matchlabels"), wh),
-		ocp.NewWorkload(ocp.NewNetworkPolicy("networkpolicy-matchexpressions"), wh),
-		ocp.NewWorkload(ocp.NewNodeDensity(&wh), wh),
-		ocp.NewWorkload(ocp.NewNodeDensityHeavy(&wh), wh),
-		ocp.NewWorkload(ocp.NewNodeDensityCNI(&wh), wh),
-		ocp.NewWorkload(ocp.NewPVCDensity(), wh),
-		ocp.NewWorkload(ocp.NewRDSCore(&wh), wh),
-		ocp.NewWorkload(ocp.NewWebBurner("web-burner-init"), wh),
-		ocp.NewWorkload(ocp.NewWebBurner("web-burner-node-density"), wh),
-		ocp.NewWorkload(ocp.NewWebBurner("web-burner-cluster-density"), wh),
-		ocp.NewWorkload(ocp.NewEgressIP("egressip"), wh),
-		ocp.NewWorkload(ocp.NewUDNDensityPods(&wh), wh),
+		ocp.NewWorkload(ocp.NewClusterDensity(&wh, "cluster-density-v2"), &wh),
+		ocp.NewWorkload(ocp.NewClusterDensity(&wh, "cluster-density-ms"), &wh),
+		ocp.NewWorkload(ocp.NewCrdScale(), &wh),
+		ocp.NewWorkload(ocp.NewNetworkPolicy("networkpolicy-multitenant"), &wh),
+		ocp.NewWorkload(ocp.NewNetworkPolicy("networkpolicy-matchlabels"), &wh),
+		ocp.NewWorkload(ocp.NewNetworkPolicy("networkpolicy-matchexpressions"), &wh),
+		ocp.NewWorkload(ocp.NewNodeDensity(&wh), &wh),
+		ocp.NewWorkload(ocp.NewNodeDensityHeavy(&wh), &wh),
+		ocp.NewWorkload(ocp.NewNodeDensityCNI(&wh), &wh),
+		ocp.NewWorkload(ocp.NewPVCDensity(), &wh),
+		ocp.NewWorkload(ocp.NewRDSCore(&wh), &wh),
+		ocp.NewWorkload(ocp.NewWebBurner("web-burner-init"), &wh),
+		ocp.NewWorkload(ocp.NewWebBurner("web-burner-node-density"), &wh),
+		ocp.NewWorkload(ocp.NewWebBurner("web-burner-cluster-density"), &wh),
+		ocp.NewWorkload(ocp.NewEgressIP("egressip"), &wh),
+		ocp.NewWorkload(ocp.NewUDNDensityPods(&wh), &wh),
 		ocp.CustomWorkload(&wh),
 		ocp.NewWorkersScale(&wh.MetricsEndpoint, &wh.MetadataAgent),
 		ocp.NewIndex(&wh.MetricsEndpoint, &wh.MetadataAgent),

--- a/common.go
+++ b/common.go
@@ -60,12 +60,10 @@ func GatherMetadata(wh *workloads.WorkloadHelper, alerting bool) error {
 	return nil
 }
 
-func NewWorkload(cmd *cobra.Command, wh workloads.WorkloadHelper) *cobra.Command {
-	cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+func NewWorkload(cmd *cobra.Command, wh *workloads.WorkloadHelper) *cobra.Command {
+	cmd.Run = func(cmd *cobra.Command, args []string) {
 		metricsProfiles, _ := cmd.Flags().GetStringSlice("metrics-profile")
 		os.Setenv("METRICS", strings.Join(metricsProfiles, ","))
-	}
-	cmd.Run = func(cmd *cobra.Command, args []string) {
 		rc := wh.Run(cmd.Name())
 		os.Exit(rc)
 	}

--- a/crd-scale.go
+++ b/crd-scale.go
@@ -18,12 +18,11 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/kube-burner/kube-burner/pkg/workloads"
 	"github.com/spf13/cobra"
 )
 
 // NewCrdScale holds the crd-scale workload
-func NewCrdScale(wh *workloads.WorkloadHelper) *cobra.Command {
+func NewCrdScale() *cobra.Command {
 	var iterations int
 	var metricsProfiles []string
 	cmd := &cobra.Command{

--- a/crd-scale.go
+++ b/crd-scale.go
@@ -26,20 +26,12 @@ import (
 func NewCrdScale(wh *workloads.WorkloadHelper) *cobra.Command {
 	var iterations int
 	var metricsProfiles []string
-	var rc int
 	cmd := &cobra.Command{
 		Use:          "crd-scale",
 		Short:        "Runs crd-scale workload",
 		SilenceUsage: true,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			os.Setenv("JOB_ITERATIONS", fmt.Sprint(iterations))
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			setMetrics(cmd, metricsProfiles)
-			rc = wh.Run(cmd.Name())
-		},
-		PostRun: func(cmd *cobra.Command, args []string) {
-			os.Exit(rc)
 		},
 	}
 	cmd.Flags().IntVar(&iterations, "iterations", 0, "Number of CRDs to create")

--- a/egressip.go
+++ b/egressip.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/kube-burner/kube-burner/pkg/config"
-	"github.com/kube-burner/kube-burner/pkg/workloads"
 	"github.com/praserx/ipconv"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -145,7 +144,7 @@ func generateEgressIPs(numJobIterations int, addressesPerIteration int, external
 }
 
 // NewClusterDensity holds cluster-density workload
-func NewEgressIP(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
+func NewEgressIP(variant string) *cobra.Command {
 	var iterations, addressesPerIteration int
 	var externalServerIP string
 	var podReadyThreshold time.Duration

--- a/egressip.go
+++ b/egressip.go
@@ -150,7 +150,6 @@ func NewEgressIP(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 	var externalServerIP string
 	var podReadyThreshold time.Duration
 	var metricsProfiles []string
-	var rc int
 	cmd := &cobra.Command{
 		Use:   variant,
 		Short: fmt.Sprintf("Runs %v workload", variant),
@@ -160,13 +159,6 @@ func NewEgressIP(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 			os.Setenv("ADDRESSES_PER_ITERATION", fmt.Sprint(addressesPerIteration))
 			os.Setenv("EXTERNAL_SERVER_IP", externalServerIP)
 			generateEgressIPs(iterations, addressesPerIteration, externalServerIP)
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			setMetrics(cmd, metricsProfiles)
-			rc = wh.Run(cmd.Name())
-		},
-		PostRun: func(cmd *cobra.Command, args []string) {
-			os.Exit(rc)
 		},
 	}
 	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 2*time.Minute, "Pod ready timeout threshold")

--- a/networkpolicy.go
+++ b/networkpolicy.go
@@ -19,12 +19,11 @@ import (
 	"os"
 	"time"
 
-	"github.com/kube-burner/kube-burner/pkg/workloads"
 	"github.com/spf13/cobra"
 )
 
 // NewNetworkPolicy holds network-policy workload
-func NewNetworkPolicy(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
+func NewNetworkPolicy(variant string) *cobra.Command {
 	var iterations, churnPercent, churnCycles int
 	var churn bool
 	var churnDelay, churnDuration time.Duration

--- a/networkpolicy.go
+++ b/networkpolicy.go
@@ -30,7 +30,6 @@ func NewNetworkPolicy(wh *workloads.WorkloadHelper, variant string) *cobra.Comma
 	var churnDelay, churnDuration time.Duration
 	var churnDeletionStrategy string
 	var metricsProfiles []string
-	var rc int
 	cmd := &cobra.Command{
 		Use:   variant,
 		Short: fmt.Sprintf("Runs %v workload", variant),
@@ -42,13 +41,6 @@ func NewNetworkPolicy(wh *workloads.WorkloadHelper, variant string) *cobra.Comma
 			os.Setenv("CHURN_DELAY", fmt.Sprintf("%v", churnDelay))
 			os.Setenv("CHURN_PERCENT", fmt.Sprint(churnPercent))
 			os.Setenv("CHURN_DELETION_STRATEGY", churnDeletionStrategy)
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			setMetrics(cmd, metricsProfiles)
-			rc = wh.Run(cmd.Name())
-		},
-		PostRun: func(cmd *cobra.Command, args []string) {
-			os.Exit(rc)
 		},
 	}
 	cmd.Flags().IntVar(&iterations, "iterations", 0, fmt.Sprintf("%v iterations", variant))

--- a/node-density-cni.go
+++ b/node-density-cni.go
@@ -33,7 +33,6 @@ func NewNodeDensityCNI(wh *workloads.WorkloadHelper) *cobra.Command {
 	var podReadyThreshold time.Duration
 	var iterationsPerNamespace int
 	var metricsProfiles []string
-	var rc int
 	cmd := &cobra.Command{
 		Use:          "node-density-cni",
 		Short:        "Runs node-density-cni workload",
@@ -49,13 +48,6 @@ func NewNodeDensityCNI(wh *workloads.WorkloadHelper) *cobra.Command {
 			os.Setenv("ITERATIONS_PER_NAMESPACE", fmt.Sprint(iterationsPerNamespace))
 			os.Setenv("POD_READY_THRESHOLD", fmt.Sprintf("%v", podReadyThreshold))
 			os.Setenv("SVC_LATENCY", strconv.FormatBool(svcLatency))
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			setMetrics(cmd, metricsProfiles)
-			rc = wh.Run(cmd.Name())
-		},
-		PostRun: func(cmd *cobra.Command, args []string) {
-			os.Exit(rc)
 		},
 	}
 	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 1*time.Minute, "Pod ready timeout threshold")

--- a/node-density-heavy.go
+++ b/node-density-heavy.go
@@ -32,7 +32,6 @@ func NewNodeDensityHeavy(wh *workloads.WorkloadHelper) *cobra.Command {
 	var namespacedIterations bool
 	var iterationsPerNamespace int
 	var metricsProfiles []string
-	var rc int
 	cmd := &cobra.Command{
 		Use:          "node-density-heavy",
 		Short:        "Runs node-density-heavy workload",
@@ -49,13 +48,6 @@ func NewNodeDensityHeavy(wh *workloads.WorkloadHelper) *cobra.Command {
 			os.Setenv("PROBES_PERIOD", fmt.Sprint(probesPeriod.Seconds()))
 			os.Setenv("NAMESPACED_ITERATIONS", fmt.Sprint(namespacedIterations))
 			os.Setenv("ITERATIONS_PER_NAMESPACE", fmt.Sprint(iterationsPerNamespace))
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			setMetrics(cmd, metricsProfiles)
-			rc = wh.Run(cmd.Name())
-		},
-		PostRun: func(cmd *cobra.Command, args []string) {
-			os.Exit(rc)
 		},
 	}
 	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 2*time.Minute, "Pod ready timeout threshold")

--- a/node-density.go
+++ b/node-density.go
@@ -31,7 +31,6 @@ func NewNodeDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 	var podReadyThreshold time.Duration
 	var containerImage string
 	var metricsProfiles []string
-	var rc int
 	cmd := &cobra.Command{
 		Use:          "node-density",
 		Short:        "Runs node-density workload",
@@ -45,13 +44,6 @@ func NewNodeDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 			os.Setenv("JOB_ITERATIONS", fmt.Sprint(totalPods-podCount))
 			os.Setenv("POD_READY_THRESHOLD", fmt.Sprintf("%v", podReadyThreshold))
 			os.Setenv("CONTAINER_IMAGE", containerImage)
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			setMetrics(cmd, metricsProfiles)
-			rc = wh.Run(cmd.Name())
-		},
-		PostRun: func(cmd *cobra.Command, args []string) {
-			os.Exit(rc)
 		},
 	}
 	cmd.Flags().IntVar(&podsPerNode, "pods-per-node", 245, "Pods per node")

--- a/pvc-density.go
+++ b/pvc-density.go
@@ -20,7 +20,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/kube-burner/kube-burner/pkg/workloads"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -36,14 +35,12 @@ var dynamicStorageProvisioners = map[string]string{
 }
 
 // NewPVCDensity holds pvc-density workload
-func NewPVCDensity(wh *workloads.WorkloadHelper) *cobra.Command {
-
+func NewPVCDensity() *cobra.Command {
 	var iterations int
 	var storageProvisioners, metricsProfiles []string
 	var claimSize string
 	var containerImage string
 	provisioner := "aws"
-
 	cmd := &cobra.Command{
 		Use:          "pvc-density",
 		Short:        "Runs pvc-density workload",

--- a/pvc-density.go
+++ b/pvc-density.go
@@ -42,7 +42,6 @@ func NewPVCDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 	var storageProvisioners, metricsProfiles []string
 	var claimSize string
 	var containerImage string
-	var rc int
 	provisioner := "aws"
 
 	cmd := &cobra.Command{
@@ -61,15 +60,7 @@ func NewPVCDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 			if !re.MatchString(provisioner) {
 				log.Fatal(fmt.Errorf("%s does not match one of %s", provisioner, storageProvisioners))
 			}
-
 			os.Setenv("STORAGE_PROVISIONER", fmt.Sprint(dynamicStorageProvisioners[provisioner]))
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			setMetrics(cmd, metricsProfiles)
-			rc = wh.Run(cmd.Name())
-		},
-		PostRun: func(cmd *cobra.Command, args []string) {
-			os.Exit(rc)
 		},
 	}
 

--- a/rds-core.go
+++ b/rds-core.go
@@ -33,7 +33,6 @@ func NewRDSCore(wh *workloads.WorkloadHelper) *cobra.Command {
 	var churnDelay, churnDuration, podReadyThreshold time.Duration
 	var churnDeletionStrategy, perfProfile string
 	var metricsProfiles []string
-	var rc int
 	cmd := &cobra.Command{
 		Use:          "rds-core",
 		Short:        "Runs rds-core workload",
@@ -55,13 +54,6 @@ func NewRDSCore(wh *workloads.WorkloadHelper) *cobra.Command {
 				log.Fatal("Error obtaining default ingress domain: ", err.Error())
 			}
 			os.Setenv("INGRESS_DOMAIN", ingressDomain)
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			setMetrics(cmd, metricsProfiles)
-			rc = wh.Run(cmd.Name())
-		},
-		PostRun: func(cmd *cobra.Command, args []string) {
-			os.Exit(rc)
 		},
 	}
 	cmd.Flags().BoolVar(&churn, "churn", true, "Enable churning")

--- a/test/test-ocp.bats
+++ b/test/test-ocp.bats
@@ -49,8 +49,8 @@ teardown_file() {
   check_metric_value jobSummary podLatencyMeasurement podLatencyQuantilesMeasurement
 }
 
-@test "cluster-density-v2: profile-type=both; user-metadata=true; es-indexing=true; churning=true; svcLatency=true" {
-  run_cmd kube-burner-ocp cluster-density-v2 --iterations=2 --churn-duration=1m --churn-delay=5s --profile-type=both ${COMMON_FLAGS} --user-metadata=user-metadata.yml --service-latency --uuid=${UUID}
+@test "cluster-density-v2: user-metadata=true; es-indexing=true; churning=true; svcLatency=true" {
+  run_cmd kube-burner-ocp cluster-density-v2 --iterations=2 --churn-duration=1m --churn-delay=5s ${COMMON_FLAGS} --user-metadata=user-metadata.yml --service-latency --uuid=${UUID}
   check_metric_value cpu-kubelet jobSummary podLatencyMeasurement podLatencyQuantilesMeasurement svcLatencyMeasurement svcLatencyQuantilesMeasurement etcdVersion 
 }
 

--- a/test/test-ocp.bats
+++ b/test/test-ocp.bats
@@ -50,8 +50,8 @@ teardown_file() {
 }
 
 @test "cluster-density-v2: user-metadata=true; es-indexing=true; churning=true; svcLatency=true" {
-  run_cmd kube-burner-ocp cluster-density-v2 --iterations=2 --churn-duration=1m --churn-delay=5s ${COMMON_FLAGS} --user-metadata=user-metadata.yml --service-latency --uuid=${UUID}
-  check_metric_value cpu-kubelet jobSummary podLatencyMeasurement podLatencyQuantilesMeasurement svcLatencyMeasurement svcLatencyQuantilesMeasurement etcdVersion 
+  run_cmd kube-burner-ocp cluster-density-v2 --iterations=2 --churn-duration=1m --churn-delay=5s ${COMMON_FLAGS} --user-metadata=user-metadata.yml --service-latency --uuid=${UUID} --metrics-profile=metrics-report.yml
+  check_metric_value cpu-kubelet jobSummary podLatencyMeasurement podLatencyQuantilesMeasurement svcLatencyMeasurement svcLatencyQuantilesMeasurement
 }
 
 @test "cluster-density-v2: churn-deletion-strategy=gvr; custom-metrics=true" {

--- a/test/test-ocp.bats
+++ b/test/test-ocp.bats
@@ -34,9 +34,9 @@ teardown_file() {
   check_metric_value jobSummary podLatencyMeasurement podLatencyQuantilesMeasurement
 }
 
-@test "node-density: es-indexing=true" {
-  run_cmd kube-burner-ocp node-density --pods-per-node=75 --pod-ready-threshold=10s --uuid=${UUID} ${COMMON_FLAGS}
-  check_metric_value etcdVersion jobSummary podLatencyMeasurement podLatencyQuantilesMeasurement
+@test "node-density: es-indexing=true; metrics-profile=metrics.yml,metrics-report.yml" {
+  run_cmd kube-burner-ocp node-density --pods-per-node=75 --pod-ready-threshold=10s --uuid=${UUID} --metrics-profile=metrics.yml,metrics-report.yml ${COMMON_FLAGS}
+  check_metric_value etcdVersion jobSummary podLatencyMeasurement podLatencyQuantilesMeasurement max-memory-kubelet
 }
 
 @test "node-density-heavy: gc-metrics=true; local-indexing=true" {

--- a/types.go
+++ b/types.go
@@ -14,11 +14,6 @@
 
 package ocp
 
-type ProfileType string
-
 const (
-	Regular    ProfileType = "regular"
-	Reporting  ProfileType = "reporting"
-	Both       ProfileType = "both"
-	TenMinutes int64       = 600
+	TenMinutes int64 = 600
 )

--- a/udn-density-pods.go
+++ b/udn-density-pods.go
@@ -17,6 +17,7 @@ package ocp
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/kube-burner/kube-burner/pkg/workloads"
@@ -46,7 +47,7 @@ func NewUDNDensityPods(wh *workloads.WorkloadHelper) *cobra.Command {
 			os.Setenv("POD_READY_THRESHOLD", fmt.Sprintf("%v", podReadyThreshold))
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			setMetrics(cmd, metricsProfiles)
+			os.Setenv("METRICS", strings.Join(metricsProfiles, ","))
 			// Disable l3 when the user chooses l2
 			if l2 {
 				l3 = false

--- a/web-burner.go
+++ b/web-burner.go
@@ -19,12 +19,11 @@ import (
 	"os"
 	"time"
 
-	"github.com/kube-burner/kube-burner/pkg/workloads"
 	"github.com/spf13/cobra"
 )
 
 // NewClusterDensity holds cluster-density workload
-func NewWebBurner(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
+func NewWebBurner(variant string) *cobra.Command {
 	var limitcount, scale int
 	var bfd, crd, icni, probe, sriov bool
 	var bridge string

--- a/web-burner.go
+++ b/web-burner.go
@@ -30,7 +30,6 @@ func NewWebBurner(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 	var bridge string
 	var podReadyThreshold time.Duration
 	var metricsProfiles []string
-	var rc int
 	cmd := &cobra.Command{
 		Use:   variant,
 		Short: fmt.Sprintf("Runs %v workload", variant),
@@ -44,13 +43,6 @@ func NewWebBurner(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 			os.Setenv("PROBE", fmt.Sprint(probe))
 			os.Setenv("SCALE", fmt.Sprint(scale))
 			os.Setenv("SRIOV", fmt.Sprint(sriov))
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			setMetrics(cmd, metricsProfiles)
-			rc = wh.Run(cmd.Name())
-		},
-		PostRun: func(cmd *cobra.Command, args []string) {
-			os.Exit(rc)
 		},
 	}
 	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 2*time.Minute, "Pod ready timeout threshold")


### PR DESCRIPTION
## Type of change

- [x] Optimization
- [x] Documentation Update

## Description

The flag --profile-type can be deprecated thanks to the new flag --metrics-profile that allows a list of files.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
