### PR TITLE
Lower barrier of entry by making indexing truly optional

### DIFF
--- a/cmd/ocp.go
+++ b/cmd/ocp.go
@@ -93,8 +93,13 @@ func openShiftCmd() *cobra.Command {
 		} else {
 			envVars["ALERTS"] = ""
 		}
-		// If metricsEndpoint is not set, use values from flags
-		if workloadConfig.MetricsEndpoint == "" && esServer != "" && esIndex != "" {
+		esServerEnv := os.Getenv("ES_SERVER")
+		esIndexEnv := os.Getenv("ES_INDEX")
+		if workloadConfig.MetricsEndpoint == "" && (esServerEnv == "" || esIndexEnv == "") {
+			envVars["ES_SERVER"] = ""
+			envVars["ES_INDEX"] = ""
+		}
+		if esServer != "" && esIndex != "" {
 			envVars["ES_SERVER"] = esServer
 			envVars["ES_INDEX"] = esIndex
 		}


### PR DESCRIPTION
Currently the go template checks that ES_SERVER is non empty and would throw a rendering error when the variable is not defined. While the intent has always been to make indexing optional, the current implementation does not support that.

We would like to enable cases where users do not care about ES or local indexing and merely want to run load quickly by using something like `kube-burner-ocp node-density` use the stdout to read high level measurements like pod ready latency.

## Type of change

<!-- Choose a type of change -->


- Bug fix https://github.com/kube-burner/kube-burner-ocp/issues/203


