### PR TITLE
Updating CDv2 pod ready latency probe

### DIFF
--- a/cmd/config/cluster-density-v2/deployment-client.yml
+++ b/cmd/config/cluster-density-v2/deployment-client.yml
@@ -34,7 +34,10 @@ spec:
       containers:
       - name: client-app
         image: quay.io/cloud-bulldozer/curl:latest
-        command: ["sleep", "inf"]
+        command:
+            - "/bin/sh"
+            - "-c"
+            - "while true; do echo $(date +'%Y-%m-%d %H:%M:%S'): INFO curl on ${ROUTE_ENDPOINT}; curl --fail -sSk ${ROUTE_ENDPOINT} -o /dev/null; sleep 120; done"
         resources:
           requests:
             memory: "10Mi"
@@ -47,7 +50,7 @@ spec:
             command:
             - "/bin/sh"
             - "-c"
-            - "curl --fail -sS ${SERVICE_ENDPOINT} -o /dev/null && curl --fail -sSk ${ROUTE_ENDPOINT} -o /dev/null"
+            - "if [ ! -f /tmp/ready.log ]; then curl --fail -sS ${SERVICE_ENDPOINT} -o /dev/null && curl --fail -sSk ${ROUTE_ENDPOINT} -o /dev/null && touch /tmp/ready.log; else curl --fail -sS ${SERVICE_ENDPOINT} -o /dev/null; fi"
           periodSeconds: 10
           timeoutSeconds: 5
           failureThreshold: 3

--- a/cmd/config/cluster-density-v2/deployment-client.yml
+++ b/cmd/config/cluster-density-v2/deployment-client.yml
@@ -37,7 +37,7 @@ spec:
         command:
             - "/bin/sh"
             - "-c"
-            - "while true; do echo $(date +'%Y-%m-%d %H:%M:%S'): INFO curl on ${ROUTE_ENDPOINT}; curl --fail -sSk ${ROUTE_ENDPOINT} -o /dev/null; sleep 120; done"
+            - "while true; do echo curl on ${ROUTE_ENDPOINT}; curl --fail -sSk ${ROUTE_ENDPOINT} -o /dev/null; sleep 120; done"
         resources:
           requests:
             memory: "10Mi"


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation
- [ ] CI

## Description
The current CDv2 workload use of `readinessProbe` is overwhelming the OpenShift-Ingress `router` in very large-scale clusters (> 250 nodes), due to thousands of routes being probed by client pods every 10s. This causes the router’s CPU usage to spike over 5 cores, and it also impacts pod startup latency, as readiness checks from newly progressing pods compete with ongoing traffic from existing client pods.
AWS handles this scenario well while Azure is struggling at 250-node scale, primarily due to its weaker ingress performance. With 500 node it gets even worse, 9K routes with ~22K client pods at a 10s interval.

In this change,  updating the behavior by replacing the `readinessProbe` with a `startupProbe` that would run only once and mark the container `ready`. This evaluates container readiness latency based on the first successful response(may be we can increase success threshold) from service and route endpoints. This change allows the container to be marked as `Ready` immediately after initial verification as we don't require to monitor health of the pod continuously every 10s.

Additionally, to maintain active traffic between pods/svcs, a separate curl job runs in the container at a reduced frequency (every 2 minutes), minimizing impact on the router while still validating end-to-end connectivity and logging. Having another `readinessProbe` with lower interval instead of this job may still affect the latency at large scale. 

Client logs
```
2025-06-25 17:05:36: INFO curl on http://cluster-density-4/256.html and https://cluster-density-1-cluster-density-v2-1.apps.rhperfscale.org/256.html
curl: (22) The requested URL returned error: 503
2025-06-25 17:07:36: INFO curl on http://cluster-density-4/256.html and https://cluster-density-1-cluster-density-v2-1.apps.rhperfscale.org/256.html
2025-06-25 17:09:36: INFO curl on http://cluster-density-4/256.html and https://cluster-density-1-cluster-density-v2-1.apps.rhperfscale.org/256.html
2025-06-25 17:11:37: INFO curl on http://cluster-density-4/256.html and https://cluster-density-1-cluster-density-v2-1.apps.rhperfscale.org/256.html
```
## Related Tickets & Documents

- Related Issue #
- Closes #

