### PR TITLE
Add compaction and defrag measurements

### DIFF
--- a/cmd/config/metrics-report.yml
+++ b/cmd/config/metrics-report.yml
@@ -90,6 +90,24 @@
   metricName: max-99thEtcdRoundTripTime
   instant: true
 
+- query: max(max_over_time((delta(etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_sum[1m:30s])/2)[{{.elapsed}}:30s]))
+  metricName: max-99thEtcdCompaction
+  instant: true
+
+- query: etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_sum
+  metricName: 99thEtcdCompaction-raw
+  instant: true
+  captureStart: true
+
+- query: max(max_over_time((delta(etcd_disk_backend_defrag_duration_seconds_sum[1m:30s])/2)[{{.elapsed}}:30s]))
+  metricName: max-99thEtcdDefrag
+  instant: true
+
+- query: etcd_disk_backend_defrag_duration_seconds_sum
+  metricName: 99thEtcdDefrag-raw
+  instant: true
+  captureStart: true
+
 # Control-plane
 
 - query: avg(avg_over_time(topk(1, sum(irate(container_cpu_usage_seconds_total{name!="", namespace="openshift-kube-controller-manager"}[2m])) by (pod))[{{.elapsed}}:]))

--- a/cmd/config/metrics.yml
+++ b/cmd/config/metrics.yml
@@ -70,6 +70,12 @@
 - query: histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket[5m]))
   metricName: 99thEtcdRoundTripTimeSeconds
 
+- query: delta(etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_sum[1m:30s])/2 > 0
+  metricName: 99thEtcdCompaction
+
+- query: delta(etcd_disk_backend_defrag_duration_seconds_sum[1m:30s])/2 > 0
+  metricName: 99thEtcdDefrag
+
 - query: sum by (cluster_version)(etcd_cluster_version)
   metricName: etcdVersion
   instant: true


### PR DESCRIPTION
## Type of change

- New feature

## Description

Adding more queries that allow us to accurately capture defrag and compaction times.

My intention is: the queries added to report profile allow us to detect whether something on that run has gone wrong, and the queries added metrics.yml allow us to find a time range when the events might have occurred.


* max-99thEtcd(Compaction|Defrag) - Gives the duration of the largest event during the time interval.
* 99thEtcd(Compaction|Defag)-raw - Allows us to calculate the total increase in each metric for each etcd member over the run. This will tell us if durations are similar across all three, or one is exceptionally slow.
* 99thEtcd(Compaction|Defrag) - Will give us the measurement interval where the event occurred. Because of 30s scrape interval, it is a 30s range for where the event happened, but provides a rough estimate to correlate with any other symptoms in other time series.

I use of magic number "2" in dividing by 2, not because I understand why, but because it gives an accurate measurement. That is, the value of 'max-99thEtcdCompaction' will equal the actual time recorded in the etcd logs.

An example from real data:
```
max-99thEtcdCompaction
["2025-02-24T18:04:29Z",853,null,"max(max_over_time((delta(etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_sum[1m:30s])/2)[1598s:30s]))"]
99thEtcdCompaction
["2025-02-24T17:41:51Z",450,"etcd-ip-10-0-14-234.us-west-2.compute.internal","delta(etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_sum[1m:30s])/2 > 0"]
["2025-02-24T17:46:51Z",853,"etcd-ip-10-0-14-234.us-west-2.compute.internal","delta(etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_sum[1m:30s])/2 > 0"]
["2025-02-24T17:51:51Z",663,"etcd-ip-10-0-14-234.us-west-2.compute.internal","delta(etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_sum[1m:30s])/2 > 0"]
["2025-02-24T17:56:51Z",586,"etcd-ip-10-0-14-234.us-west-2.compute.internal","delta(etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_sum[1m:30s])/2 > 0"]
["2025-02-24T18:01:51Z",614,"etcd-ip-10-0-14-234.us-west-2.compute.internal","delta(etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_sum[1m:30s])/2 > 0"]
99thEtcdCompaction-raw
["2025-02-24T18:04:29Z",5877,"etcd-ip-10-0-14-234.us-west-2.compute.internal","etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_sum"]
99thEtcdCompaction-raw-start
["2025-02-24T17:37:51Z",2711,"etcd-ip-10-0-14-234.us-west-2.compute.internal","etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_sum"]
```
The slowest compaction was 853ms, and the peak occurred within a 30s interval before 2025-02-24T17:46:51Z
Sum of all compactions on that member can be found from -raw measurement: 5877-2711 = 3166ms
Which matches each individual compaction: 450+853+663+586+614 = 3166

Comparing all three members:
```
99thEtcdCompaction-raw
["2025-02-24T18:04:29Z",3879,"etcd-ip-10-0-34-91.us-west-2.compute.internal","etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_sum"]
["2025-02-24T18:04:29Z",5877,"etcd-ip-10-0-14-234.us-west-2.compute.internal","etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_sum"]
["2025-02-24T18:04:29Z",6427,"etcd-ip-10-0-79-187.us-west-2.compute.internal","etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_sum"]
99thEtcdCompaction-raw-start
["2025-02-24T17:37:51Z",2711,"etcd-ip-10-0-14-234.us-west-2.compute.internal","etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_sum"]
["2025-02-24T17:37:51Z",3455,"etcd-ip-10-0-79-187.us-west-2.compute.internal","etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_sum"]
["2025-02-24T17:37:51Z",909,"etcd-ip-10-0-34-91.us-west-2.compute.internal","etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_sum"]
```
ip-10-0-14-234: 5877-2711= 3166ms
ip-10-0-79-187: 6427-3455= 2972ms
ip-10-0-34-91 : 3879-909 = 2970ms

Only 200ms higher on one member over several compactions is normal.