### PR TITLE
Remove duplicated field "env"

### DIFF
--- a/cmd/config/cluster-density-v2/deployment-client.yml
+++ b/cmd/config/cluster-density-v2/deployment-client.yml
@@ -14,10 +14,10 @@ spec:
         app: client
     spec:
       topologySpreadConstraints:
-      - maxSkew: 1 
+      - maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway 
-        labelSelector: 
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
           matchLabels:
             app: client
       affinity:
@@ -39,7 +39,6 @@ spec:
           requests:
             memory: "10Mi"
             cpu: "10m"
-        env:
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: false
@@ -118,4 +117,3 @@ spec:
       restartPolicy: Always
   strategy:
     type: RollingUpdate
-

--- a/cmd/config/rds-core/deployment-client.yml
+++ b/cmd/config/rds-core/deployment-client.yml
@@ -39,7 +39,6 @@ spec:
           requests:
             memory: "10Mi"
             cpu: "10m"
-        env:
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: false
@@ -118,4 +117,3 @@ spec:
       restartPolicy: Always
   strategy:
     type: RollingUpdate
-


### PR DESCRIPTION
## Type of change

- Refactor

## Description

Remove an extra ignored "env" field to keep manifests clean. Editor automatically removes unnecessary whitespace as well.

## Related Tickets & Documents

No related ticket, just noticed while testing and extracting workloads from kube-burner-ocp


