### PR TITLE
Adding whereabouts workload

### DIFF
--- a/cmd/config/whereabouts/ipam-fast.yml
+++ b/cmd/config/whereabouts/ipam-fast.yml
@@ -1,0 +1,19 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+    name: bridge-whereabouts-10-1-0-0
+spec:
+    config: |-
+        {
+            "cniVersion": "0.3.1",
+            "name": "bridge-whereabouts-10-1-0-0",
+            "type": "bridge",
+            "bridge": "cni0",
+            "ipam": {
+                "type": "whereabouts",
+                "range": "10.1.0.0/16",
+                "fast_ipam": true,
+                "node_slice_size": "/24" 
+            }
+        }

--- a/cmd/config/whereabouts/ipam.yml
+++ b/cmd/config/whereabouts/ipam.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+    name: bridge-whereabouts-10-1-0-0
+spec:
+    config: |-
+        {
+            "cniVersion": "0.3.1",
+            "name": "bridge-whereabouts-10-1-0-0",
+            "type": "bridge",
+            "bridge": "cni0",
+            "ipam": {
+                "type": "whereabouts",
+                "range": "10.1.0.0/16"
+            }
+        }

--- a/cmd/config/whereabouts/pod.yml
+++ b/cmd/config/whereabouts/pod.yml
@@ -1,0 +1,46 @@
+---
+kind: Pod
+apiVersion: v1
+metadata:
+  labels:
+    name: whereabouts-{{.Iteration}}-{{.Replica}}
+    app: pause
+  name: {{.JobName}}-{{.Iteration}}-{{.Replica}}
+  annotations:
+    k8s.v1.cni.cncf.io/networks: bridge-whereabouts-10-1-0-0
+spec:
+  topologySpreadConstraints:
+  - maxSkew: 1 
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway 
+    labelSelector: 
+      matchLabels:
+        app: pause
+  securityContext:
+      seccompProfile:
+          type: RuntimeDefault
+      runAsNonRoot: true
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: node-role.kubernetes.io/worker
+            operator: Exists
+          - key: node-role.kubernetes.io/infra
+            operator: DoesNotExist
+          - key: node-role.kubernetes.io/workload
+            operator: DoesNotExist
+  containers:
+  - image: {{.containerImage}}
+    name: whereabouts 
+    resources:
+      requests:
+        memory: "10Mi"
+        cpu: "10m"
+    securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+            drop:
+                - ALL
+    imagePullPolicy: IfNotPresent

--- a/cmd/config/whereabouts/whereabouts.yml
+++ b/cmd/config/whereabouts/whereabouts.yml
@@ -1,0 +1,54 @@
+---
+global:
+  gc: {{.GC}}
+  gcMetrics: {{.GC_METRICS}}
+  measurements:
+    - name: podLatency
+      thresholds:
+        - conditionType: Ready
+          metric: P99
+          threshold: {{.POD_READY_THRESHOLD}}
+metricsEndpoints:
+{{ if .ES_SERVER }}
+  - metrics: [{{.METRICS}}]
+    alerts: [{{.ALERTS}}]
+    indexer:
+      esServers: ["{{.ES_SERVER}}"]
+      insecureSkipVerify: true
+      defaultIndex: {{.ES_INDEX}}
+      type: opensearch
+{{ end }}
+{{ if eq .LOCAL_INDEXING "true" }}
+  - metrics: [{{.METRICS}}]
+    alerts: [{{.ALERTS}}]
+    indexer:
+      type: local
+      metricsDirectory: collected-metrics-{{.UUID}}
+{{ end }}
+jobs:
+  - name: whereabouts
+    namespace: kube-burner-whereabouts-{{.JOB_ITERATIONS}} 
+    jobIterations: {{.JOB_ITERATIONS}}
+    podWait: true
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    namespacedIterations: true
+    waitWhenFinished: true
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+    objects:
+{{ if eq .FAST "true" }}
+        - objectTemplate: ipam-fast.yml
+          replicas: 1
+{{ end }}
+{{ if eq .FAST "false" }}
+        - objectTemplate: ipam.yml
+          replicas: 1
+{{ end }}
+        - objectTemplate: pod.yml
+          replicas: 6
+          inputVars:
+            containerImage: registry.k8s.io/pause:3.1

--- a/cmd/ocp.go
+++ b/cmd/ocp.go
@@ -124,6 +124,7 @@ func openShiftCmd() *cobra.Command {
 		ocp.NewWebBurner(&wh, "web-burner-node-density"),
 		ocp.NewWebBurner(&wh, "web-burner-cluster-density"),
 		ocp.NewEgressIP(&wh, "egressip"),
+		ocp.NewWhereabouts(&wh),
 		ocp.ClusterHealth(),
 		ocp.CustomWorkload(&wh),
 	)

