### PR TITLE
add new measurements support

### DIFF
--- a/cmd/config/cluster-density-v2/cluster-density-v2.yml
+++ b/cmd/config/cluster-density-v2/cluster-density-v2.yml
@@ -8,6 +8,9 @@ global:
         - conditionType: Ready
           metric: P99
           threshold: {{.POD_READY_THRESHOLD}}
+    - name: serviceLatency
+      svcTimeout: 5s
+    - name: exampleLatency
 {{ if eq .PPROF "true" }}
     - name: pprof
       pprofInterval: 2m
@@ -72,40 +75,12 @@ jobs:
       pod-security.kubernetes.io/warn: privileged
     objects:
 
-      - objectTemplate: imagestream.yml
+      - objectTemplate: pod.yml
         replicas: 1
-
-      - objectTemplate: build.yml
-        replicas: 1
-
+        inputVars:
+          podReplicas: 1
       - objectTemplate: service.yml
-        replicas: 5
-        
-      - objectTemplate: route.yml
-        replicas: 2
-
-      - objectTemplate: secret.yml
-        replicas: 10
-
-      - objectTemplate: configmap.yml
-        replicas: 10
-
-      - objectTemplate: np-deny-all.yml
         replicas: 1
-
-      - objectTemplate: np-allow-from-clients.yml
-        replicas: 1
-
-      - objectTemplate: np-allow-from-ingress.yml
-        replicas: 1
-
-      - objectTemplate: deployment-server.yml
-        replicas: 3
         inputVars:
-          podReplicas: 2
+          podReplicas: 1
 
-      - objectTemplate: deployment-client.yml
-        replicas: 2
-        inputVars:
-          podReplicas: 2
-          ingressDomain: {{.INGRESS_DOMAIN}}

--- a/cmd/config/cluster-density-v2/pod.yml
+++ b/cmd/config/cluster-density-v2/pod.yml
@@ -1,0 +1,43 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  labels:
+    name: cluster-density-{{.Iteration}}
+    app: nginx
+  name: {{.JobName}}-{{.Iteration}}
+spec:
+  topologySpreadConstraints:
+  - maxSkew: 1 
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway 
+    labelSelector: 
+      matchLabels:
+        app: pause
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: node-role.kubernetes.io/worker
+            operator: Exists
+          - key: node-role.kubernetes.io/infra
+            operator: DoesNotExist
+          - key: node-role.kubernetes.io/workload
+            operator: DoesNotExist
+  tolerations:
+  - key: os
+    value: Windows
+    effect: NoSchedule
+  containers:
+  - image: quay.io/cloud-bulldozer/nginx:latest
+    name: cluster-density
+    resources:
+      requests:
+        memory: "10Mi"
+        cpu: "10m"
+    imagePullPolicy: IfNotPresent
+    ports:
+      - containerPort: 8080
+        protocol: TCP
+      - containerPort: 8443
+        protocol: TCP

