### PR TITLE
add metrics of cpu and memory usage 5-min average for ovs-vswitchd

### DIFF
--- a/cmd/config/metrics.yml
+++ b/cmd/config/metrics.yml
@@ -187,3 +187,14 @@
 
 - query: rate ( node_vmstat_pgmajfault[1m] )
   metricName: nodeMajorFaults
+
+# OVS 5m CPU usage average
+- query: avg by (instance) (rate(container_cpu_usage_seconds_total{id=~"/system.slice/ovs-vswitchd.service"}[5m])) * 100
+  metricName: ovsCPUUsagePercent
+  instant: true
+  captureStart: true
+
+# OVS 5m Memory usage average
+- query: avg_over_time(container_memory_usage_bytes{id=~"/system.slice/ovs-vswitchd.service"}[5m])
+  metricName: ovsMemory
+  instant: true

--- a/cmd/config/metrics.yml
+++ b/cmd/config/metrics.yml
@@ -188,13 +188,10 @@
 - query: rate ( node_vmstat_pgmajfault[1m] )
   metricName: nodeMajorFaults
 
-# OVS 5m CPU usage average
-- query: avg by (instance) (rate(container_cpu_usage_seconds_total{id=~"/system.slice/ovs-vswitchd.service"}[5m])) * 100
-  metricName: ovsCPUUsagePercent
-  instant: true
-  captureStart: true
+# OVS 2m CPU usage average
+- query: sum (  irate( container_cpu_usage_seconds_total {  id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice" }[2m])  )  by   (   id , instance )
+  metricName: cgroupOVSCPUUsagePercent
 
 # OVS 5m Memory usage average
-- query: avg_over_time(container_memory_usage_bytes{id=~"/system.slice/ovs-vswitchd.service"}[5m])
+- query: sum(process_resident_memory_bytes{job="ovs-vswitchd"}) by (node)
   metricName: ovsMemory
-  instant: true


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->


- New feature


## Description

<!--- Describe your changes in detail -->

Add new metrics of 5-min average CPU and Memory of ovs-vswitchd

## Related Tickets & Documents

- Related Issue: https://issues.redhat.com/browse/CORENET-6058
- Closes #

I tested URL encoded version of my two queries, results are logged here:
https://privatebin.corp.redhat.com/?6ab4f88ded99ee90#Dt9uwqpeMHYFrG2X47KzMJHQq7T7AytyMDkxzcZjJ32R


/assign @mohit-sheth 
/assign @jtaleric 
/assign @jluhrsen

Can you help review the PR?
This is my first time learning to do this, not sure if my format is correct and if I invited right parts to review, feel free to include right reviewers for this, thanks a lot!

