### PR TITLE
add OVS cpu and memory metrics

### DIFF
--- a/cmd/config/metrics-profiles/metrics.yml
+++ b/cmd/config/metrics-profiles/metrics.yml
@@ -187,3 +187,11 @@
 
 - query: rate ( node_vmstat_pgmajfault[1m] )
   metricName: nodeMajorFaults
+
+# cgroup CPU instantaneous per-second rate of increase over the last 2 minutes
+- query: sum (  irate( container_cpu_usage_seconds_total { id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice" }[2m])  )  by   (   id , instance )
+  metricName: cgroupCPU
+
+# RSS Memory
+- query: sum( container_memory_rss { id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice"}) by (id, instance)
+  metricName: cgroupMemoryRSS


### PR DESCRIPTION
## Type of change
Add new metrics for OVS CPU and Memory

<!-- Choose a type of change -->

- Refactor
- New feature
- Bug fix
- Optimization
- Documentation
- CI

## Description

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue # https://issues.redhat.com/browse/CORENET-6058
- Closes #

This new PR incorporates updates based on review comments from the original [PR ](https://github.com/kube-burner/kube-burner-ocp/pull/280) which was closed due to some difficulty of squashing all commits into one as some commits were merged in from main.

/assign @mohit-sheth
/assign @afcollins

Sorry for having to ask you to review again.  
/cc @jluhrsen
/cc @weliang1