### PR TITLE
use RA API v2

### DIFF
--- a/cmd/config/udn-bgp/cudn.yml
+++ b/cmd/config/udn-bgp/cudn.yml
@@ -18,7 +18,7 @@ spec:
     - key: kubernetes.io/metadata.name
       operator: In
       values: {{$nsNames}}
-  {{- $firstOctet := add (div $.Iteration 255) 10 }}
+  {{- $firstOctet := add (div $.Iteration 255) 40 }}
   {{- $secondOctet := mod $.Iteration 255 }}
   {{- $cudnCidr := print $firstOctet "." $secondOctet ".0.0/16" }}
   network:

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/kube-burner/kube-burner v1.16.0
 	github.com/openshift/api v0.0.0-20240527133614-ba11c1587003
 	github.com/openshift/client-go v0.0.0-20240821135114-75c118605d5f
-	github.com/ovn-org/ovn-kubernetes/go-controller v0.0.0-20250307193230-744ecedf57b6
 	github.com/praserx/ipconv v1.2.1
 	github.com/prometheus-community/pro-bing v0.7.0
 	github.com/sirupsen/logrus v1.9.3

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.3.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
+	github.com/cloud-bulldozer/go-commons v1.0.19 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/elastic/go-elasticsearch/v7 v7.13.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.3.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
-	github.com/cloud-bulldozer/go-commons v1.0.19 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/elastic/go-elasticsearch/v7 v7.13.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,6 @@ github.com/chzyer/readline v1.5.1/go.mod h1:Eh+b79XXUwfKfcPLepksvw2tcLE/Ct21YObk
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloud-bulldozer/go-commons v1.0.19 h1:WVkKb5uTyxFmrsRqZKU4RT7BBhjystpdSgm7VPpJSlw=
-github.com/cloud-bulldozer/go-commons v1.0.19/go.mod h1:CKmdWhyxN6p4leLhdwKxQHJ3wiKNUistFKsctLTSqIk=
 github.com/cloud-bulldozer/go-commons/v2 v2.1.1 h1:rmLXPG7o2SbJjJWWHDnz7QmntpGs7kRiaxG9SLJS3L4=
 github.com/cloud-bulldozer/go-commons/v2 v2.1.1/go.mod h1:aNO6P9yANMO8x7Q+7D9uErmIEpAT4o8RLM8n8kMTlRA=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=

--- a/go.sum
+++ b/go.sum
@@ -336,8 +336,6 @@ github.com/openshift/client-go v0.0.0-20240821135114-75c118605d5f/go.mod h1:3IPD
 github.com/openshift/custom-resource-status v1.1.2 h1:C3DL44LEbvlbItfd8mT5jWrqPfHnSOQoQf/sypqA6A4=
 github.com/openshift/custom-resource-status v1.1.2/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
-github.com/ovn-org/ovn-kubernetes/go-controller v0.0.0-20250307193230-744ecedf57b6 h1:Cg31qvTFv1mXy5zzph3wW+p2QUU0nisvUT7yxsVLzMc=
-github.com/ovn-org/ovn-kubernetes/go-controller v0.0.0-20250307193230-744ecedf57b6/go.mod h1:MzFM3OEsLM2w/4MBMOCsxGR6ZBUvJfOxvQHB8LIKSv4=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/chzyer/readline v1.5.1/go.mod h1:Eh+b79XXUwfKfcPLepksvw2tcLE/Ct21YObk
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cloud-bulldozer/go-commons v1.0.19 h1:WVkKb5uTyxFmrsRqZKU4RT7BBhjystpdSgm7VPpJSlw=
+github.com/cloud-bulldozer/go-commons v1.0.19/go.mod h1:CKmdWhyxN6p4leLhdwKxQHJ3wiKNUistFKsctLTSqIk=
 github.com/cloud-bulldozer/go-commons/v2 v2.1.1 h1:rmLXPG7o2SbJjJWWHDnz7QmntpGs7kRiaxG9SLJS3L4=
 github.com/cloud-bulldozer/go-commons/v2 v2.1.1/go.mod h1:aNO6P9yANMO8x7Q+7D9uErmIEpAT4o8RLM8n8kMTlRA=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=

--- a/udn-bgp.go
+++ b/udn-bgp.go
@@ -51,7 +51,7 @@ func NewUdnBgp(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 	}
 	cmd.Flags().IntVar(&iterations, "iterations", 10, fmt.Sprintf("%v iterations", variant))
 	cmd.Flags().IntVar(&namespacePerCudn, "namespaces-per-cudn", 1, "Number of namespaces sharing the same cluster udn")
-	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics-aggregated.yml"}, "Comma separated list of metrics profiles to use")
+	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
 	cmd.MarkFlagRequired("iterations")
 	return cmd
 }


### PR DESCRIPTION
routeadvertisement API changed which introduced new fields in networkSelectors. Instead of using ovnk's UDN and RA clientsets, we are now using dynamic client and informers with GVR to watch and fetch UDN and RA.

We will use metrics.yml instead of metrics-aggregated.yml, similar to other UDN workload.

CUDN will be using 40.X.X.X CIDR instead of 10.X.X.X to make BGP route exchange work with AWS cluster.

