### PR TITLE
BGP RouteAdvertisement latency measurements

### DIFF
--- a/cluster-density.go
+++ b/cluster-density.go
@@ -20,16 +20,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/kube-burner/kube-burner/pkg/measurements"
 	"github.com/kube-burner/kube-burner/pkg/workloads"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
-
-var measurementFactoryMap = map[string]measurements.NewMeasurementFactory{
-	"podLatency":     measurements.NewPodLatencyMeasurementFactory,
-	"exampleLatency": NewExampleLatencyMeasurementFactory,
-}
 
 // NewClusterDensity holds cluster-density workload
 func NewClusterDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Command {

--- a/cmd/config/cluster-density-v2/cluster-density-v2.yml
+++ b/cmd/config/cluster-density-v2/cluster-density-v2.yml
@@ -8,6 +8,9 @@ global:
         - conditionType: Ready
           metric: P99
           threshold: {{.POD_READY_THRESHOLD}}
+    - name: serviceLatency
+      svcTimeout: 5s
+    - name: exampleLatency
 {{ if eq .PPROF "true" }}
     - name: pprof
       pprofInterval: 2m
@@ -72,40 +75,12 @@ jobs:
       pod-security.kubernetes.io/warn: privileged
     objects:
 
-      - objectTemplate: imagestream.yml
+      - objectTemplate: pod.yml
         replicas: 1
-
-      - objectTemplate: build.yml
-        replicas: 1
-
+        inputVars:
+          podReplicas: 1
       - objectTemplate: service.yml
-        replicas: 5
-        
-      - objectTemplate: route.yml
-        replicas: 2
-
-      - objectTemplate: secret.yml
-        replicas: 10
-
-      - objectTemplate: configmap.yml
-        replicas: 10
-
-      - objectTemplate: np-deny-all.yml
         replicas: 1
-
-      - objectTemplate: np-allow-from-clients.yml
-        replicas: 1
-
-      - objectTemplate: np-allow-from-ingress.yml
-        replicas: 1
-
-      - objectTemplate: deployment-server.yml
-        replicas: 3
         inputVars:
-          podReplicas: 2
+          podReplicas: 1
 
-      - objectTemplate: deployment-client.yml
-        replicas: 2
-        inputVars:
-          podReplicas: 2
-          ingressDomain: {{.INGRESS_DOMAIN}}

--- a/cmd/config/cluster-density-v2/pod.yml
+++ b/cmd/config/cluster-density-v2/pod.yml
@@ -1,0 +1,43 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  labels:
+    name: cluster-density-{{.Iteration}}
+    app: nginx
+  name: {{.JobName}}-{{.Iteration}}
+spec:
+  topologySpreadConstraints:
+  - maxSkew: 1 
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway 
+    labelSelector: 
+      matchLabels:
+        app: pause
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: node-role.kubernetes.io/worker
+            operator: Exists
+          - key: node-role.kubernetes.io/infra
+            operator: DoesNotExist
+          - key: node-role.kubernetes.io/workload
+            operator: DoesNotExist
+  tolerations:
+  - key: os
+    value: Windows
+    effect: NoSchedule
+  containers:
+  - image: quay.io/cloud-bulldozer/nginx:latest
+    name: cluster-density
+    resources:
+      requests:
+        memory: "10Mi"
+        cpu: "10m"
+    imagePullPolicy: IfNotPresent
+    ports:
+      - containerPort: 8080
+        protocol: TCP
+      - containerPort: 8443
+        protocol: TCP

--- a/cmd/config/udn-bgp/configmap.yml
+++ b/cmd/config/udn-bgp/configmap.yml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{.JobName}}-{{.Replica}}
+data:
+  key1: "{{randAlphaNum 2048}}"
+

--- a/cmd/config/udn-bgp/cudn.yml
+++ b/cmd/config/udn-bgp/cudn.yml
@@ -1,0 +1,30 @@
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: cudn-{{.Iteration}}
+  labels:
+    cudn-{{.Iteration}}: ""
+spec:
+  {{- $nsList := list }}
+  {{- $nsStart := mul $.Iteration $.namespaces_per_cudn }}
+  {{- range $i, $v := until $.namespaces_per_cudn }}
+    {{- $nextNs := mod (add $nsStart $i) $.total_namespaces }}
+    {{- $next_namespace := print "udn-bgp-" $nextNs }}
+    {{- $nsList = append $nsList $next_namespace }}
+  {{- end }}
+  {{- $nsNames := toJson $nsList }}
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values: {{$nsNames}}
+  {{- $firstOctet := add (div $.Iteration 255) 10 }}
+  {{- $secondOctet := mod $.Iteration 255 }}
+  {{- $cudnCidr := print $firstOctet "." $secondOctet ".0.0/16" }}
+  network:
+    topology: Layer3
+    layer3:
+      role: Primary
+      subnets:
+        - cidr: {{$cudnCidr}}
+          hostSubnet: 24

--- a/cmd/config/udn-bgp/pod.yml
+++ b/cmd/config/udn-bgp/pod.yml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod-{{.Replica}}
+spec:
+  containers:
+  - name: webserver
+    image: quay.io/cloud-bulldozer/sampleapp:latest
+    resources:
+      requests:
+        memory: "10Mi"
+        cpu: "10m"
+    imagePullPolicy: Always
+    ports:
+     - containerPort: 8080
+       protocol: TCP
+    securityContext:
+       privileged: false

