### PR TITLE
we need seperate udn l2 and l3 job names

### DIFF
--- a/cmd/config/udn-density-pods/udn-density-pods.yml
+++ b/cmd/config/udn-density-pods/udn-density-pods.yml
@@ -81,7 +81,11 @@ jobs:
         replicas: 1
       {{ end }}
 
-  - name: udn-density-pods
+  {{ if eq .ENABLE_LAYER_3 "true"}}
+  - name: udn-density-l3-pods
+  {{ else }}
+  - name: udn-density-l2-pods
+  {{ end }}
     namespace: udn-density-pods
     jobIterations: {{.JOB_ITERATIONS}}
     qps: {{.QPS}}


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->
- Optimization


## Description
job name is indexed as udn-density-pods which doesn't let us identify whether the run was l3 or l2


