### PR TITLE
add OVS cpu and memory metrics

### DIFF
--- a/cmd/config/metrics-profiles/metrics.yml
+++ b/cmd/config/metrics-profiles/metrics.yml
@@ -187,3 +187,13 @@
 
 - query: rate ( node_vmstat_pgmajfault[1m] )
   metricName: nodeMajorFaults
+
+# OVS 2m CPU usage average
+- query: sum (  irate( container_cpu_usage_seconds_total {  id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice" }[2m])  )  by   (   id , instance )
+  metricName: cgroupOVSCPUUsagePercent
+
+# OVS Memory usage average
+- query: sum(container_memory_rss{id=~"/system.slice/ovs-vswitchd.service"}) by (id)
+  metricName: ovsMemory
+  instant: true
+  captureStart: true

--- a/cmd/config/metrics-profiles/metrics.yml
+++ b/cmd/config/metrics-profiles/metrics.yml
@@ -188,12 +188,12 @@
 - query: rate ( node_vmstat_pgmajfault[1m] )
   metricName: nodeMajorFaults
 
-# OVS 2m CPU usage average
+# OVS instantaneous per-second rate of increase over the last 2 minutes
 - query: sum (  irate( container_cpu_usage_seconds_total {  id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice" }[2m])  )  by   (   id , instance )
   metricName: cgroupOVSCPUUsagePercent
 
-# OVS Memory usage average
+# OVS RSS Memory 
 - query: sum(container_memory_rss{id=~"/system.slice/ovs-vswitchd.service"}) by (id)
-  metricName: ovsMemory
+  metricName: ovsMemoryRSS
   instant: true
   captureStart: true


### PR DESCRIPTION
## Type of change
Add new metrics for OVS CPU and Memory 


<!-- Choose a type of change -->

- Refactor
- New feature
- Bug fix
- Optimization
- Documentation
- CI

## Description

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #:  https://issues.redhat.com/browse/CORENET-6058
- Closes #

test log on these two metrics:  https://privatebin.corp.redhat.com/?d5b0338c3784ee42#8L911DkmbBho8EyZqxcGFCtEBmRuV2hba1jPxAeARTXa


/assign @mohit-sheth
/assign @rsevilla87 
/assign @afcollins 

This new PR incorporates updates based on review comments from the original [PR](https://github.com/kube-burner/kube-burner-ocp/pull/261) which was closed due to conflict after file structure change, please help review the new PR, thanks!

/cc @jluhrsen, @weliang1