--- a/example_measurements.go
+++ b/example_measurements.go
@@ -1,0 +1,128 @@
+// Copyright 2020 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package ocp
+
+import (
+	"sync"
+	"time"
+
+	"github.com/cloud-bulldozer/go-commons/v2/indexers"
+	"github.com/kube-burner/kube-burner/pkg/config"
+	"github.com/kube-burner/kube-burner/pkg/measurements"
+	"github.com/kube-burner/kube-burner/pkg/measurements/metrics"
+	"github.com/kube-burner/kube-burner/pkg/measurements/types"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	exampleLatencyMeasurement          = "exampleLatencyMeasurement"
+	exampleLatencyQuantilesMeasurement = "exampleLatencyQuantilesMeasurement"
+)
+
+type exampleMetric struct {
+	Timestamp    time.Time   `json:"timestamp"`
+	MetricName   string      `json:"metricName"`
+	UUID         string      `json:"uuid"`
+	JobName      string      `json:"jobName,omitempty"`
+	JobIteration int         `json:"jobIteration"`
+	Replica      int         `json:"replica"`
+	Namespace    string      `json:"namespace"`
+	Name         string      `json:"exampleName"`
+	Metadata     interface{} `json:"metadata,omitempty"`
+}
+
+type exampleLatency struct {
+	measurements.BaseLatencyMeasurement
+
+	metrics          sync.Map
+	latencyQuantiles []interface{}
+	normLatencies    []interface{}
+}
+
+type exampleLatencyMeasurementFactory struct {
+	measurements.BaseLatencyMeasurementFactory
+}
+
+func NewExampleLatencyMeasurementFactory(configSpec config.Spec, measurement types.Measurement, metadata map[string]interface{}) (measurements.MeasurementFactory, error) {
+	return exampleLatencyMeasurementFactory{
+		measurements.NewBaseLatencyMeasurementFactory(configSpec, measurement, metadata),
+	}, nil
+}
+
+func (plmf exampleLatencyMeasurementFactory) NewMeasurement(jobConfig *config.Job, clientSet kubernetes.Interface, restConfig *rest.Config) measurements.Measurement {
+	return &exampleLatency{
+		BaseLatencyMeasurement: plmf.NewBaseLatency(jobConfig, clientSet, restConfig),
+	}
+}
+
+// start exampleLatency measurement
+func (p *exampleLatency) Start(measurementWg *sync.WaitGroup) error {
+	// Reset latency slices, required in multi-job benchmarks
+	p.latencyQuantiles, p.normLatencies = nil, nil
+	defer measurementWg.Done()
+	p.metrics = sync.Map{}
+	log.Infof("Creating Example latency watcher for %s", p.JobConfig.Name)
+	p.metrics.LoadOrStore("example-1", exampleMetric{
+		Timestamp:    time.Now().UTC(),
+		Namespace:    "example-1",
+		Name:         "example-1",
+		MetricName:   exampleLatencyMeasurement,
+		UUID:         "example-1",
+		JobName:      p.JobConfig.Name,
+		Metadata:     p.Metadata,
+		JobIteration: 0,
+		Replica:      1,
+	})
+	return nil
+}
+
+// collects example measurements triggered in the past
+func (p *exampleLatency) Collect(measurementWg *sync.WaitGroup) {
+	defer measurementWg.Done()
+}
+
+// Stop stops exampleLatency measurement
+func (p *exampleLatency) Stop() error {
+	var err error
+	p.normalizeMetrics()
+	for _, q := range p.latencyQuantiles {
+		pq := q.(metrics.LatencyQuantiles)
+		log.Infof("%s: %v 99th: %v max: %v avg: %v", p.JobConfig.Name, pq.QuantileName, pq.P99, pq.Max, pq.Avg)
+	}
+	return err
+}
+
+// index sends metrics to the configured indexer
+func (p *exampleLatency) Index(jobName string, indexerList map[string]indexers.Indexer) {
+	metricMap := map[string][]interface{}{
+		exampleLatencyMeasurement:          p.normLatencies,
+		exampleLatencyQuantilesMeasurement: p.latencyQuantiles,
+	}
+	measurements.IndexLatencyMeasurement(p.Config, jobName, metricMap, indexerList)
+}
+
+func (p *exampleLatency) GetMetrics() *sync.Map {
+	return &p.metrics
+}
+
+func (p *exampleLatency) normalizeMetrics() float64 {
+	p.metrics.Range(func(key, value interface{}) bool {
+		m := value.(exampleMetric)
+		p.normLatencies = append(p.normLatencies, m)
+		return true
+	})
+	return 0.0
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	k8s.io/client-go v0.31.1
 )
 
+replace github.com/kube-burner/kube-burner => /root/module/kube-burner
 require (
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/virt-capacity-benchmark.go
+++ b/virt-capacity-benchmark.go
@@ -125,7 +125,7 @@ func NewVirtCapacityBenchmark(wh *workloads.WorkloadHelper) *cobra.Command {
 			counter := 0
 			for {
 				os.Setenv("counter", fmt.Sprint(counter))
-				rc = wh.RunWithAdditionalVars(cmd.Name(), additionalVars)
+				rc = wh.RunWithAdditionalVars(cmd.Name(), additionalVars, nil)
 				if rc != 0 {
 					log.Infof("Capacity failed in loop #%d", counter)
 					break

--- a/virt-clone.go
+++ b/virt-clone.go
@@ -107,7 +107,7 @@ func NewVirtClone(wh *workloads.WorkloadHelper) *cobra.Command {
 			}
 
 			setMetrics(cmd, metricsProfiles)
-			rc = wh.RunWithAdditionalVars(cmd.Name(), additionalVars)
+			rc = wh.RunWithAdditionalVars(cmd.Name(), additionalVars, nil)
 		},
 		PostRun: func(cmd *cobra.Command, args []string) {
 			os.Exit(rc)


### PR DESCRIPTION
This enables kube-burner-ocp to define its own measurement functionality (example, network-policy-measurement.go, router-advertisement-measurement.go). This is required to avoid using openshift CRD in kube-burner measurements code.

It defines exampleLatency which is currently working and can be used as a reference for other measurements like router-advertisement-measurement.go.

Now kube-burner-ocp prepares measurementFactoryMap with the core measurements (like pod, service latency) and additional measurements which is defined in kube-burner-ocp (like exampleLatency).

I have tested this code with only enabling podLatency and exampleLatency. I will fine tune it once we are fine with this approach.

This PR depends on kube-burner PR
https://github.com/kube-burner/kube-burner/pull/841

## Type of change

<!-- Choose a type of change -->

- Refactor
- New feature
- Bug fix
- Optimization
- Documentation
- CI

## Description

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #
- Closes #

