### PR TITLE
Add test for DV Cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,11 +555,11 @@ By default, the namespace is `virt-ephemeral-restart`. Set it by passing `--name
 
 Users may control the workload sizes by passing the following arguments:
 - `--iteration-vms` - Number of `VirtualMachines` to batch in each group in step 6
-- `--iteration-vms` - Number of batches to run in step 6
+- `--iteration` - Number of batches to run in step 6
 
 !!! Note
 
-    The total number of `VirtualMachines` created is `--iteration-vms` * `--iteration-vms`
+    The total number of `VirtualMachines` created is `--iteration-vms` * `--iteration`
 
 #### Volume Access Mode
 
@@ -571,6 +571,49 @@ If not supported, the access mode may be changes by setting `--access-mode`. The
 In order to verify that the VMs actually completed booting, the test generates an SSH key pair.
 By default, it stores the pair in a temporary directory.
 Users may choose the store the key in a specified directory by setting `--ssh-key-path`
+
+### DataVolume Clone
+
+Test the capacity and performance of creating multiple data volumes that are clones of a single data volume
+
+#### Test Sequence
+
+The test runs the following sequence:
+1. Create a `DataVolume` based on a container disk image
+2. If the `dataImportCronSourceFormat` field of the `StorageProfile` `status` is set to `snapshot`, or `--use-snapshot` is set to `true`, create a `VolumeSnapshot` of the DataVolume
+3. Create a `DataSource`, setting the `source` field to either the `VolumeSnapshot` (if was created) or the `DataVolume`
+4. Create `DataVolumes` based on the `DataSource`. The creation process is divided into iterations
+
+#### Tested StorageClass
+
+By default, the test will use the default `StorageClass`. To use a different one, use `--storage-class` to provide a different name.
+
+If `--use-snapshot` is explicitly set to `true` a corresponding `VolumeSnapshotClass` using the same provisioner must exist.
+Otherwise, the test will check the `StorageProfile` for the `StorageClass` and act accordingly.
+
+#### Test Namespace
+
+All the resources are created in the same namespace.
+
+By default, the namespace is `dv-clone`. Set it by passing `--namespace` (or `-n`)
+
+#### Test Container Disk Image
+
+Users may set the container disk image used as a source to the base `DataVolume` using the `--container-disk` parameter.
+When setting `--container-disk`, make sure that it can fit to the default Volume Size `1Gi` or set a new size by passing `--datavolume-size`.
+
+If not passed, the test will use  `quay.io/yblum/tiny_image:latest` for the the container disk image.
+
+#### Test Size Parameters
+
+Users may control the workload sizes by passing the following arguments:
+- `--iteration` - Number of iterations to run in step 4
+- `--iteration-clones` - Number of `DataVolumes` to create in each iteration of step 4
+
+#### Volume Access Mode
+
+By default, volumes are created with `ReadWriteMany` access mode as this is the recommended configuration for `VirtualMachines`.
+If not supported, the access mode may be changes by setting `--access-mode`. The supported values are `RO`, `RWO` and `RWX`.
 
 ## CUDN BGP Workload
 

--- a/cmd/config/dv-clone/dv-clone.yml
+++ b/cmd/config/dv-clone/dv-clone.yml
@@ -1,0 +1,137 @@
+{{- $testNamespacesLabelKey := "kube-burner.io/test-name" -}}
+{{- $testNamespacesLabelValue := "dv-clone" -}}
+
+{{- $baseDataVolumeName := "master-image" -}}
+{{- $baseVolumeSnapshotName := "master-image" -}}
+{{- $baseDataSourceName := "master-image" -}}
+{{- $cloneDataVolumeName := "clone-image" -}}
+
+global:
+  measurements:
+  - name: dataVolumeLatency
+
+metricsEndpoints:
+- indexer:
+    type: local
+    metricsDirectory: ./dv-clone-results
+
+jobs:
+- name: start-fresh
+  jobType: delete
+  waitForDeletion: true
+  qps: 5
+  burst: 10
+  objects:
+  - kind: Namespace
+    labelSelector:
+      {{ $testNamespacesLabelKey }}: {{ $testNamespacesLabelValue }}
+
+# Create the DV in a separate job to make sure it is ready before continuing
+- name: create-base-image-dv
+  jobType: create
+  jobIterations: 1
+  qps: 20
+  burst: 20
+  namespacedIterations: false
+  namespace: {{ .testNamespace }}
+  namespaceLabels:
+    {{ $testNamespacesLabelKey }}: {{ $testNamespacesLabelValue }}
+  # verify object count after running each job
+  verifyObjects: true
+  errorOnVerify: true
+  waitWhenFinished: false
+  podWait: true
+  maxWaitTimeout: 15m
+  # wait before job completes to allow metrics collection
+  jobPause: 10s
+  # Do not clean the namespaces
+  cleanup: false
+  # Set missing key as empty to allow using default values
+  defaultMissingKeysWithZero: true
+  objects:
+  - objectTemplate: templates/baseImageDataVolume.yml
+    replicas: 1
+    inputVars:
+      baseDataVolumeName: {{ $baseDataVolumeName }}
+      storageClassName: {{ .storageClassName }}
+      accessMode: {{ .accessMode }}
+      imageUrl: "docker://{{ .containerDiskUrl }}"
+      baseDataVolumeSize: {{ .dataVolumeSize }}
+
+- name: create-data-source
+  jobType: create
+  jobIterations: 1
+  qps: 20
+  burst: 20
+  namespacedIterations: false
+  namespace: {{ .testNamespace }}
+  namespaceLabels:
+    {{ $testNamespacesLabelKey }}: {{ $testNamespacesLabelValue }}
+  # verify object count after running each job
+  verifyObjects: true
+  errorOnVerify: true
+  # wait all VMI be in the Ready Condition
+  waitWhenFinished: false
+  podWait: true
+  # timeout time after waiting for all object creation
+  maxWaitTimeout: 15m
+  # wait before job completes to allow metrics collection
+  jobPause: 10s
+  # Do not clean the namespaces
+  cleanup: false
+  # Set missing key as empty to allow using default values
+  defaultMissingKeysWithZero: true
+  objects:
+  {{ if .volumeSnapshotClassName | default false }}
+  - objectTemplate: templates/baseImageDataVolumeSnapshot.yml
+    replicas: 1
+    inputVars:
+      baseVolumeSnapshotName: {{ $baseVolumeSnapshotName }}
+      volumeSnapshotClassName: {{ .volumeSnapshotClassName }}
+      baseVolumeSnapshotPVCName: {{ $baseDataVolumeName }}
+  {{ end }}
+  - objectTemplate: templates/baseImageDataSource.yml
+    replicas: 1
+    inputVars:
+      baseDataSourceName: {{ $baseDataSourceName }}
+      namespace: {{ .testNamespace }}
+      baseDataSourcePVCName: {{ $baseDataVolumeName }}
+      baseDataSourceSnapshotName: {{ $baseVolumeSnapshotName }}
+      useSnapshot: {{ .volumeSnapshotClassName | default false }}
+    waitOptions:
+      customStatusPaths:
+      - key: '(.conditions.[] | select(.type == "Ready")).status'
+        value: "True"
+
+# Create the DV in a separate job to make sure it is ready before continuing
+- name: create-clone-dvs
+  jobType: create
+  jobIterations: {{ .iterations }}
+  qps: 20
+  burst: 20
+  namespacedIterations: false
+  namespace: {{ .testNamespace }}
+  namespaceLabels:
+    {{ $testNamespacesLabelKey }}: {{ $testNamespacesLabelValue }}
+  # verify object count after running each job
+  verifyObjects: true
+  errorOnVerify: true
+  waitWhenFinished: false
+  podWait: true
+  maxWaitTimeout: 2h
+  # wait before job completes to allow metrics collection
+  jobPause: 10s
+  # Do not clean the namespaces
+  cleanup: false
+  # Set missing key as empty to allow using default values
+  defaultMissingKeysWithZero: true
+  objects:
+  - objectTemplate: templates/cloneImageDataVolume.yml
+    replicas: {{ .clonesPerIteration }}
+    inputVars:
+      dataVolumeName: {{ $cloneDataVolumeName }}
+      storageClassName: {{ .storageClassName }}
+      accessMode: {{ .accessMode }}
+      dataSourceName: {{ $baseDataSourceName }}
+      dataSourceNamespace: {{ .testNamespace }}
+      dataVolumeSize: {{ .dataVolumeSize }}

--- a/cmd/config/dv-clone/templates/baseImageDataSource.yml
+++ b/cmd/config/dv-clone/templates/baseImageDataSource.yml
@@ -1,0 +1,15 @@
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataSource
+metadata:
+  name: {{ .baseDataSourceName }}
+spec:
+  source:
+    {{ if .useSnapshot }}
+    snapshot:
+      name: {{ .baseDataSourceSnapshotName }}
+      namespace: {{ .namespace }}
+    {{ else }}
+    pvc:
+      name: {{ .baseDataSourcePVCName }}
+      namespace: {{ .namespace }}
+    {{ end }}

--- a/cmd/config/dv-clone/templates/baseImageDataVolume.yml
+++ b/cmd/config/dv-clone/templates/baseImageDataVolume.yml
@@ -1,0 +1,19 @@
+---
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: {{ .baseDataVolumeName }}
+  annotations:
+    cdi.kubevirt.io/storage.bind.immediate.requested: "true"
+spec:
+  source:
+    registry:
+      url: {{ .imageUrl }}
+  storage:
+    accessModes:
+    - {{ .accessMode }}
+    resources:
+      requests:
+        storage: {{ .baseDataVolumeSize }}
+    storageClassName: {{ .storageClassName }}
+...

--- a/cmd/config/dv-clone/templates/baseImageDataVolumeSnapshot.yml
+++ b/cmd/config/dv-clone/templates/baseImageDataVolumeSnapshot.yml
@@ -1,0 +1,8 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: {{ .baseVolumeSnapshotName }}
+spec:
+  volumeSnapshotClassName: {{ .volumeSnapshotClassName }}
+  source:
+    persistentVolumeClaimName: {{ .baseVolumeSnapshotPVCName }}

--- a/cmd/config/dv-clone/templates/cloneImageDataVolume.yml
+++ b/cmd/config/dv-clone/templates/cloneImageDataVolume.yml
@@ -1,0 +1,20 @@
+---
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: "{{ .dataVolumeName }}-{{ .Iteration }}-{{ .Replica }}"
+  annotations:
+    cdi.kubevirt.io/storage.bind.immediate.requested: "true"
+spec:
+  sourceRef:
+    kind: DataSource
+    name: {{ .dataSourceName }}
+    namespace: {{ .dataSourceNamespace }}
+  storage:
+    accessModes:
+    - {{ .accessMode }}
+    resources:
+      requests:
+        storage: {{ .dataVolumeSize }}
+    storageClassName: {{ .storageClassName }}
+...

--- a/cmd/ocp.go
+++ b/cmd/ocp.go
@@ -133,6 +133,7 @@ func openShiftCmd() *cobra.Command {
 		ocp.NewVirtCapacityBenchmark(&wh),
 		ocp.NewVirtClone(&wh),
 		ocp.NewVirtEphemeralRestart(&wh),
+		ocp.NewDVClone(&wh),
 	)
 	util.SetupCmd(ocpCmd)
 	return ocpCmd

--- a/dv-clone.go
+++ b/dv-clone.go
@@ -1,0 +1,95 @@
+// Copyright 2025 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocp
+
+import (
+	"os"
+
+	"github.com/kube-burner/kube-burner/pkg/workloads"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	dvCloneTestName                = "dv-clone"
+	dvCloneDefaultContainerDiskUrl = "quay.io/kube-burner/tiny_image:latest"
+	dvCloneDefaultDataVolumeSize   = "1Gi"
+)
+
+// Returns virt-density workload
+func NewDVClone(wh *workloads.WorkloadHelper) *cobra.Command {
+	var storageClassName string
+	var volumeSnapshotClassName string
+	var useSnapshot bool
+	var testNamespace string
+	var containerDiskUrl string
+	var dataVolumeSize string
+	var iterations int
+	var clonesPerIteration int
+	var metricsProfiles []string
+	var volumeAccessMode string
+	var rc int
+	cmd := &cobra.Command{
+		Use:          dvCloneTestName,
+		Short:        "Runs dv-clone workload",
+		SilenceUsage: true,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			if _, ok := accessModeTranslator[volumeAccessMode]; !ok {
+				log.Fatalf("Unsupported access mode - %s", volumeAccessMode)
+			}
+
+			storageClassName, volumeSnapshotClassName = getStorageAndSnapshotClasses(storageClassName, useSnapshot, cmd.Flags().Lookup("use-snapshot").Changed)
+
+			if cmd.Flags().Lookup("container-disk").Changed && !cmd.Flags().Lookup("datavolume-size").Changed {
+				log.Warnf("--container-disk was set without setting --datavolume-size. Make sure the default size [%v] is sufficient", dataVolumeSize)
+			}
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+
+			log.Infof("All resources will be create in the namespace [%s]", testNamespace)
+			log.Infof("Using [%s] as the container disk image for the base DataVolume", containerDiskUrl)
+			log.Infof("DataVolume size set to [%v]", dataVolumeSize)
+			log.Infof("Clone DataVolumes will be created in [%v] iterations of [%v] each", iterations, clonesPerIteration)
+
+			additionalVars := map[string]any{
+				"storageClassName":        storageClassName,
+				"volumeSnapshotClassName": volumeSnapshotClassName,
+				"testNamespace":           testNamespace,
+				"containerDiskUrl":        containerDiskUrl,
+				"dataVolumeSize":          dataVolumeSize,
+				"accessMode":              accessModeTranslator[volumeAccessMode],
+				"iterations":              iterations,
+				"clonesPerIteration":      clonesPerIteration,
+			}
+
+			setMetrics(cmd, metricsProfiles)
+			rc = wh.RunWithAdditionalVars(cmd.Name(), additionalVars, nil)
+		},
+		PostRun: func(cmd *cobra.Command, args []string) {
+			os.Exit(rc)
+		},
+	}
+	cmd.Flags().StringVar(&storageClassName, "storage-class", "", "Name of the Storage Class to test")
+	cmd.Flags().BoolVar(&useSnapshot, "use-snapshot", true, "Clone from snapshot")
+	cmd.Flags().IntVar(&iterations, "iterations", 2, "Number of iterations to create DataVolume clones . The total number of DataVolumes is iterations*iteration-clones")
+	cmd.Flags().IntVar(&clonesPerIteration, "iteration-clones", 10, "How many DataVolumes to create per iteration. The total number of DataVolumes is iterations*iteration-clones")
+	cmd.Flags().StringVarP(&testNamespace, "namespace", "n", dvCloneTestName, "Name for the namespace to run the test in")
+	cmd.Flags().StringVar(&volumeAccessMode, "access-mode", "RWX", "Access mode for the created volumes - RO, RWO, RWX")
+	cmd.Flags().StringVar(&containerDiskUrl, "container-disk", dvCloneDefaultContainerDiskUrl, "URL of the container disk to load into the volume")
+	cmd.Flags().StringVar(&dataVolumeSize, "datavolume-size", dvCloneDefaultDataVolumeSize, "Size of the DataVolume to create")
+	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
+	return cmd
+}


### PR DESCRIPTION
## Type of change

- New feature

## Description

Add a new test for creating many DataVolume clones of a single DataVolume.
This test should be used by Storage Vendors to test the limits of their storage as this is a basic flow in creating VirtualMachines from golden images
