### PR TITLE
have a udn simple workload as a backup in case the full workload fails

### DIFF
--- a/cmd/config/udn-density-pods/deployment-client.yml
+++ b/cmd/config/udn-density-pods/deployment-client.yml
@@ -43,12 +43,14 @@ spec:
         - name: SERVICE_ENDPOINT
           value: "http://udn-density-{{randInt 1 6}}/256.html"
         imagePullPolicy: IfNotPresent
+        {{ if eq .simple false }}
         readinessProbe:
           exec:
             command:
             - "/bin/sh"
             - "-c"
             - "curl --fail -sS ${SERVICE_ENDPOINT} -o /dev/null"
+        {{ end }}
         securityContext:
           privileged: false
         volumeMounts:

--- a/cmd/config/udn-density-pods/udn-density-pods.yml
+++ b/cmd/config/udn-density-pods/udn-density-pods.yml
@@ -89,6 +89,7 @@ jobs:
       k8s.ovn.org/primary-user-defined-network: ""
     objects:
 
+      {{ if ne .SIMPLE "true"}}
       - objectTemplate: np-deny-all.yml
         replicas: 1
 
@@ -97,6 +98,7 @@ jobs:
 
       - objectTemplate: service.yml
         replicas: 5
+     {{ end }}
 
       - objectTemplate: deployment-server.yml
         replicas: 3
@@ -107,4 +109,4 @@ jobs:
         replicas: 2
         inputVars:
           podReplicas: 2
-
+          simple: {{.SIMPLE}}

--- a/udn-density-pods.go
+++ b/udn-density-pods.go
@@ -27,7 +27,7 @@ import (
 // NewUDNDensityPods holds udn-density-pods workload
 func NewUDNDensityPods(wh *workloads.WorkloadHelper) *cobra.Command {
 	var churnPercent, churnCycles, iterations int
-	var churn, l3 bool
+	var churn, l3, simple bool
 	var churnDelay, churnDuration, podReadyThreshold time.Duration
 	var churnDeletionStrategy, jobPause string
 	var metricsProfiles []string
@@ -38,6 +38,7 @@ func NewUDNDensityPods(wh *workloads.WorkloadHelper) *cobra.Command {
 		SilenceUsage: true,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			os.Setenv("JOB_PAUSE", jobPause)
+			os.Setenv("SIMPLE", fmt.Sprint(simple))
 			os.Setenv("CHURN", fmt.Sprint(churn))
 			os.Setenv("CHURN_CYCLES", fmt.Sprintf("%v", churnCycles))
 			os.Setenv("CHURN_DURATION", fmt.Sprintf("%v", churnDuration))
@@ -65,6 +66,7 @@ func NewUDNDensityPods(wh *workloads.WorkloadHelper) *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&l3, "layer3", true, "Layer3 UDN test")
 	cmd.Flags().StringVar(&jobPause, "job-pause", "1ms", "Time to pause after finishing the job")
+	cmd.Flags().BoolVar(&simple, "simple", false, "only client and server pods to be deployed, no services and networkpolicies")
 	cmd.Flags().BoolVar(&churn, "churn", true, "Enable churning")
 	cmd.Flags().IntVar(&churnCycles, "churn-cycles", 0, "Churn cycles to execute")
 	cmd.Flags().DurationVar(&churnDuration, "churn-duration", 1*time.Hour, "Churn duration")


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->

- Optimization

## Description

The full workload which includes services and network policies has issues that cause our Prow runs to fail. To prevent missing results due to this bug, it would be beneficial to have a simpler version running. This would mean that metrics can still be tracked, allowing us to detect regressions in a timely manner.


