### PR TITLE
Virt Migration - add option for creating additional VMs for load

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = go.mod,go.sum
-ignore-words-list = passt
+ignore-words-list = passt, NotIn

--- a/README.md
+++ b/README.md
@@ -604,7 +604,20 @@ Users may control the workload sizes by passing the following arguments:
 
 !!! Note
 
-    The total number of `VirtualMachines` created is `--iteration` * `--iteration-vms`
+    The total number of `VirtualMachines` created is `--iterations` * `--iteration-vms`
+
+#### Addition `VirtualMachines` load
+
+The test can create additional `VirtualMachines` that will not be migrated to simulate load on the other nodes as well.
+By default, no additional `VirtualMachines` are created.
+
+Set the following arguments to create load `VirtualMachines`:
+- `--load-iterations` - Number of iterations to create load VMs
+- `--load-per-iteration` - Number of VMs to create in each load VM iteration
+
+!!! Note
+
+    The total number of load `VirtualMachines` created is `--load-vms-iterations` * `--iteration-load-vms`
 
 #### Initial Worker Node
 

--- a/cmd/config/virt-migration/virt-migration.yml
+++ b/cmd/config/virt-migration/virt-migration.yml
@@ -3,6 +3,7 @@
 {{- $vmName := $testName -}}
 {{- $sshPublicKeySecretName := $testName -}}
 {{- $createMigratingVMsJobName := "create-migrating-vms" -}}
+{{- $createLoadVMsJobName := "create-load-vms" -}}
 ---
 global:
   measurements:
@@ -68,6 +69,46 @@ jobs:
       {{ end }}
       affinity: "In"
       workerNodeName: {{ .workerNodeName }}
+
+{{- if gt .loadVMsPerIteration 0 }}
+- name: {{ $createLoadVMsJobName }}
+  jobType: create
+  jobIterations: {{ .loadVMsIterations }}
+  qps: 20
+  burst: 20
+  namespacedIterations: false
+  namespace: {{ .testNamespace }}
+  namespaceLabels:
+    {{ $testNamespacesLabelKey }}: {{ $testName }}
+  # verify object count after running each job
+  verifyObjects: true
+  errorOnVerify: true
+  # wait all VMI be in the Ready Condition
+  waitWhenFinished: false
+  podWait: true
+  # timeout time after waiting for all object creation
+  maxWaitTimeout: 2h
+  jobPause: 10s
+  cleanup: false
+  # Set missing key as empty to allow using default values
+  defaultMissingKeysWithZero: true
+  beforeCleanup: "./check.sh check_vm_running kube-burner-job {{ $createLoadVMsJobName }} {{ .testNamespace }} {{ .privateKey }} fedora"
+  objects:
+
+  - objectTemplate: templates/vm.yml
+    replicas: {{ .loadVMsPerIteration }}
+    inputVars:
+      name: {{ $vmName }}-load
+      rootDiskImage: quay.io/containerdisks/fedora:41
+      storageClassName: {{ .storageClassName }}
+      sshPublicKeySecret: {{ $sshPublicKeySecretName }}
+      dataVolumeCounters:
+      {{ range .dataVolumeCounters }}
+      - {{ . }}
+      {{ end }}
+      affinity: "NotIn"
+      workerNodeName: {{ .workerNodeName }}
+{{- end }}
 
 - name: remove-affinity-rule
   jobType: patch

--- a/virt-migration.go
+++ b/virt-migration.go
@@ -31,9 +31,11 @@ const (
 	virtMigrationTmpDirPattern  = "kube-burner-virt-migration-*"
 	virtMigrationTestName       = "virt-migration"
 	// Defaults
-	virtMigrationDefaultDataVolumeCount = 1
-	virtMigrationDefaultVMsPerIteration = 10
-	virtMigrationDefaultIteration       = 2
+	virtMigrationDefaultDataVolumeCount     = 1
+	virtMigrationDefaultVMsPerIteration     = 10
+	virtMigrationDefaultIteration           = 2
+	virtMigrationDefaultLoadVMsIteration    = 0
+	virtMigrationDefaultLoadVMsPerIteration = 0
 )
 
 // Returns virt-density workload
@@ -46,6 +48,8 @@ func NewVirtMigration(wh *workloads.WorkloadHelper) *cobra.Command {
 	var dataVolumeCount int
 	var workerNodeName string
 	var metricsProfiles []string
+	var loadVMsIterations int
+	var loadVMsPerIteration int
 
 	var rc int
 	cmd := &cobra.Command{
@@ -77,6 +81,8 @@ func NewVirtMigration(wh *workloads.WorkloadHelper) *cobra.Command {
 				"vmCreatePerIteration": vmsPerIteration,
 				"dataVolumeCounters":   generateLoopCounterSlice(dataVolumeCount, 1),
 				"workerNodeName":       workerNodeName,
+				"loadVMsIterations":    loadVMsIterations,
+				"loadVMsPerIteration":  loadVMsPerIteration,
 			}
 
 			setMetrics(cmd, metricsProfiles)
@@ -93,6 +99,8 @@ func NewVirtMigration(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().IntVar(&iterations, "iterations", virtMigrationDefaultIteration, "How many iterations of VM creations. The total number of VMs is iterations*iteration-vms")
 	cmd.Flags().IntVar(&vmsPerIteration, "iteration-vms", virtMigrationDefaultVMsPerIteration, "How many VMs to create in each iteration. The total number of VMs is iterations*iteration-vms")
 	cmd.Flags().IntVar(&dataVolumeCount, "data-volume-count", virtMigrationDefaultDataVolumeCount, "Number of data volumes per VM")
+	cmd.Flags().IntVar(&loadVMsIterations, "load-iterations", virtMigrationDefaultLoadVMsIteration, "Number of iterations to create load VMs")
+	cmd.Flags().IntVar(&loadVMsPerIteration, "load-per-iteration", virtMigrationDefaultLoadVMsPerIteration, "Number of VMs to create in each load VM iteration")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
 	return cmd
 }


### PR DESCRIPTION
## Type of change

- New feature
- Documentation

## Description
Virt Migration - Allow users to create additional VMs before the migration to simulate a more realistic distribution of VMs


