### PR TITLE
Virt Migration - allow users to set QPS for the migration phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,6 +619,15 @@ Set the following arguments to create load `VirtualMachines`:
 
     The total number of load `VirtualMachines` created is `--load-vms-iterations` * `--iteration-load-vms`
 
+#### Limiting migration requests load
+
+By default, the test will be limited to 20 concurrent migrate request calls.
+Users can set a different value by passing `--migration-qps`.
+
+!!! Note
+
+    This parameter limits the concurrent migration requests, not actual concurrent migrations
+
 #### Initial Worker Node
 
 The worker node on which all VMs are scheduled and migrated from can be set by passing the `--worker-node` parameter.

--- a/cmd/config/virt-migration/virt-migration.yml
+++ b/cmd/config/virt-migration/virt-migration.yml
@@ -127,8 +127,8 @@ jobs:
 
 - name: migrate-vms
   jobType: kubevirt
-  qps: 20
-  burst: 20
+  qps: {{ .migrationQPS }}
+  burst: {{ .migrationQPS }}
   jobIterations: 1
   maxWaitTimeout: 1h
   waitWhenFinished: true

--- a/virt-migration.go
+++ b/virt-migration.go
@@ -36,6 +36,7 @@ const (
 	virtMigrationDefaultIteration           = 2
 	virtMigrationDefaultLoadVMsIteration    = 0
 	virtMigrationDefaultLoadVMsPerIteration = 0
+	virtMigrationDefaultMigrationQPS        = 20
 )
 
 // Returns virt-density workload
@@ -50,6 +51,7 @@ func NewVirtMigration(wh *workloads.WorkloadHelper) *cobra.Command {
 	var metricsProfiles []string
 	var loadVMsIterations int
 	var loadVMsPerIteration int
+	var migrationQPS int
 
 	var rc int
 	cmd := &cobra.Command{
@@ -83,6 +85,7 @@ func NewVirtMigration(wh *workloads.WorkloadHelper) *cobra.Command {
 				"workerNodeName":       workerNodeName,
 				"loadVMsIterations":    loadVMsIterations,
 				"loadVMsPerIteration":  loadVMsPerIteration,
+				"migrationQPS":         migrationQPS,
 			}
 
 			setMetrics(cmd, metricsProfiles)
@@ -101,6 +104,7 @@ func NewVirtMigration(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().IntVar(&dataVolumeCount, "data-volume-count", virtMigrationDefaultDataVolumeCount, "Number of data volumes per VM")
 	cmd.Flags().IntVar(&loadVMsIterations, "load-iterations", virtMigrationDefaultLoadVMsIteration, "Number of iterations to create load VMs")
 	cmd.Flags().IntVar(&loadVMsPerIteration, "load-per-iteration", virtMigrationDefaultLoadVMsPerIteration, "Number of VMs to create in each load VM iteration")
+	cmd.Flags().IntVar(&migrationQPS, "migration-qps", virtMigrationDefaultMigrationQPS, "Number of concurrent calls to migrate")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
 	return cmd
 }


### PR DESCRIPTION
## Type of change

- Optimization
- Documentation
- CI

## Description

Some clusters are overloaded when handling 20 parallel requests. Allow users to set a different value


