### PR TITLE
Replace `kube_deployment_labels` and `kube_replicaset_labels` with `k…

### DIFF
--- a/cmd/config/metrics-aggregated.yml
+++ b/cmd/config/metrics-aggregated.yml
@@ -95,7 +95,7 @@
   metricName: secretCount
   instant: true
 
-- query: count(kube_deployment_labels{})
+- query: count(kube_deployment_spec_replicas{})
   metricName: deploymentCount
   instant: true
 
@@ -117,7 +117,7 @@
 - query: sum(kube_node_status_condition{status="true"}) by (condition)
   metricName: nodeStatus
 
-- query: count(kube_replicaset_labels{})
+- query: count(kube_replicaset_spec_replicas{})
   metricName: replicaSetCount
   instant: true
 

--- a/cmd/config/metrics-egressip.yml
+++ b/cmd/config/metrics-egressip.yml
@@ -7,7 +7,7 @@
   metricName: eipRecoveryLatencyTotal
   instant: true
 
-- query: scale_startup_non_eip_total{}>0 
+- query: scale_startup_non_eip_total{}>0
   metricName: startupEipNodeIPReqCount
   instant: true
 
@@ -107,7 +107,7 @@
   metricName: secretCount
   instant: true
 
-- query: count(kube_deployment_labels{})
+- query: count(kube_deployment_spec_replicas{})
   metricName: deploymentCount
   instant: true
 
@@ -129,7 +129,7 @@
 - query: sum(kube_node_status_condition{status="true"}) by (condition)
   metricName: nodeStatus
 
-- query: count(kube_replicaset_labels{})
+- query: count(kube_replicaset_spec_replicas{})
   metricName: replicaSetCount
   instant: true
 

--- a/cmd/config/metrics.yml
+++ b/cmd/config/metrics.yml
@@ -92,7 +92,7 @@
   metricName: secretCount
   instant: true
 
-- query: count(kube_deployment_labels{})
+- query: count(kube_deployment_spec_replicas{})
   metricName: deploymentCount
   instant: true
 
@@ -114,7 +114,7 @@
 - query: sum(kube_node_status_condition{status="true"}) by (condition)
   metricName: nodeStatus
 
-- query: count(kube_replicaset_labels{})
+- query: count(kube_replicaset_spec_replicas{})
   metricName: replicaSetCount
   instant: true
 


### PR DESCRIPTION
…ube_deployment_spec_replicas` and `kube_replicaset_spec_replicas`

## Type of change

- Bug fix

## Description

Fix prometheus queries for deployment and replicaset counts


