### PR TITLE
Preload vm images

### DIFF
--- a/cmd/config/virt-density/virt-density.yml
+++ b/cmd/config/virt-density/virt-density.yml
@@ -32,7 +32,7 @@ jobs:
     qps: {{.QPS}}
     burst: {{.BURST}}
     namespacedIterations: false
-    preLoadImages: false
+    preLoadImages: true
     waitWhenFinished: true
     namespaceLabels:
       security.openshift.io/scc.podSecurityLabelSync: false

--- a/cmd/config/virt-udn-density/virt-udn-density.yml
+++ b/cmd/config/virt-udn-density/virt-udn-density.yml
@@ -38,7 +38,7 @@ jobs:
     namespacedIterations: true
     podWait: false
     waitWhenFinished: true
-    preLoadImages: false
+    preLoadImages: true
     preLoadPeriod: 15s
     churn: {{.CHURN}}
     churnCycles: {{.CHURN_CYCLES}}


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->

- Bug fix

## Description

For some reason I don't recall now image preload was disabled on these workloads.

## Related Tickets & Documents

- Related Issue #
- Closes #

