### PR TITLE
Split udn creation and other objects, parameterize job pause

### DIFF
--- a/cmd/config/udn-density-pods/udn-density-pods.yml
+++ b/cmd/config/udn-density-pods/udn-density-pods.yml
@@ -28,10 +28,41 @@ metricsEndpoints:
 
 jobs:
   {{ if eq .ENABLE_LAYER_3 "true" }}
-  - name: udn-density-l3-pods
+  - name: create-udn-l3
   {{ else }}
-  - name: udn-density-l2-pods
+  - name: create-udn-l2
   {{ end }}
+    namespace: udn-density-pods
+    jobIterations: {{.JOB_ITERATIONS}}
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    namespacedIterations: true
+    podWait: false
+    waitWhenFinished: true
+    preLoadImages: false
+    preLoadPeriod: 15s
+    churn: {{.CHURN}}
+    churnCycles: {{.CHURN_CYCLES}}
+    churnDuration: {{.CHURN_DURATION}}
+    churnPercent: {{.CHURN_PERCENT}}
+    churnDelay: {{.CHURN_DELAY}}
+    churnDeletionStrategy: {{.CHURN_DELETION_STRATEGY}}
+    jobPause: {{.JOB_PAUSE}}
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+    objects:
+      {{ if eq .ENABLE_LAYER_3 "true"}}
+      - objectTemplate: udn_l3.yml
+        replicas: 1
+      {{ else }}
+      - objectTemplate: udn_l2.yml
+        replicas: 1
+      {{ end }}
+
+  - name: udn-density-pods
     namespace: udn-density-pods
     jobIterations: {{.JOB_ITERATIONS}}
     qps: {{.QPS}}
@@ -48,19 +79,13 @@ jobs:
     churnDelay: {{.CHURN_DELAY}}
     churnDeletionStrategy: {{.CHURN_DELETION_STRATEGY}}
     jobPause: 5m
+    cleanup: false
     namespaceLabels:
       security.openshift.io/scc.podSecurityLabelSync: false
       pod-security.kubernetes.io/enforce: privileged
       pod-security.kubernetes.io/audit: privileged
       pod-security.kubernetes.io/warn: privileged
     objects:
-      {{ if eq .ENABLE_LAYER_3 "true"}}
-      - objectTemplate: udn_l3.yml
-        replicas: 1
-      {{ else }}
-      - objectTemplate: udn_l2.yml
-        replicas: 1
-      {{ end }}
 
       - objectTemplate: service.yml
         replicas: 5
@@ -74,3 +99,4 @@ jobs:
         replicas: 2
         inputVars:
           podReplicas: 2
+

--- a/udn-density-pods.go
+++ b/udn-density-pods.go
@@ -29,7 +29,7 @@ func NewUDNDensityPods(wh *workloads.WorkloadHelper) *cobra.Command {
 	var churnPercent, churnCycles, iterations int
 	var churn, l3 bool
 	var churnDelay, churnDuration, podReadyThreshold time.Duration
-	var churnDeletionStrategy string
+	var churnDeletionStrategy, jobPause string
 	var metricsProfiles []string
 	var rc int
 	cmd := &cobra.Command{
@@ -37,6 +37,7 @@ func NewUDNDensityPods(wh *workloads.WorkloadHelper) *cobra.Command {
 		Short:        "Runs node-density-udn workload",
 		SilenceUsage: true,
 		PreRun: func(cmd *cobra.Command, args []string) {
+			os.Setenv("JOB_PAUSE", jobPause)
 			os.Setenv("CHURN", fmt.Sprint(churn))
 			os.Setenv("CHURN_CYCLES", fmt.Sprintf("%v", churnCycles))
 			os.Setenv("CHURN_DURATION", fmt.Sprintf("%v", churnDuration))
@@ -63,6 +64,7 @@ func NewUDNDensityPods(wh *workloads.WorkloadHelper) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&l3, "layer3", true, "Layer3 UDN test")
+	cmd.Flags().StringVar(&jobPause, "job-pause", "1ms", "Time to pause after finishing the job")
 	cmd.Flags().BoolVar(&churn, "churn", true, "Enable churning")
 	cmd.Flags().IntVar(&churnCycles, "churn-cycles", 0, "Churn cycles to execute")
 	cmd.Flags().DurationVar(&churnDuration, "churn-duration", 1*time.Hour, "Churn duration")


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->

- Optimization

## Description
We want to run two cases

- udn and pods are created simultaneously in a namespaces, this is good for stressing the CNI
- wait for udns to come up and then create pods, a more practical approach

to switch between two cases we can simply change the ` --job-pause` time to 1s for case1 or X mins, X depends on how much time it takes to create udns.

Tested locally
```
./bin/amd64/kube-burner-ocp udn-density-pods --iterations=2 --gc=false --churn=false --job-pause 1s
time="2025-01-13 17:10:41" level=info msg="❤️ Checking for Cluster Health" file="cluster_health.go:46"
time="2025-01-13 17:10:41" level=info msg="Cluster is Healthy" file="cluster_health.go:54"
time="2025-01-13 17:10:41" level=info msg="Layer 3 is enabled" file="udn-density-pods.go:54"
<snip>
time="2025-01-13 17:11:47" level=info msg="Verifying created objects" file="utils.go:92"
time="2025-01-13 17:11:47" level=info msg="Pausing for 1s before finishing job" file="job.go:153"
```


<!--- Describe your changes in detail -->



