### PR TITLE
Increase vmi-ready-threshold timeout

### DIFF
--- a/virt-density.go
+++ b/virt-density.go
@@ -53,7 +53,7 @@ func NewVirtDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 		},
 	}
 	cmd.Flags().IntVar(&vmsPerNode, "vms-per-node", 245, "VMs per node")
-	cmd.Flags().DurationVar(&vmiRunningThreshold, "vmi-ready-threshold", 20*time.Second, "VMI ready timeout threshold")
+	cmd.Flags().DurationVar(&vmiRunningThreshold, "vmi-ready-threshold", 25*time.Second, "VMI ready timeout threshold")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
 	return cmd
 }


### PR DESCRIPTION
## Type of change

- Optimization

## Description

Increate vmi-ready-threshold timeout from 20 to 25 sec

## Related Issues

The CI cluster sometimes hit this timeout.