--- a/whereabouts.go
+++ b/whereabouts.go
@@ -1,0 +1,59 @@
+// Copyright 2022 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocp
+
+import (
+        "fmt"
+        "os"
+        "time"
+
+        "github.com/kube-burner/kube-burner/pkg/workloads"
+
+        "github.com/spf13/cobra"
+)
+
+// NewWhereabouts
+func NewWhereabouts(wh *workloads.WorkloadHelper) *cobra.Command {
+        var iterations int
+	var fast bool
+        var podReadyThreshold time.Duration
+        var containerImage string
+        var metricsProfiles []string
+        var rc int
+        cmd := &cobra.Command{
+                Use:          "whereabouts",
+                Short:        "Runs whereabouts workload",
+                SilenceUsage: true,
+                PreRun: func(cmd *cobra.Command, args []string) {
+                        os.Setenv("JOB_ITERATIONS", fmt.Sprint(iterations))
+                        os.Setenv("POD_READY_THRESHOLD", fmt.Sprintf("%v", podReadyThreshold))
+                        os.Setenv("CONTAINER_IMAGE", containerImage)
+			os.Setenv("FAST", fmt.Sprint(fast))
+                },
+                Run: func(cmd *cobra.Command, args []string) {
+                        setMetrics(cmd, metricsProfiles)
+                        rc = wh.Run(cmd.Name())
+                },
+                PostRun: func(cmd *cobra.Command, args []string) {
+                        os.Exit(rc)
+                },
+        }
+        cmd.Flags().IntVar(&iterations, "iterations", 10, "Number of iterations - each iteration is 1 ns and 6 pods")
+	cmd.Flags().BoolVar(&fast, "fast", false, "Use Fast IPAM")
+        cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 15*time.Second, "Pod ready timeout threshold")
+        cmd.Flags().StringVar(&containerImage, "container-image", "gcr.io/google_containers/pause:3.1", "Container image")
+	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics-aggregated.yml"}, "Comma separated list of metrics profiles to use")
+        return cmd
+}

--- a/whereabouts.go
+++ b/whereabouts.go
@@ -15,45 +15,45 @@
 package ocp
 
 import (
-        "fmt"
-        "os"
-        "time"
+	"fmt"
+	"os"
+	"time"
 
-        "github.com/kube-burner/kube-burner/pkg/workloads"
+	"github.com/kube-burner/kube-burner/pkg/workloads"
 
-        "github.com/spf13/cobra"
+	"github.com/spf13/cobra"
 )
 
 // NewWhereabouts
 func NewWhereabouts(wh *workloads.WorkloadHelper) *cobra.Command {
-        var iterations int
+	var iterations int
 	var fast bool
-        var podReadyThreshold time.Duration
-        var containerImage string
-        var metricsProfiles []string
-        var rc int
-        cmd := &cobra.Command{
-                Use:          "whereabouts",
-                Short:        "Runs whereabouts workload",
-                SilenceUsage: true,
-                PreRun: func(cmd *cobra.Command, args []string) {
-                        os.Setenv("JOB_ITERATIONS", fmt.Sprint(iterations))
-                        os.Setenv("POD_READY_THRESHOLD", fmt.Sprintf("%v", podReadyThreshold))
-                        os.Setenv("CONTAINER_IMAGE", containerImage)
+	var podReadyThreshold time.Duration
+	var containerImage string
+	var metricsProfiles []string
+	var rc int
+	cmd := &cobra.Command{
+		Use:          "whereabouts",
+		Short:        "Runs whereabouts workload",
+		SilenceUsage: true,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			os.Setenv("JOB_ITERATIONS", fmt.Sprint(iterations))
+			os.Setenv("POD_READY_THRESHOLD", fmt.Sprintf("%v", podReadyThreshold))
+			os.Setenv("CONTAINER_IMAGE", containerImage)
 			os.Setenv("FAST", fmt.Sprint(fast))
-                },
-                Run: func(cmd *cobra.Command, args []string) {
-                        setMetrics(cmd, metricsProfiles)
-                        rc = wh.Run(cmd.Name())
-                },
-                PostRun: func(cmd *cobra.Command, args []string) {
-                        os.Exit(rc)
-                },
-        }
-        cmd.Flags().IntVar(&iterations, "iterations", 10, "Number of iterations - each iteration is 1 ns and 6 pods")
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			setMetrics(cmd, metricsProfiles)
+			rc = wh.Run(cmd.Name())
+		},
+		PostRun: func(cmd *cobra.Command, args []string) {
+			os.Exit(rc)
+		},
+	}
+	cmd.Flags().IntVar(&iterations, "iterations", 10, "Number of iterations - each iteration is 1 ns and 6 pods")
 	cmd.Flags().BoolVar(&fast, "fast", false, "Use Fast IPAM")
-        cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 15*time.Second, "Pod ready timeout threshold")
-        cmd.Flags().StringVar(&containerImage, "container-image", "gcr.io/google_containers/pause:3.1", "Container image")
+	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 15*time.Second, "Pod ready timeout threshold")
+	cmd.Flags().StringVar(&containerImage, "container-image", "gcr.io/google_containers/pause:3.1", "Container image")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics-aggregated.yml"}, "Comma separated list of metrics profiles to use")
-        return cmd
+	return cmd
 }


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Similar workload to node-density however applies annotation to the pod to have a secondary interface w/ IP address provide by whereabouts.

The optional `fast_ipam` is a TP feature which is still in development and needs additional RBAC to work (for now).

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
