### PR TITLE
CI - Restore tmp in PATH to allow access to virtctl

### DIFF
--- a/.github/workflows/test-ocp.yml
+++ b/.github/workflows/test-ocp.yml
@@ -56,6 +56,7 @@ jobs:
 
     - name: Execute Tests
       run: |
+        export PATH=${PATH}:/tmp/
         chmod +x /tmp/kube-burner-ocp
         make test-ocp
       env:


### PR DESCRIPTION
## Type of change

- Bug fix
- CI

## Description

virtctl is downloaded to /tmp so it must be in the PATH

