### PR TITLE
add job pause as an AdditionalVars for udn test

### DIFF
--- a/udn-density-pods.go
+++ b/udn-density-pods.go
@@ -49,6 +49,7 @@ func NewUDNDensityPods(wh *workloads.WorkloadHelper) *cobra.Command {
 			}
 
 			AdditionalVars["PPROF"] = pprof
+			AdditionalVars["JOB_PAUSE"] = jobPause
 			AdditionalVars["SIMPLE"] = simple
 			AdditionalVars["CHURN"] = churn
 			AdditionalVars["CHURN_CYCLES"] = churnCycles


### PR DESCRIPTION
removed here https://github.com/kube-burner/kube-burner-ocp/pull/262/files
adds it back

Tested
```

time="2025-08-04 17:23:45" level=info msg="🔥 Starting kube-burner (job-pause-udn@acbb986204c09cbe710631c952b4707b3221f1d2) with UUID 7a06561f-16bc-4fde-89b6-e98854fd0a9d" file="job.go:90" 
<snip>
time="2025-08-04 17:24:20" level=info msg="Verifying created objects" file="utils.go:119"
time="2025-08-04 17:24:20" level=info msg="Pausing for 45m0s before finishing job" file="job.go:181"

```