--- a/cmd/config/udn-bgp/ra.yml
+++ b/cmd/config/udn-bgp/ra.yml
@@ -1,0 +1,11 @@
+apiVersion: k8s.ovn.org/v1
+kind: RouteAdvertisements
+metadata:
+  name: ra-{{.Iteration}}
+spec:
+  networkSelector:
+    matchLabels:
+      cudn-{{.Iteration}}: ""
+  advertisements:
+  - "PodNetwork"
+  - "EgressIP"

--- a/cmd/config/udn-bgp/secret.yml
+++ b/cmd/config/udn-bgp/secret.yml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{.JobName}}-{{.Replica}}
+data:
+  top-secret: "{{randAlphaNum 2048}}"

--- a/cmd/config/udn-bgp/udn-bgp.yml
+++ b/cmd/config/udn-bgp/udn-bgp.yml
@@ -1,0 +1,134 @@
+# This workload has special hardware requirements.
+# In order to meet those requirements we have added CI tests in e2e-benchmarking: 
+# https://github.com/openshift/release/tree/master/ci-operator/step-registry/cloud-bulldozer/e2e-benchmarking
+---
+global:
+  gc: false
+  gcMetrics: {{.GC_METRICS}}
+  measurements:
+    - name: raLatency
+      thresholds:
+        - conditionType: Ready
+          metric: P99
+metricsEndpoints:
+{{ if .ES_SERVER }}
+  - metrics: [{{.METRICS}}]
+    alerts: [{{.ALERTS}}]
+    indexer:
+      esServers: ["{{.ES_SERVER}}"]
+      insecureSkipVerify: true
+      defaultIndex: {{.ES_INDEX}}
+      type: opensearch
+{{ end }}
+{{ if eq .LOCAL_INDEXING "true" }}
+  - metrics: [{{.METRICS}}]
+    alerts: [{{.ALERTS}}]
+    indexer:
+      type: local
+      metricsDirectory: collected-metrics-{{.UUID}}
+{{ end }}
+jobs:
+  - name: udn-bgp-create-namespaces
+    namespace: udn-bgp
+    jobIterations: {{.JOB_ITERATIONS}}
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    namespacedIterations: true
+    waitWhenFinished: true
+    skipIndexing: true
+    jobPause: 20s
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+      k8s.ovn.org/primary-user-defined-network: ""
+    objects:
+      - objectTemplate: configmap.yml
+        replicas: 1
+
+  - name: udn-bgp-create-cudn
+    {{- $numCudn := div .JOB_ITERATIONS .NAMESPACES_PER_CUDN }}
+    jobIterations: {{$numCudn}}
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    namespacedIterations: false
+    waitWhenFinished: true
+    jobPause: 1m
+    skipIndexing: true
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+      k8s.ovn.org/primary-user-defined-network: ""
+    objects:
+      - objectTemplate: cudn.yml
+        replicas: 1
+        inputVars:
+          namespaces_per_cudn: {{.NAMESPACES_PER_CUDN}}
+          total_namespaces: {{.JOB_ITERATIONS}}
+
+  - name: udn-bgp-create-pods
+    namespace: udn-bgp
+    jobIterations: {{.JOB_ITERATIONS}}
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    namespacedIterations: true
+    podWait: false
+    waitWhenFinished: true
+    preLoadImages: true
+    preLoadPeriod: 15s
+    jobPause: 1m
+    cleanup: false
+    skipIndexing: true
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+      k8s.ovn.org/primary-user-defined-network: ""
+    objects:
+      - objectTemplate: pod.yml
+        replicas: 1 
+        inputVars:
+          podReplicas: 1
+
+  - name: udn-bgp-export-routes
+    {{- $numCudn := div .JOB_ITERATIONS .NAMESPACES_PER_CUDN }}
+    jobIterations: {{$numCudn}}
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    namespacedIterations: false
+    waitWhenFinished: true
+    jobPause: 1m
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+      k8s.ovn.org/primary-user-defined-network: ""
+    objects:
+      - objectTemplate: ra.yml
+        replicas: 1
+        inputVars:
+          namespaces_per_cudn: {{.NAMESPACES_PER_CUDN}}
+          total_namespaces: {{.JOB_ITERATIONS}}
+
+  - name: udn-bgp-import-routes
+    namespace: udn-bgp
+    jobIterations: 1
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    namespacedIterations: true
+    waitWhenFinished: true
+    jobPause: 1m
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+      k8s.ovn.org/primary-user-defined-network: ""
+    objects:
+      - objectTemplate: secret.yml
+        replicas: 1

--- a/common.go
+++ b/common.go
@@ -23,6 +23,7 @@ import (
 	k8sconnector "github.com/cloud-bulldozer/go-commons/v2/k8s-connector"
 	ocpmetadata "github.com/cloud-bulldozer/go-commons/v2/ocp-metadata"
 	"github.com/kube-burner/kube-burner/pkg/config"
+	"github.com/kube-burner/kube-burner/pkg/measurements"
 	"github.com/kube-burner/kube-burner/pkg/workloads"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -37,6 +38,12 @@ var (
 		"RWX": "ReadWriteMany",
 	}
 )
