### PR TITLE
UDN Churn fix

### DIFF
--- a/cmd/config/udn-density-pods/udn-density-pods.yml
+++ b/cmd/config/udn-density-pods/udn-density-pods.yml
@@ -1,6 +1,3 @@
-# This workload has special hardware requirements.
-# In order to meet those requirements we have added CI tests in e2e-benchmarking: 
-# https://github.com/openshift/release/tree/master/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking
 ---
 global:
   gc: {{.GC}}
@@ -48,6 +45,7 @@ metricsEndpoints:
 {{ end }}
 
 jobs:
+  {{ if eq .CHURN "false" }}
   {{ if eq .ENABLE_LAYER_3 "true" }}
   - name: create-udn-l3
   {{ else }}
@@ -62,12 +60,6 @@ jobs:
     waitWhenFinished: true
     preLoadImages: false
     preLoadPeriod: 15s
-    churn: {{.CHURN}}
-    churnCycles: {{.CHURN_CYCLES}}
-    churnDuration: {{.CHURN_DURATION}}
-    churnPercent: {{.CHURN_PERCENT}}
-    churnDelay: {{.CHURN_DELAY}}
-    churnDeletionStrategy: {{.CHURN_DELETION_STRATEGY}}
     jobPause: {{.JOB_PAUSE}}
     namespaceLabels:
       security.openshift.io/scc.podSecurityLabelSync: false
@@ -83,6 +75,8 @@ jobs:
       - objectTemplate: udn_l2.yml
         replicas: 1
       {{ end }}
+  {{ end }}
+
 
   {{ if eq .ENABLE_LAYER_3 "true"}}
   - name: udn-density-l3-pods
@@ -113,6 +107,15 @@ jobs:
       pod-security.kubernetes.io/warn: privileged
       k8s.ovn.org/primary-user-defined-network: ""
     objects:
+      {{ if eq .CHURN "true"}}
+      {{ if eq .ENABLE_LAYER_3 "true"}}
+      - objectTemplate: udn_l3.yml
+        replicas: 1
+      {{ else }}
+      - objectTemplate: udn_l2.yml
+        replicas: 1
+      {{ end }}
+      {{ end }}
 
       {{ if ne .SIMPLE "true"}}
       - objectTemplate: np-deny-all.yml
@@ -123,7 +126,7 @@ jobs:
 
       - objectTemplate: service.yml
         replicas: 5
-     {{ end }}
+      {{ end }}
 
       - objectTemplate: deployment-server.yml
         replicas: 3

--- a/udn-density-pods.go
+++ b/udn-density-pods.go
@@ -59,6 +59,9 @@ func NewUDNDensityPods(wh *workloads.WorkloadHelper) *cobra.Command {
 				log.Info("Layer 2 is enabled")
 				os.Setenv("ENABLE_LAYER_3", "false")
 			}
+			if churn {
+				log.Info("Churn is enabled, there will not be a pause after UDN creation")
+			}
 			rc = wh.Run("udn-density-pods")
 		},
 		PostRun: func(cmd *cobra.Command, args []string) {
@@ -69,7 +72,7 @@ func NewUDNDensityPods(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().StringVar(&jobPause, "job-pause", "1ms", "Time to pause after finishing the job")
 	cmd.Flags().BoolVar(&pprof, "pprof", false, "Enable pprof collection")
 	cmd.Flags().BoolVar(&simple, "simple", false, "only client and server pods to be deployed, no services and networkpolicies")
-	cmd.Flags().BoolVar(&churn, "churn", true, "Enable churning")
+	cmd.Flags().BoolVar(&churn, "churn", false, "Enable churning")
 	cmd.Flags().IntVar(&churnCycles, "churn-cycles", 0, "Churn cycles to execute")
 	cmd.Flags().DurationVar(&churnDuration, "churn-duration", 1*time.Hour, "Churn duration")
 	cmd.Flags().DurationVar(&churnDelay, "churn-delay", 2*time.Minute, "Time to wait between each churn")
@@ -78,5 +81,6 @@ func NewUDNDensityPods(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().IntVar(&iterations, "iterations", 0, "Iterations")
 	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 1*time.Minute, "Pod ready timeout threshold")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
+	cmd.MarkFlagRequired("iterations")
 	return cmd
 }


### PR DESCRIPTION
The way that the udn-density-pods workload has currently been implemented, the churn functionality does not ireally work as the UDNs are created in a separate job from the one in which pods/other resoruces are created. This leads to a condition where the `udn-density-l3-pods` job tries to create pods without the UDN, which has been deleted during the churn phase. Thecurrent changes preserve the jobPause functionality by keeping UDN creationin a separate job and enable true churning without pause when requested by user. Churn is also defaulted to false after this change. Current behavior with jobPause is not changed with this patch.

## Type of change

<!-- Choose a type of change -->

- Refactor
- Bug fix



