### PR TITLE
Virt Clone - allow creating VMs in iterations

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ The test runs the following sequence:
 3. Create a `DataVolume` in namespace B using the rootdisk of the `VirtualMachine` as the source
 4. If the `dataImportCronSourceFormat` field of the `StorageProfile` `status` is set to `snapshot`, or `--use-snapshot` is set to `true`, create a `VolumeSnapshot` of the DataVolume
 5. Create a `DataSource`, setting the `source` field to either the `VolumeSnapshot` (if was created) or the `DataVolume`
-6. Create `VirtualMachine` in namespace B based in the `DataSource`
+6. Create `VirtualMachines` in namespace B based in the `DataSource`
 
 #### Tested StorageClass
 
@@ -525,7 +525,8 @@ By default, the `baseName` is `virt-clone`. Set it by passing `--namespace` (or 
 #### Test Size Parameters
 
 Users may control the workload sizes by passing the following arguments:
-- `--vms` - Number of `VirtualMachines` to create in step 6
+- `--iteration` - Number of iterations to run in step 6. Default is 1
+- `--iteration-clones` - Number of `VirtualMachines` to create in each iteration of step 6. Default is 10
 
 #### Volume Access Mode
 

--- a/cmd/config/virt-clone/templates/vm.yml
+++ b/cmd/config/virt-clone/templates/vm.yml
@@ -20,7 +20,7 @@ spec:
         resources:
           requests:
             storage: {{ default "6Gi" .rootVolumeSize }}
-  running: true
+  runStrategy: RerunOnFailure
   template:
     spec:
       accessCredentials:

--- a/cmd/config/virt-clone/virt-clone.yml
+++ b/cmd/config/virt-clone/virt-clone.yml
@@ -108,7 +108,7 @@ jobs:
   # timeout time after waiting for all object creation
   maxWaitTimeout: 15m
   # wait before job completes to allow metrics collection
-  jobPause: 1m
+  jobPause: 10s
   # Do not clean the namespaces
   cleanup: false
   # Set missing key as empty to allow using default values
@@ -145,7 +145,7 @@ jobs:
   # timeout time after waiting for all object creation
   maxWaitTimeout: 15m
   # wait before job completes to allow metrics collection
-  jobPause: 1m
+  jobPause: 10s
   # Do not clean the namespaces
   cleanup: false
   # Set missing key as empty to allow using default values
@@ -179,7 +179,7 @@ jobs:
 
 - name: {{ $createCloneVMJobName }}
   jobType: create
-  jobIterations: 1
+  jobIterations: {{ .iterations }}
   qps: 20
   burst: 20
   namespacedIterations: false
@@ -208,7 +208,7 @@ jobs:
       publicKeyPath: {{ .publicKey }}
 
   - objectTemplate: templates/vm.yml
-    replicas: {{ .cloneVMCount }}
+    replicas: {{ .clonesPerIteration }}
     inputVars:
       vmName: "{{ $cloneVMName }}"
       rootdiskVolumeSourceRef:

--- a/test/test-ocp.bats
+++ b/test/test-ocp.bats
@@ -159,7 +159,7 @@ teardown_file() {
   if [ -n "$KUBE_BURNER_OCP_STORAGE_CLASS" ]; then
     STORAGE_PARAMETER="--storage-class ${KUBE_BURNER_OCP_STORAGE_CLASS}"
   fi
-  run_cmd ${KUBE_BURNER_OCP} virt-clone ${STORAGE_PARAMETER} --access-mode RWO --vms 2
+  run_cmd ${KUBE_BURNER_OCP} virt-clone ${STORAGE_PARAMETER} --access-mode RWO --iterations 2 --iteration-clones 2
   local jobs=("create-base-vm" "create-clone-vms")
   for job in "${jobs[@]}"; do
     check_metric_recorded ./virt-clone-results ${job} dvLatency dvReadyLatency

--- a/virt-clone.go
+++ b/virt-clone.go
@@ -37,7 +37,8 @@ func NewVirtClone(wh *workloads.WorkloadHelper) *cobra.Command {
 	var volumeSnapshotClassName string
 	var sshKeyPairPath string
 	var useSnapshot bool
-	var vmCount int
+	var iterations int
+	var clonesPerIteration int
 	var testNamespaceBaseName string
 	var metricsProfiles []string
 	var volumeAccessMode string
@@ -68,8 +69,9 @@ func NewVirtClone(wh *workloads.WorkloadHelper) *cobra.Command {
 			AdditionalVars["storageClassName"] = storageClassName
 			AdditionalVars["volumeSnapshotClassName"] = volumeSnapshotClassName
 			AdditionalVars["testNamespaceBaseName"] = testNamespaceBaseName
-			AdditionalVars["cloneVMCount"] = vmCount
 			AdditionalVars["accessMode"] = accessModeTranslator[volumeAccessMode]
+			AdditionalVars["iterations"] = iterations
+			AdditionalVars["clonesPerIteration"] = clonesPerIteration
 
 			setMetrics(cmd, metricsProfiles)
 			rc = wh.RunWithAdditionalVars(cmd.Name()+".yml", AdditionalVars, nil)
@@ -81,7 +83,8 @@ func NewVirtClone(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().StringVar(&storageClassName, "storage-class", "", "Name of the Storage Class to test")
 	cmd.Flags().StringVar(&sshKeyPairPath, "ssh-key-path", "", "Path to save the generarated SSH keys")
 	cmd.Flags().BoolVar(&useSnapshot, "use-snapshot", true, "Clone from snapshot")
-	cmd.Flags().IntVar(&vmCount, "vms", 10, "Number of clone VMs to create")
+	cmd.Flags().IntVar(&iterations, "iterations", 1, "Number of iterations to create VirtualMachines. The total number of VirtualMachines is iterations*iteration-clones")
+	cmd.Flags().IntVar(&clonesPerIteration, "iteration-clones", 10, "How many VirtualMachines to create per iteration. The total number of VirtualMachines is iterations*iteration-clones")
 	cmd.Flags().StringVarP(&testNamespaceBaseName, "namespace", "n", virtCloneTestName, "Base name for the namespace to run the test in")
 	cmd.Flags().StringVar(&volumeAccessMode, "access-mode", "RWX", "Access mode for the created volumes - RO, RWO, RWX")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")


### PR DESCRIPTION
## Type of change

- New feature
- Documentation
- CI

## Description

Virt Clone Test - Allow users to create VMs in iterations instead of all in parallel

## Related Tickets & Documents

- Closes #286