+
+var measurementFactoryMap = map[string]measurements.NewMeasurementFactory{
+	"podLatency":     measurements.NewPodLatencyMeasurementFactory,
+	"exampleLatency": NewExampleLatencyMeasurementFactory,
+	"raLatency":      NewRaLatencyMeasurementFactory,
+}
 
 func setMetrics(cmd *cobra.Command, metricsProfiles []string) {
 	profileType, _ := cmd.Root().PersistentFlags().GetString("profile-type")

--- a/example_measurements.go
+++ b/example_measurements.go
@@ -1,0 +1,128 @@
+// Copyright 2020 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package ocp
+
+import (
+	"sync"
+	"time"
+
+	"github.com/cloud-bulldozer/go-commons/v2/indexers"
+	"github.com/kube-burner/kube-burner/pkg/config"
+	"github.com/kube-burner/kube-burner/pkg/measurements"
+	"github.com/kube-burner/kube-burner/pkg/measurements/metrics"
+	"github.com/kube-burner/kube-burner/pkg/measurements/types"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	exampleLatencyMeasurement          = "exampleLatencyMeasurement"
+	exampleLatencyQuantilesMeasurement = "exampleLatencyQuantilesMeasurement"
+)
+
+type exampleMetric struct {
+	Timestamp    time.Time   `json:"timestamp"`
+	MetricName   string      `json:"metricName"`
+	UUID         string      `json:"uuid"`
+	JobName      string      `json:"jobName,omitempty"`
+	JobIteration int         `json:"jobIteration"`
+	Replica      int         `json:"replica"`
+	Namespace    string      `json:"namespace"`
+	Name         string      `json:"exampleName"`
+	Metadata     interface{} `json:"metadata,omitempty"`
+}
+
+type exampleLatency struct {
+	measurements.BaseLatencyMeasurement
+
+	metrics          sync.Map
+	latencyQuantiles []interface{}
+	normLatencies    []interface{}
+}
+
+type exampleLatencyMeasurementFactory struct {
+	measurements.BaseLatencyMeasurementFactory
+}
+
+func NewExampleLatencyMeasurementFactory(configSpec config.Spec, measurement types.Measurement, metadata map[string]interface{}) (measurements.MeasurementFactory, error) {
+	return exampleLatencyMeasurementFactory{
+		measurements.NewBaseLatencyMeasurementFactory(configSpec, measurement, metadata),
+	}, nil
+}
+
+func (plmf exampleLatencyMeasurementFactory) NewMeasurement(jobConfig *config.Job, clientSet kubernetes.Interface, restConfig *rest.Config) measurements.Measurement {
+	return &exampleLatency{
+		BaseLatencyMeasurement: plmf.NewBaseLatency(jobConfig, clientSet, restConfig),
+	}
+}
+
+// start exampleLatency measurement
+func (p *exampleLatency) Start(measurementWg *sync.WaitGroup) error {
+	// Reset latency slices, required in multi-job benchmarks
+	p.latencyQuantiles, p.normLatencies = nil, nil
+	defer measurementWg.Done()
+	p.metrics = sync.Map{}
+	log.Infof("Creating Example latency watcher for %s", p.JobConfig.Name)
+	p.metrics.LoadOrStore("example-1", exampleMetric{
+		Timestamp:    time.Now().UTC(),
+		Namespace:    "example-1",
+		Name:         "example-1",
+		MetricName:   exampleLatencyMeasurement,
+		UUID:         "example-1",
+		JobName:      p.JobConfig.Name,
+		Metadata:     p.Metadata,
+		JobIteration: 0,
+		Replica:      1,
+	})
+	return nil
+}
+
+// collects example measurements triggered in the past
+func (p *exampleLatency) Collect(measurementWg *sync.WaitGroup) {
+	defer measurementWg.Done()
+}
+
+// Stop stops exampleLatency measurement
+func (p *exampleLatency) Stop() error {
+	var err error
+	p.normalizeMetrics()
+	for _, q := range p.latencyQuantiles {
+		pq := q.(metrics.LatencyQuantiles)
+		log.Infof("%s: %v 99th: %v max: %v avg: %v", p.JobConfig.Name, pq.QuantileName, pq.P99, pq.Max, pq.Avg)
+	}
+	return err
+}
+
+// index sends metrics to the configured indexer
+func (p *exampleLatency) Index(jobName string, indexerList map[string]indexers.Indexer) {
+	metricMap := map[string][]interface{}{
+		exampleLatencyMeasurement:          p.normLatencies,
+		exampleLatencyQuantilesMeasurement: p.latencyQuantiles,
+	}
+	measurements.IndexLatencyMeasurement(p.Config, jobName, metricMap, indexerList)
+}
+
+func (p *exampleLatency) GetMetrics() *sync.Map {
+	return &p.metrics
+}
+
+func (p *exampleLatency) normalizeMetrics() float64 {
+	p.metrics.Range(func(key, value interface{}) bool {
+		m := value.(exampleMetric)
+		p.normLatencies = append(p.normLatencies, m)
+		return true
+	})
+	return 0.0
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	k8s.io/client-go v0.31.1
 )
 
+replace github.com/kube-burner/kube-burner => /root/module/kube-burner
 require (
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/ra_latency.go
+++ b/ra_latency.go
@@ -1,0 +1,647 @@
+// Copyright 2020 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cloud-bulldozer/go-commons/v2/indexers"
+	"github.com/go-ping/ping"
+	"github.com/kube-burner/kube-burner/pkg/config"
+	"github.com/kube-burner/kube-burner/pkg/measurements"
+	"github.com/kube-burner/kube-burner/pkg/measurements/metrics"
+	"github.com/kube-burner/kube-burner/pkg/measurements/types"
+	routeadvertisementsv1 "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1"
+	routeadvertisementsclientset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1/apis/clientset/versioned"
+	routeadvertisementsinformerfactory "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1/apis/informers/externalversions"
+	userdefinednetworkclientset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/clientset/versioned"
+	log "github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	raLatencyMeasurement          = "raLatencyMeasurement"
+	raLatencyQuantilesMeasurement = "raLatencyQuantilesMeasurement"
+	exportWorkerCount             = 20
+	pingAttempts                  = 100
+	numDummyIfaces                = 20
+	numAddressOnDummyIface        = 10
+	importWorkerCount             = 10
+	importPingThreads             = 5
+	importScenario                = true
+	exportScenario                = true
+	importWaitBeforePingRetryMsec = 100
+	importPingerTimeoutMsec       = 10
+	exportWaitBeforePingRetryMsec = 100
+	exportPingerTimeoutMsec       = 100
+)
+
+// Internal struct used to marshal PodAnnotation to the pod annotation
+type podAnnotation struct {
+	IPs      []string   `json:"ip_addresses"`
+	MAC      string     `json:"mac_address"`
+	Gateways []string   `json:"gateway_ips,omitempty"`
+	Routes   []podRoute `json:"routes,omitempty"`
+
+	IP      string `json:"ip_address,omitempty"`
+	Gateway string `json:"gateway_ip,omitempty"`
+
+	TunnelID int    `json:"tunnel_id,omitempty"`
+	Role     string `json:"role,omitempty"`
+}
+
+// Internal struct used to marshal PodRoute to the pod annotation
+type podRoute struct {
+	Dest    string `json:"dest"`
+	NextHop string `json:"nextHop"`
+}
+
+type routeImport struct {
+	link string
+	addr string
+	pods []string
+}
+
+var stopCh = make(chan struct{})
+
+type raMetric struct {
+	Timestamp              time.Time   `json:"timestamp"`
+	MetricName             string      `json:"metricName"`
+	UUID                   string      `json:"uuid"`
+	JobName                string      `json:"jobName,omitempty"`
+	Name                   string      `json:"routeAdvertisementName"`
+	Metadata               interface{} `json:"metadata,omitempty"`
+	Scenario               string      `json:"scenario,omitempty"`
+	cudn                   []string
+	Latency                []float64 `json:"latency,omitempty"`
+	MinReadyLatency        int       `json:"minReadyLatency"`
+	MaxReadyLatency        int       `json:"maxReadyLatency"`
+	ReadyLatency           int       `json:"readyLatency"`
+	NetlinkRouteLatency    []float64 `json:"netlinkRouteLatency,omitempty"`
+	MaxNetlinkRouteLatency int       `json:"maxNetlinkRouteLatency,omitempty"`
+	MinNetlinkRouteLatency int       `json:"minNetlinkRouteLatency,omitempty"`
+	P99NetlinkRouteLatency int       `json:"p99NetlinkRouteLatency,omitempty"`
+}
+
+type cudnPods struct {
+	cudn string
+	pods []string
+}
+
+type netlinkRoutes struct {
+	// linux doesn't allow adding duplicate routes, so routeTimestamp is not a slice
+	routeTimestamp time.Time
+	pingTimestamps []time.Time
+}
+
+type raLatency struct {
+	measurements.BaseLatencyMeasurement
+
+	metrics            sync.Map
+	latencyQuantiles   []interface{}
+	normLatenciesMutex sync.Mutex
+	normLatencies      []interface{}
+	cudnSubnet         map[string]cudnPods
+	cudnConnTimestamp  sync.Map
+	routeCh            chan netlink.RouteUpdate
+	doneCh             chan struct{}
+	udnclientset       userdefinednetworkclientset.Interface
+	routeImportChan    chan routeImport
+	wg                 sync.WaitGroup
+}
+
+type raLatencyMeasurementFactory struct {
+	measurements.BaseLatencyMeasurementFactory
+}
+
+func NewRaLatencyMeasurementFactory(configSpec config.Spec, measurement types.Measurement, metadata map[string]interface{}) (measurements.MeasurementFactory, error) {
+	return raLatencyMeasurementFactory{
+		measurements.NewBaseLatencyMeasurementFactory(configSpec, measurement, metadata),
+	}, nil
+}
+
+func (plmf raLatencyMeasurementFactory) NewMeasurement(jobConfig *config.Job, clientSet kubernetes.Interface, restConfig *rest.Config) measurements.Measurement {
+	return &raLatency{
+		BaseLatencyMeasurement: plmf.NewBaseLatency(jobConfig, clientSet, restConfig),
+	}
+}
+
+func (r *raLatency) getPods() error {
+	var err error
+	listOptions := metav1.ListOptions{LabelSelector: fmt.Sprintf("kube-burner-uuid=%s", r.Uuid)}
+	nsList, err := r.ClientSet.CoreV1().Namespaces().List(context.TODO(), listOptions)
+	if err != nil {
+		log.Errorf("Error listing namespaces: %v", err)
+		return err
+	}
+	for _, ns := range nsList.Items {
+		podList, err := r.ClientSet.CoreV1().Pods(ns.Name).List(context.TODO(), listOptions)
+		if err != nil {
+			log.Errorf("Error listing pods in %s: %v", ns, err)
+			return err
+		}
+		for _, pod := range podList.Items {
+			podNetworks := make(map[string]podAnnotation)
+			ovnAnnotation, ok := pod.Annotations["k8s.ovn.org/pod-networks"]
+			if ok {
+				if err := json.Unmarshal([]byte(ovnAnnotation), &podNetworks); err != nil {
+					log.Debugf("failed to unmarshal ovn pod annotation  %v", err)
+					continue
+				}
+				for pnet, val := range podNetworks {
+					if pnet != "default" {
+						var udn string
+						parts := strings.Split(pnet, "/")
+						if len(parts) == 2 {
+							_, udn = parts[0], parts[1]
+						} else {
+							log.Debugf("Invalid input format")
+							continue
+						}
+						ipAddr, subnet, err := net.ParseCIDR(val.IP)
+						if err != nil {
+							log.Debugf("Unable to get CIDR for IP")
+							continue
+						}
+						subnetString := subnet.String()
+						ipAddrString := ipAddr.String()
+						cudnpods, exists := r.cudnSubnet[subnetString]
+						if exists {
+							cudnpods.pods = append(cudnpods.pods, ipAddrString)
+							r.cudnSubnet[subnetString] = cudnpods
+						} else {
+							r.cudnSubnet[subnetString] = cudnPods{
+								cudn: udn,
+								pods: []string{ipAddrString},
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (r *raLatency) handleAdd(obj interface{}) {
+	var cudn []string
+	ra := obj.(*routeadvertisementsv1.RouteAdvertisements)
+	listOptions := metav1.ListOptions{}
+	selector, err := metav1.LabelSelectorAsSelector(&ra.Spec.NetworkSelector)
+	if err != nil {
+		log.Errorf("Error parsing Router Advertisement NetworkSelector: %v", err)
+		return
+	}
+	listOptions.LabelSelector = selector.String()
+
+	udns, err := r.udnclientset.K8sV1().ClusterUserDefinedNetworks().List(context.Background(), listOptions)
+	if err != nil {
+		log.Errorf("Error listing udns: %v", err.Error())
+		return
+	}
+	for _, udn := range udns.Items {
+		cudn = append(cudn, udn.Name)
+	}
+	log.Debugf("RA %s created at: %v", ra.Name, time.Now().UTC())
+	r.metrics.LoadOrStore(ra.Name, raMetric{
+		Name:       ra.Name,
+		Timestamp:  ra.CreationTimestamp.Time.UTC(),
+		Latency:    []float64{},
+		cudn:       cudn,
+		MetricName: raLatencyMeasurement,
+		UUID:       r.Uuid,
+		Metadata:   r.Metadata,
+		JobName:    r.JobConfig.Name,
+		Scenario:   "ExportRoutes",
+	})
+}
+
+func pingAddress(srcIP, destIP string, pingerTimeoutMsec int) error {
+	pinger, err := ping.NewPinger(destIP)
+	if err != nil {
+		log.Debugf("Failed to create pinger for %s: %v", destIP, err)
+		return err
+	}
+
+	if srcIP != "" {
+		// Required for raw sockets (root access needed)
+		pinger.SetPrivileged(true)
+		// Bind to the specified source IP
+		pinger.Source = srcIP
+	}
+	pinger.Count = 1
+	pinger.Timeout = time.Duration(pingerTimeoutMsec) * time.Millisecond
+	//pinger.Timeout = 1 * time.Second
+	if err := pinger.Run(); err != nil {
+		log.Debugf("Ping to %s failed: %v", destIP, err)
+		return err
+	}
+	return nil
+}
+
+func pingAllCudns(destCudnPods []string, srcAddr string) []float64 {
+	importLatency := []float64{}
+	var mutex sync.Mutex
+	var wg sync.WaitGroup
+
+	sem := make(chan struct{}, importPingThreads) // Semaphore to limit goroutines
+
+	importTimestamp := time.Now().UTC()
+
+	for _, destCudnPod := range destCudnPods {
+		wg.Add(1)
+		sem <- struct{}{} // Acquire a slot
+
+		go func(destCudnPod string) {
+			defer wg.Done()
+			defer func() { <-sem }() // Release the slot when done
+
+			pingSuccess := false
+			for i := 0; i < pingAttempts; i++ {
+				if err := pingAddress(srcAddr, destCudnPod, importPingerTimeoutMsec); err == nil {
+					latency := float64(time.Since(importTimestamp).Milliseconds())
+
+					mutex.Lock()
+					importLatency = append(importLatency, latency)
+					mutex.Unlock()
+
+					pingSuccess = true
+					break
+				}
+				time.Sleep(importWaitBeforePingRetryMsec * time.Millisecond)
+			}
+
+			if !pingSuccess {
+				mutex.Lock()
+				importLatency = append(importLatency, -1)
+				mutex.Unlock()
+			}
+		}(destCudnPod)
+	}
+
+	wg.Wait() // Wait for all goroutines to finish
+	return importLatency
+}
+
+func (r *raLatency) importWorker() {
+	defer r.wg.Done()
+	for {
+		select {
+		case mc, ok := <-r.routeImportChan:
+			if !ok {
+				return
+			}
+			// Get the netlink.Link object for the given interface name
+			link, err := netlink.LinkByName(mc.link)
+			if err != nil {
+				log.Errorf("Failed to get link %s: %v", mc.link, err)
+			}
+			// Parse IP address
+			addr, err := netlink.ParseAddr(mc.addr)
+			if err != nil {
+				log.Errorf("Failed to parse IP address: %v", err)
+			}
+
+			importTimestamp := time.Now().UTC()
+			// Generate route by adding IP address to the interface
+			if err := netlink.AddrAdd(link, addr); err != nil {
+				log.Errorf("Failed to add IP address: %v", err)
+			}
+			ipAddr, _, err := net.ParseCIDR(mc.addr)
+			if err != nil {
+				log.Errorf("Failed to add IP address: %v", err)
+			}
+			importLatency := pingAllCudns(mc.pods, ipAddr.String())
+
+			latencySummary := metrics.NewLatencySummary(importLatency, mc.addr)
+			log.Tracef("%s: 50th: %d 95th: %d 99th: %d min: %d max: %d avg: %d\n", mc.addr, latencySummary.P50, latencySummary.P95, latencySummary.P99, latencySummary.Min, latencySummary.Max, latencySummary.Avg)
+
+			m := raMetric{
+				Name:            mc.addr,
+				Timestamp:       importTimestamp,
+				MetricName:      raLatencyMeasurement,
+				Latency:         importLatency,
+				MinReadyLatency: int(latencySummary.Min),
+				MaxReadyLatency: int(latencySummary.Max),
+				ReadyLatency:    int(latencySummary.P99),
+				UUID:            r.Uuid,
+				Metadata:        r.Metadata,
+				JobName:         r.JobConfig.Name,
+				Scenario:        "ImportRoutes",
+			}
+			r.metrics.LoadOrStore(mc.addr, m)
+
+		case <-r.doneCh:
+			return
+		}
+	}
+}
+func (r *raLatency) exportWorker() {
+	r.wg.Done()
+	for {
+		select {
+		case update, ok := <-r.routeCh:
+			if !ok {
+				return
+			}
+			if update.Type == unix.RTM_NEWROUTE {
+				cudnpods, exists := r.cudnSubnet[update.Route.Dst.String()]
+				if exists {
+					// linux doesn't allow adding duplicate routes, so new routeTimestamp should be added
+					log.Debugf("Netlink route: %s received for udn: %s at: %v", update.Route.Dst.String(), cudnpods.cudn, time.Now().UTC())
+					val, _ := r.cudnConnTimestamp.LoadOrStore(cudnpods.cudn, netlinkRoutes{
+						routeTimestamp: time.Now().UTC(),
+						pingTimestamps: []time.Time{}})
+					if nlRouteVal, ok := val.(netlinkRoutes); ok {
+						pingSuccess := nlRouteVal.pingTimestamps
+						for _, pod := range cudnpods.pods {
+							for i := 0; i < pingAttempts; i++ {
+								if err := pingAddress("", pod, exportPingerTimeoutMsec); err == nil {
+									log.Debugf("Ping success to pod %s for the Netlink route: %s received for udn: %s at: %v", pod, update.Route.Dst.String(), cudnpods.cudn, time.Now().UTC())
+									pingSuccess = append(pingSuccess, time.Now().UTC())
+									break
+								}
+								time.Sleep(exportWaitBeforePingRetryMsec * time.Millisecond)
+							}
+						}
+						nlRouteVal.pingTimestamps = pingSuccess
+						r.cudnConnTimestamp.Store(cudnpods.cudn, nlRouteVal)
+					}
+				}
+			}
+		case <-r.doneCh:
+			return
+		}
+	}
+}
+
+func (r *raLatency) deleteDummyInterface(i int) error {
+	var err error
+	ifaceName := fmt.Sprintf("dummy%d", i)
+	link, err := netlink.LinkByName(ifaceName)
+	if err != nil {
+		return fmt.Errorf("failed to find interface %s: %v", ifaceName, err)
+	}
+
+	if err := netlink.LinkDel(link); err != nil {
+		return fmt.Errorf("failed to delete interface %s: %v", ifaceName, err)
+	}
+	return err
+}
+
+func (r *raLatency) createDummyInterface(i int) error {
+	var err error
+	// Define the name of the dummy interface
+	ifaceName := fmt.Sprintf("dummy%d", i)
+
+	// Create a dummy link (interface)
+	dummy := &netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: ifaceName,
+		},
+	}
+
+	// Add the dummy interface
+	if err := netlink.LinkAdd(dummy); err != nil {
+		log.Errorf("Failed to add dummy interface: %v", err)
+		return err
+	}
+
+	// Bring the interface up
+	if err := netlink.LinkSetUp(dummy); err != nil {
+		log.Errorf("Failed to bring up interface: %v", err)
+		return err
+	}
+
+	// Verify interface exists
+	_, err = netlink.LinkByName(ifaceName)
+	if err != nil {
+		log.Errorf("Failed to get interface: %v", err)
+	}
+	return err
+}
+
+func (r *raLatency) startImportScenario() error {
+	var err error
+	var i int
+	podsToPingDuingImport := []string{}
+	for _, cpods := range r.cudnSubnet {
+		podsToPingDuingImport = append(podsToPingDuingImport, cpods.pods[0])
+	}
+	if len(podsToPingDuingImport) == 0 {
+		return nil
+	}
+	for i = 0; i < numDummyIfaces; i++ {
+		err = r.createDummyInterface(i)
+		if err != nil {
+			return err
+		}
+	}
+	r.routeImportChan = make(chan routeImport, 2250)
+	for i = 0; i < numAddressOnDummyIface; i++ {
+		for j := 0; j < numDummyIfaces; j++ {
+			mm := routeImport{
+				link: fmt.Sprintf("dummy%d", j),
+				addr: fmt.Sprintf("20.%d.%d.1/24", j, i+1),
+				pods: podsToPingDuingImport,
+			}
+			r.routeImportChan <- mm
+		}
+	}
+	close(r.routeImportChan)
+	// Start import worker goroutines
+	for i = 0; i < importWorkerCount; i++ {
+		r.wg.Add(1)
+		go r.importWorker()
+	}
+	return nil
+}
+func (r *raLatency) startExportScenario() error {
+	var err error
+	r.cudnConnTimestamp = sync.Map{}
+	r.routeCh = make(chan netlink.RouteUpdate, 10000)
+
+	if err = netlink.RouteSubscribe(r.routeCh, r.doneCh); err != nil {
+		log.Errorf("Failed to subscribe to route updates: %v", err)
+		return err
+	}
+
+	// Start export worker goroutines
+	for i := 0; i < exportWorkerCount; i++ {
+		r.wg.Add(1)
+		go r.exportWorker()
+	}
+
+	log.Infof("Creating Router Advertisement latency watcher for %s", r.JobConfig.Name)
+	routeAdvertisementsClientset, err := routeadvertisementsclientset.NewForConfig(r.RestConfig)
+	if err != nil {
+		return err
+	}
+	udnclientset, err := userdefinednetworkclientset.NewForConfig(r.RestConfig)
+	if err != nil {
+		return err
+	}
+	r.udnclientset = udnclientset
+	raFactory := routeadvertisementsinformerfactory.NewSharedInformerFactory(routeAdvertisementsClientset, 30*time.Second)
+	raInformer := raFactory.K8s().V1().RouteAdvertisements().Informer()
+	raInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: r.handleAdd,
+	})
+	raFactory.Start(stopCh)
+	raFactory.WaitForCacheSync(stopCh)
+	return nil
+}
+
+// start raLatency measurement
+func (r *raLatency) Start(measurementWg *sync.WaitGroup) error {
+	// Reset latency slices, required in multi-job benchmarks
+	var err error
+	r.latencyQuantiles, r.normLatencies = nil, nil
+	r.metrics = sync.Map{}
+
+	defer measurementWg.Done()
+
+	if r.JobConfig.SkipIndexing {
+		return nil
+	}
+
+	// channel to notify both import and export workers to exit
+	r.doneCh = make(chan struct{})
+
+	// cudn pods which will be pinged during both import and export scenarios
+	r.cudnSubnet = make(map[string]cudnPods)
+	r.getPods()
+
+	if importScenario {
+		if err = r.startImportScenario(); err != nil {
+			return err
+		}
+	}
+
+	if exportScenario {
+		if err = r.startExportScenario(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *raLatency) Collect(measurementWg *sync.WaitGroup) {
+	defer measurementWg.Done()
+}
+
+// Stop stops raLatency measurement
+func (r *raLatency) Stop() error {
+	if r.JobConfig.SkipIndexing {
+		return nil
+	}
+	var err error
+
+	// stop both import and export workers
+	close(r.doneCh)
+	r.wg.Wait()
+	if importScenario {
+		/*
+			for i := 0; i < numDummyIfaces; i++ {
+				err = r.deleteDummyInterface(i)
+			}
+		*/
+	}
+	r.normalizeMetrics()
+	r.calcQuantiles()
+	if len(r.Config.LatencyThresholds) > 0 {
+		err = metrics.CheckThreshold(r.Config.LatencyThresholds, r.latencyQuantiles)
+	}
+	for _, q := range r.latencyQuantiles {
+		pq := q.(metrics.LatencyQuantiles)
+		log.Infof("%s: %v 99th: %v max: %v avg: %v", r.JobConfig.Name, pq.QuantileName, pq.P99, pq.Max, pq.Avg)
+	}
+	return err
+}
+
+// index sends metrics to the configured indexer
+func (r *raLatency) Index(jobName string, indexerList map[string]indexers.Indexer) {
+	metricMap := map[string][]interface{}{
+		raLatencyMeasurement:          r.normLatencies,
+		raLatencyQuantilesMeasurement: r.latencyQuantiles,
+	}
+	measurements.IndexLatencyMeasurement(r.Config, jobName, metricMap, indexerList)
+}
+
+func (r *raLatency) GetMetrics() *sync.Map {
+	return &r.metrics
+}
+
+func (r *raLatency) normalizeMetrics() bool {
+	r.metrics.Range(func(key, value interface{}) bool {
+		m := value.(raMetric)
+		if m.Scenario == "ExportRoutes" {
+			for _, udn := range m.cudn {
+				val, exists := r.cudnConnTimestamp.Load(udn)
+				if exists {
+					nlRouteVal := val.(netlinkRoutes)
+					for _, ts := range nlRouteVal.pingTimestamps {
+						m.Latency = append(m.Latency, float64(ts.Sub(m.Timestamp).Milliseconds()))
+					}
+					m.NetlinkRouteLatency = append(m.NetlinkRouteLatency, float64(nlRouteVal.routeTimestamp.Sub(m.Timestamp).Milliseconds()))
+				}
+			}
+			latencySummary := metrics.NewLatencySummary(m.Latency, m.Name)
+			log.Tracef("%s: 50th: %d 95th: %d 99th: %d min: %d max: %d avg: %d\n", m.Name, latencySummary.P50, latencySummary.P95, latencySummary.P99, latencySummary.Min, latencySummary.Max, latencySummary.Avg)
+
+			m.MinReadyLatency = int(latencySummary.Min)
+			m.MaxReadyLatency = int(latencySummary.Max)
+			m.ReadyLatency = int(latencySummary.P99)
+
+			nrLatencySummary := metrics.NewLatencySummary(m.NetlinkRouteLatency, m.Name)
+			log.Tracef("%s: 50th: %d 95th: %d 99th: %d min: %d max: %d avg: %d\n", m.Name, nrLatencySummary.P50, nrLatencySummary.P95, nrLatencySummary.P99, nrLatencySummary.Min, nrLatencySummary.Max, nrLatencySummary.Avg)
+
+			m.MinNetlinkRouteLatency = nrLatencySummary.Min
+			m.MaxNetlinkRouteLatency = nrLatencySummary.Max
+			m.P99NetlinkRouteLatency = nrLatencySummary.P99
+		}
+
+		r.normLatencies = append(r.normLatencies, m)
+		return true
+
+	})
+	return true
+}
+
+func (r *raLatency) calcQuantiles() {
+	getLatency := func(normLatency interface{}) map[string]float64 {
+		raMetric := normLatency.(raMetric)
+		return map[string]float64{
+			"MinReadyLatency":        float64(raMetric.MinReadyLatency),
+			"MaxReadyLatency":        float64(raMetric.MaxReadyLatency),
+			"ReadyLatency":           float64(raMetric.ReadyLatency),
+			"MinNetlinkRouteLatency": float64(raMetric.MinNetlinkRouteLatency),
+			"MaxNetlinkRouteLatency": float64(raMetric.MaxNetlinkRouteLatency),
+			"P99NetlinkRouteLatency": float64(raMetric.P99NetlinkRouteLatency),
+		}
+	}
+	r.latencyQuantiles = measurements.CalculateQuantiles(r.Uuid, r.JobConfig.Name, r.Metadata, r.normLatencies, getLatency, raLatencyQuantilesMeasurement)
+}

--- a/udn-bgp.go
+++ b/udn-bgp.go
@@ -1,0 +1,54 @@
+// Copyright 2022 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocp
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/kube-burner/kube-burner/pkg/workloads"
+	"github.com/spf13/cobra"
+)
+
+// NewUdnBgp holds network-policy workload
+func NewUdnBgp(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
+	var iterations, namespacePerCudn int
+	var scenario string
+	var metricsProfiles []string
+	var rc int
+	cmd := &cobra.Command{
+		Use:   variant,
+		Short: fmt.Sprintf("Runs %v workload", variant),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			os.Setenv("JOB_ITERATIONS", fmt.Sprint(iterations))
+			os.Setenv("SCENARIO", scenario)
+			os.Setenv("NAMESPACES_PER_CUDN", fmt.Sprint(namespacePerCudn))
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			setMetrics(cmd, metricsProfiles)
+			//rc = wh.Run(cmd.Name())
+			rc = wh.RunWithAdditionalVars(cmd.Name(), nil, measurementFactoryMap)
+		},
+		PostRun: func(cmd *cobra.Command, args []string) {
+			os.Exit(rc)
+		},
+	}
+	cmd.Flags().IntVar(&iterations, "iterations", 10, fmt.Sprintf("%v iterations", variant))
+	cmd.Flags().IntVar(&namespacePerCudn, "namespaces-per-cudn", 2, "Number of namespaces sharing the same cluster udn")
+	cmd.Flags().StringVar(&scenario, "scenario", "export", "export or import routes scenarios")
+	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics-aggregated.yml"}, "Comma separated list of metrics profiles to use")
+	cmd.MarkFlagRequired("iterations")
+	return cmd
+}

--- a/virt-capacity-benchmark.go
+++ b/virt-capacity-benchmark.go
@@ -125,7 +125,7 @@ func NewVirtCapacityBenchmark(wh *workloads.WorkloadHelper) *cobra.Command {
 			counter := 0
 			for {
 				os.Setenv("counter", fmt.Sprint(counter))
-				rc = wh.RunWithAdditionalVars(cmd.Name(), additionalVars)
+				rc = wh.RunWithAdditionalVars(cmd.Name(), additionalVars, nil)
 				if rc != 0 {
 					log.Infof("Capacity failed in loop #%d", counter)
 					break

--- a/virt-clone.go
+++ b/virt-clone.go
@@ -107,7 +107,7 @@ func NewVirtClone(wh *workloads.WorkloadHelper) *cobra.Command {
 			}
 
 			setMetrics(cmd, metricsProfiles)
-			rc = wh.RunWithAdditionalVars(cmd.Name(), additionalVars)
+			rc = wh.RunWithAdditionalVars(cmd.Name(), additionalVars, nil)
 		},
 		PostRun: func(cmd *cobra.Command, args []string) {
 			os.Exit(rc)


### PR DESCRIPTION
Both BGP workload and RouteAdvertisement latency measurement inside kube-burner-ocp.

Run the command like below
    bin/amd64/kube-burner-ocp udn-bgp --scenario export --namespaces-per-cudn 1 \
     --iterations 1 --check-health=false --es-server=<es-server> \
     --es-index=<index> --profile-type=regular --log-level=debug --local-indexing

