### PR TITLE
fix(cluster-density-v2): add missing kube-burner labels to Build resources

### DIFF
--- a/cmd/config/cluster-density-v2/build.yml
+++ b/cmd/config/cluster-density-v2/build.yml
@@ -3,6 +3,11 @@ kind: Build
 apiVersion: build.openshift.io/v1
 metadata:
   name: {{.JobName}}-{{.Replica}}
+  labels:
+    name: {{.JobName}}-{{.Replica}}
+    kube-burner-job: "{{.JobName}}"
+    kube-burner-uuid: "{{.UUID}}"
+    kube-burner-runid: "{{.RunID}}"
 spec:
   resources:
     requests:


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->
- Bug fix

## Description

<!--- Describe your changes in detail -->

This PR fixes an issue where the build pods generated by the `cluster-density-v2` workload were missing standard kube-burner labels such as `kube-burner-uuid`, `kube-burner-job`, and `kube-burner-runid`. 

Due to the absence of these labels, the build pods were not consistent with the rest of the workload’s resources and were not included in label-based operations or monitoring tools that rely on these identifiers.

To resolve this, the `build.yml` template has been updated to include the missing labels in the `metadata.labels` section, ensuring consistent labeling across all pods created by the workload.

## Related Tickets & Documents

- Related Issue #284 
- Closes #284 

