### PR TITLE
Node scale workload

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Available Commands:
   node-density               Runs node-density workload
   node-density-cni           Runs node-density-cni workload
   node-density-heavy         Runs node-density-heavy workload
+  node-scale                 Runs node-scale workload
   olm                        Runs olm workload
   pvc-density                Runs pvc-density workload
   rds-core                   Runs rds-core workload
@@ -190,6 +191,10 @@ Note: This workload calculates the number of iterations to create from the numbe
 Creates two deployments, a postgresql database, and a simple client that performs periodic insert queries (configured through liveness and readiness probes) on the previous database and a service that is used by the client to reach the database.
 
 Note: this workload calculates the number of iterations to create from the number of nodes and desired pods per node.  In order to keep the test scalable and performant, chunks of 1000 iterations will by broken into separate namespaces, using the config variable `iterationsPerNamespace`.
+
+### node-scale
+
+Leverages [Kubemark](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-scalability/kubemark-guide.md) to create a number of hollow nodes and allow to run experiments on simulated clusters. The primary use case is scalability testing, as simulated clusters can be much bigger than the real ones. The objective is to expose problems with the master components (API server, controller manager or scheduler) that appear only on bigger clusters (e.g. small memory leaks).
 
 ### udn-density-l3-pods
 

--- a/cmd/config/node-scale/namespace.yml
+++ b/cmd/config/node-scale/namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubemark

--- a/cmd/config/node-scale/node-scale.yml
+++ b/cmd/config/node-scale/node-scale.yml
@@ -50,8 +50,6 @@ jobs:
         replicas: 1
       - objectTemplate: secret-kubeconfig.yml
         replicas: 1
-        inputVars:
-          kubeconfig: {{ .KUBECONFIG }}
 
   - name: node-scale
     namespace: kubemark

--- a/cmd/config/node-scale/node-scale.yml
+++ b/cmd/config/node-scale/node-scale.yml
@@ -2,6 +2,7 @@
 global:
   gc: {{.GC}}
   gcMetrics: {{.GC_METRICS}}
+  deletionStrategy: {{.DELETION_STRATEGY}}
   measurements:
     - name: podLatency
       thresholds:
@@ -41,6 +42,7 @@ jobs:
     jobIterationDelay: 0s
     jobPause: 0s
     preLoadImages: false
+    skipIndexing: true
     objects:
       - objectTemplate: namespace.yml
         replicas: 1
@@ -49,7 +51,7 @@ jobs:
       - objectTemplate: secret-kubeconfig.yml
         replicas: 1
         inputVars:
-          kubeconfigB64: "{{ $.KUBECONFIGB64 }}"
+          kubeconfig: {{ .KUBECONFIG }}
 
   - name: node-scale
     namespace: kubemark
@@ -61,7 +63,6 @@ jobs:
     churnDuration: {{.CHURN_DURATION}}
     churnPercent: {{.CHURN_PERCENT}}
     churnDelay: {{.CHURN_DELAY}}
-    churnDeletionStrategy: {{.CHURN_DELETION_STRATEGY}}
     podWait: false
     waitWhenFinished: true
     preLoadImages: true
@@ -75,7 +76,7 @@ jobs:
       - objectTemplate: pod.yml
         replicas: 1
         inputVars:
-          cpu: "{{ $.CPU }}"
-          memory: "{{ $.MEMORY }}"
-          tag: "{{ $.TAG }}"
-          maxPods: "{{ $.MAX_PODS }}"
+          cpu: {{ .CPU }}
+          maxPods: {{ .MAX_PODS }}
+          memory: {{ .MEMORY }}
+          tag: {{ .TAG }}

--- a/cmd/config/node-scale/node-scale.yml
+++ b/cmd/config/node-scale/node-scale.yml
@@ -78,3 +78,4 @@ jobs:
           cpu: "{{ $.CPU }}"
           memory: "{{ $.MEMORY }}"
           tag: "{{ $.TAG }}"
+          maxPods: "{{ $.MAX_PODS }}"

--- a/cmd/config/node-scale/node-scale.yml
+++ b/cmd/config/node-scale/node-scale.yml
@@ -1,0 +1,55 @@
+---
+global:
+  gc: {{.GC}}
+  gcMetrics: {{.GC_METRICS}}
+  measurements:
+    - name: podLatency
+      thresholds:
+        - conditionType: Ready
+          metric: P99
+          threshold: {{.POD_READY_THRESHOLD}}
+metricsEndpoints:
+{{ if .ES_SERVER }}
+  - metrics: [{{.METRICS}}]
+    alerts: [{{.ALERTS}}]
+    indexer:
+      esServers: ["{{.ES_SERVER}}"]
+      insecureSkipVerify: true
+      defaultIndex: {{.ES_INDEX}}
+      type: opensearch
+{{ end }}
+{{ if .LOCAL_INDEXING }}
+  - metrics: [{{.METRICS}}]
+    alerts: [{{.ALERTS}}]
+    indexer:
+      type: local
+      metricsDirectory: collected-metrics-{{.UUID}}
+{{ end }}
+
+jobs:
+  - name: node-scale
+    namespace: node-scale
+    jobIterations: {{.JOB_ITERATIONS}}
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    churn: {{.CHURN}}
+    churnCycles: {{.CHURN_CYCLES}}
+    churnDuration: {{.CHURN_DURATION}}
+    churnPercent: {{.CHURN_PERCENT}}
+    churnDelay: {{.CHURN_DELAY}}
+    churnDeletionStrategy: {{.CHURN_DELETION_STRATEGY}}
+    podWait: false
+    waitWhenFinished: true
+    preLoadImages: true
+    preLoadPeriod: 10s
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+    objects:
+
+      - objectTemplate: pod.yml
+        replicas: 1
+        inputVars:
+          containerImage: registry.k8s.io/pause:3.1

--- a/cmd/config/node-scale/node-scale.yml
+++ b/cmd/config/node-scale/node-scale.yml
@@ -27,8 +27,64 @@ metricsEndpoints:
 {{ end }}
 
 jobs:
+
+  - name: namespace
+    jobType: create
+    jobIterations: 1
+    qps: {{ .QPS }}
+    burst: {{ .BURST }}
+    cleanup: false
+    podWait: false
+    waitWhenFinished: false
+    verifyObjects: true
+    errorOnVerify: true
+    jobIterationDelay: 0s
+    jobPause: 0s
+    preLoadImages: false
+    objects:
+      - objectTemplate: namespace.yml
+        replicas: 1
+
+  - name: role-binding
+    jobType: create
+    jobIterations: 1
+    qps: {{ .QPS }}
+    burst: {{ .BURST }}
+    cleanup: false
+    namespace: kubemark
+    podWait: false
+    waitWhenFinished: false
+    verifyObjects: true
+    errorOnVerify: true
+    jobIterationDelay: 0s
+    jobPause: 0s
+    preLoadImages: false
+    objects:
+      - objectTemplate: rolebinding.yml
+        replicas: 1
+
+  - name: secret-kubeconfig
+    jobType: create
+    jobIterations: 1
+    qps: {{ .QPS }}
+    burst: {{ .BURST }}
+    cleanup: false
+    namespace: kubemark
+    podWait: false
+    waitWhenFinished: false
+    verifyObjects: true
+    errorOnVerify: true
+    jobIterationDelay: 0s
+    jobPause: 0s
+    preLoadImages: false
+    objects:
+      - objectTemplate: secret-kubeconfig.yml
+        replicas: 1
+        inputVars:
+          KubeconfigB64: "{{ $.KubeconfigB64 }}"
+
   - name: node-scale
-    namespace: node-scale
+    namespace: kubemark
     jobIterations: {{.JOB_ITERATIONS}}
     qps: {{.QPS}}
     burst: {{.BURST}}

--- a/cmd/config/node-scale/node-scale.yml
+++ b/cmd/config/node-scale/node-scale.yml
@@ -49,7 +49,7 @@ jobs:
       - objectTemplate: secret-kubeconfig.yml
         replicas: 1
         inputVars:
-          KubeconfigB64: "{{ $.KubeconfigB64 }}"
+          kubeconfigB64: "{{ $.KUBECONFIGB64 }}"
 
   - name: node-scale
     namespace: kubemark

--- a/cmd/config/node-scale/node-scale.yml
+++ b/cmd/config/node-scale/node-scale.yml
@@ -28,7 +28,7 @@ metricsEndpoints:
 
 jobs:
 
-  - name: namespace
+  - name: pre-reqs
     jobType: create
     jobIterations: 1
     qps: {{ .QPS }}
@@ -44,40 +44,8 @@ jobs:
     objects:
       - objectTemplate: namespace.yml
         replicas: 1
-
-  - name: role-binding
-    jobType: create
-    jobIterations: 1
-    qps: {{ .QPS }}
-    burst: {{ .BURST }}
-    cleanup: false
-    namespace: kubemark
-    podWait: false
-    waitWhenFinished: false
-    verifyObjects: true
-    errorOnVerify: true
-    jobIterationDelay: 0s
-    jobPause: 0s
-    preLoadImages: false
-    objects:
       - objectTemplate: rolebinding.yml
         replicas: 1
-
-  - name: secret-kubeconfig
-    jobType: create
-    jobIterations: 1
-    qps: {{ .QPS }}
-    burst: {{ .BURST }}
-    cleanup: false
-    namespace: kubemark
-    podWait: false
-    waitWhenFinished: false
-    verifyObjects: true
-    errorOnVerify: true
-    jobIterationDelay: 0s
-    jobPause: 0s
-    preLoadImages: false
-    objects:
       - objectTemplate: secret-kubeconfig.yml
         replicas: 1
         inputVars:
@@ -104,8 +72,9 @@ jobs:
       pod-security.kubernetes.io/audit: privileged
       pod-security.kubernetes.io/warn: privileged
     objects:
-
       - objectTemplate: pod.yml
         replicas: 1
         inputVars:
-          containerImage: registry.k8s.io/pause:3.1
+          cpu: "{{ $.CPU }}"
+          memory: "{{ $.MEMORY }}"
+          tag: "{{ $.TAG }}"

--- a/cmd/config/node-scale/pod.yml
+++ b/cmd/config/node-scale/pod.yml
@@ -13,6 +13,7 @@ spec:
         - --morph=kubelet
         - --name=kubemark-node-{{.Iteration}}
         - --extended-resources=cpu={{.cpu}},memory={{.memory}}G
+        - --max-pods={{.maxPods}}
       command:
         - /kubemark
       image: "quay.io/cluster-api-provider-kubemark/kubemark:{{.tag}}"

--- a/cmd/config/node-scale/pod.yml
+++ b/cmd/config/node-scale/pod.yml
@@ -12,10 +12,10 @@ spec:
         - --v=3
         - --morph=kubelet
         - --name=kubemark-node-{{.Iteration}}
-        - --extended-resources=cpu=1,memory=4G
+        - --extended-resources=cpu={{.cpu}},memory={{.memory}}G
       command:
         - /kubemark
-      image: quay.io/cluster-api-provider-kubemark/kubemark:v1.26.7
+      image: "quay.io/cluster-api-provider-kubemark/kubemark:{{.tag}}"
       name: hollow-node
       securityContext:
         privileged: true

--- a/cmd/config/node-scale/pod.yml
+++ b/cmd/config/node-scale/pod.yml
@@ -1,0 +1,35 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  labels:
+    name: node-scale-{{.Iteration}}
+    app: hollow-node
+  name: kubemark-node-{{.Iteration}}
+  namespace: kubemark
+spec:
+  containers:
+    - args:
+        - --v=3
+        - --morph=kubelet
+        - --name=kubemark-node-{{.Iteration}}
+        - --extended-resources=cpu=1,memory=4G
+      command:
+        - /kubemark
+      image: quay.io/cluster-api-provider-kubemark/kubemark:v1.26.7
+      name: hollow-node
+      securityContext:
+        privileged: true
+      volumeMounts:
+        - mountPath: /kubeconfig
+          name: kubeconfig
+        - mountPath: /run/containerd/containerd.sock
+          name: containerd-sock
+  volumes:
+    - name: kubeconfig
+      secret:
+        defaultMode: 420
+        secretName: kubeconfig
+    - hostPath:
+        path: /run/crio/crio.sock
+        type: Socket
+      name: containerd-sock

--- a/cmd/config/node-scale/rolebinding.yml
+++ b/cmd/config/node-scale/rolebinding.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: privileged-to-default
+  namespace: kubemark
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: kubemark

--- a/cmd/config/node-scale/secret-kubeconfig.yml
+++ b/cmd/config/node-scale/secret-kubeconfig.yml
@@ -5,4 +5,4 @@ metadata:
   namespace: kubemark
 type: Opaque
 data:
-  kubeconfig: {{ .kubeconfigB64 }}
+  kubeconfig: {{ .kubeconfig | ReadFile | b64enc }}

--- a/cmd/config/node-scale/secret-kubeconfig.yml
+++ b/cmd/config/node-scale/secret-kubeconfig.yml
@@ -5,4 +5,4 @@ metadata:
   namespace: kubemark
 type: Opaque
 data:
-  kubeconfig: {{ .kubeconfig | ReadFile | b64enc }}
+  kubeconfig: {{ env "KUBECONFIG" | ReadFile | b64enc }}

--- a/cmd/config/node-scale/secret-kubeconfig.yml
+++ b/cmd/config/node-scale/secret-kubeconfig.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kubeconfig
+  namespace: kubemark
+type: Opaque
+data:
+  kubeconfig: {{ .KubeconfigB64 }}

--- a/cmd/config/node-scale/secret-kubeconfig.yml
+++ b/cmd/config/node-scale/secret-kubeconfig.yml
@@ -5,4 +5,4 @@ metadata:
   namespace: kubemark
 type: Opaque
 data:
-  kubeconfig: {{ .KubeconfigB64 }}
+  kubeconfig: {{ .kubeconfigB64 }}

--- a/cmd/ocp.go
+++ b/cmd/ocp.go
@@ -122,6 +122,7 @@ func openShiftCmd() *cobra.Command {
 		ocp.NewNodeDensity(&wh, "node-density"),
 		ocp.NewNodeDensity(&wh, "node-density-heavy"),
 		ocp.NewNodeDensity(&wh, "node-density-cni"),
+		ocp.NewNodeScale(&wh, "node-scale"),
 		ocp.NewUDNDensityPods(&wh),
 		ocp.NewIndex(&wh, ocpConfig),
 		ocp.NewPVCDensity(&wh),

--- a/node-scale.go
+++ b/node-scale.go
@@ -1,0 +1,66 @@
+// Copyright 2025 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocp
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/kube-burner/kube-burner/pkg/workloads"
+
+	"github.com/spf13/cobra"
+)
+
+// NewNodeScale holds node-scale workload
+func NewNodeScale(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
+	var rc int
+	var metricsProfiles []string
+	var iterations, churnCycles, churnPercent int
+	var podReadyThreshold, churnDuration, churnDelay, probesPeriod time.Duration
+	var churnDeletionStrategy string
+	var churn bool
+	cmd := &cobra.Command{
+		Use:          variant,
+		Short:        fmt.Sprintf("Runs %v workload", variant),
+		SilenceUsage: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			AdditionalVars["CHURN"] = churn
+			AdditionalVars["CHURN_CYCLES"] = churnCycles
+			AdditionalVars["CHURN_DURATION"] = churnDuration
+			AdditionalVars["CHURN_DELAY"] = churnDelay
+			AdditionalVars["CHURN_PERCENT"] = churnPercent
+			AdditionalVars["CHURN_DELETION_STRATEGY"] = churnDeletionStrategy
+			AdditionalVars["JOB_ITERATIONS"] = iterations
+			AdditionalVars["PROBES_PERIOD"] = probesPeriod.Seconds()
+			AdditionalVars["POD_READY_THRESHOLD"] = podReadyThreshold
+			setMetrics(cmd, metricsProfiles)
+			rc = wh.RunWithAdditionalVars(cmd.Name()+".yml", AdditionalVars, nil)
+		},
+		PostRun: func(cmd *cobra.Command, args []string) {
+			os.Exit(rc)
+		},
+	}
+	cmd.Flags().BoolVar(&churn, "churn", false, "Enable churning")
+	cmd.Flags().IntVar(&churnCycles, "churn-cycles", 0, "Churn cycles to execute")
+	cmd.Flags().DurationVar(&churnDuration, "churn-duration", 1*time.Hour, "Churn duration")
+	cmd.Flags().DurationVar(&churnDelay, "churn-delay", 2*time.Minute, "Time to wait between each churn")
+	cmd.Flags().StringVar(&churnDeletionStrategy, "churn-deletion-strategy", "gvr", "Churn deletion strategy to use")
+	cmd.Flags().IntVar(&churnPercent, "churn-percent", 10, "Percentage of job iterations that kube-burner will churn each round")
+	cmd.Flags().IntVar(&iterations, "iterations", 0, "Number of iterations/namespaces")
+	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 2*time.Minute, "Pod ready timeout threshold")
+	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
+	return cmd
+}

--- a/node-scale.go
+++ b/node-scale.go
@@ -64,7 +64,7 @@ func NewNodeScale(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 			AdditionalVars["CHURN_DURATION"] = churnDuration
 			AdditionalVars["CHURN_DELAY"] = churnDelay
 			AdditionalVars["CHURN_PERCENT"] = churnPercent
-			AdditionalVars["CHURN_DELETION_STRATEGY"] = churnDeletionStrategy
+			AdditionalVars["DELETION_STRATEGY"] = deletionStrategy
 			AdditionalVars["JOB_ITERATIONS"] = iterations
 			AdditionalVars["PROBES_PERIOD"] = probesPeriod.Seconds()
 			AdditionalVars["POD_READY_THRESHOLD"] = podReadyThreshold

--- a/node-scale.go
+++ b/node-scale.go
@@ -30,7 +30,7 @@ func NewNodeScale(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 	var metricsProfiles []string
 	var iterations, churnCycles, churnPercent, cpu, memory, maxPods int
 	var podReadyThreshold, churnDuration, churnDelay, probesPeriod time.Duration
-	var deletionStrategy, kubeconfig, tag string
+	var deletionStrategy, tag string
 	var churn bool
 	cmd := &cobra.Command{
 		Use:          variant,
@@ -44,7 +44,6 @@ func NewNodeScale(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 			AdditionalVars["CHURN_PERCENT"] = churnPercent
 			AdditionalVars["DELETION_STRATEGY"] = deletionStrategy
 			AdditionalVars["JOB_ITERATIONS"] = iterations
-			AdditionalVars["KUBECONFIG"] = kubeconfig
 			AdditionalVars["PROBES_PERIOD"] = probesPeriod.Seconds()
 			AdditionalVars["POD_READY_THRESHOLD"] = podReadyThreshold
 			AdditionalVars["CPU"] = cpu

--- a/node-scale.go
+++ b/node-scale.go
@@ -30,9 +30,9 @@ import (
 func NewNodeScale(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 	var rc int
 	var metricsProfiles []string
-	var iterations, churnCycles, churnPercent int
+	var iterations, churnCycles, churnPercent, cpu, memory int
 	var podReadyThreshold, churnDuration, churnDelay, probesPeriod time.Duration
-	var churnDeletionStrategy string
+	var churnDeletionStrategy, tag string
 	var churn bool
 	cmd := &cobra.Command{
 		Use:          variant,
@@ -68,6 +68,9 @@ func NewNodeScale(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 			AdditionalVars["JOB_ITERATIONS"] = iterations
 			AdditionalVars["PROBES_PERIOD"] = probesPeriod.Seconds()
 			AdditionalVars["POD_READY_THRESHOLD"] = podReadyThreshold
+			AdditionalVars["CPU"] = cpu
+			AdditionalVars["MEMORY"] = memory
+			AdditionalVars["TAG"] = tag
 			setMetrics(cmd, metricsProfiles)
 			rc = wh.RunWithAdditionalVars(cmd.Name()+".yml", AdditionalVars, nil)
 		},
@@ -80,8 +83,11 @@ func NewNodeScale(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 	cmd.Flags().DurationVar(&churnDuration, "churn-duration", 1*time.Hour, "Churn duration")
 	cmd.Flags().DurationVar(&churnDelay, "churn-delay", 2*time.Minute, "Time to wait between each churn")
 	cmd.Flags().StringVar(&churnDeletionStrategy, "churn-deletion-strategy", "gvr", "Churn deletion strategy to use")
+	cmd.Flags().StringVar(&tag, "version", "v1.33.0", "Image tag version of the kubemark container")
 	cmd.Flags().IntVar(&churnPercent, "churn-percent", 10, "Percentage of job iterations that kube-burner will churn each round")
 	cmd.Flags().IntVar(&iterations, "iterations", 0, "Number of iterations/namespaces")
+	cmd.Flags().IntVar(&cpu, "cpu", 1, "CPU capacity of each hollow node")
+	cmd.Flags().IntVar(&memory, "memory", 4, "Memory (G) of each hollow node")
 	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 2*time.Minute, "Pod ready timeout threshold")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
 	return cmd

--- a/node-scale.go
+++ b/node-scale.go
@@ -56,7 +56,7 @@ func NewNodeScale(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 				}
 
 				kubeconfigB64 := base64.StdEncoding.EncodeToString(kubeconfigContent)
-				AdditionalVars["KubeconfigB64"] = kubeconfigB64
+				AdditionalVars["KUBECONFIGB64"] = kubeconfigB64
 			}
 
 			AdditionalVars["CHURN"] = churn

--- a/node-scale.go
+++ b/node-scale.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/kube-burner/kube-burner/pkg/config"
 	"github.com/kube-burner/kube-burner/pkg/workloads"
 
 	"github.com/spf13/cobra"

--- a/node-scale.go
+++ b/node-scale.go
@@ -30,7 +30,7 @@ import (
 func NewNodeScale(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 	var rc int
 	var metricsProfiles []string
-	var iterations, churnCycles, churnPercent, cpu, memory int
+	var iterations, churnCycles, churnPercent, cpu, memory, maxPods int
 	var podReadyThreshold, churnDuration, churnDelay, probesPeriod time.Duration
 	var churnDeletionStrategy, tag string
 	var churn bool
@@ -71,6 +71,7 @@ func NewNodeScale(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 			AdditionalVars["CPU"] = cpu
 			AdditionalVars["MEMORY"] = memory
 			AdditionalVars["TAG"] = tag
+			AdditionalVars["MAX_PODS"] = maxPods
 			setMetrics(cmd, metricsProfiles)
 			rc = wh.RunWithAdditionalVars(cmd.Name()+".yml", AdditionalVars, nil)
 		},
@@ -88,6 +89,7 @@ func NewNodeScale(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 	cmd.Flags().IntVar(&iterations, "iterations", 0, "Number of iterations/namespaces")
 	cmd.Flags().IntVar(&cpu, "cpu", 1, "CPU capacity of each hollow node")
 	cmd.Flags().IntVar(&memory, "memory", 4, "Memory (G) of each hollow node")
+	cmd.Flags().IntVar(&maxPods, "max-pods", 250, "Max number of pods of each hollow node")
 	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 2*time.Minute, "Pod ready timeout threshold")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
 	return cmd

--- a/node-scale.go
+++ b/node-scale.go
@@ -83,7 +83,7 @@ func NewNodeScale(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 	cmd.Flags().IntVar(&churnCycles, "churn-cycles", 0, "Churn cycles to execute")
 	cmd.Flags().DurationVar(&churnDuration, "churn-duration", 1*time.Hour, "Churn duration")
 	cmd.Flags().DurationVar(&churnDelay, "churn-delay", 2*time.Minute, "Time to wait between each churn")
-	cmd.Flags().StringVar(&churnDeletionStrategy, "churn-deletion-strategy", "gvr", "Churn deletion strategy to use")
+	cmd.Flags().StringVar(&deletionStrategy, "churn-deletion-strategy", "gvr", "Churn deletion strategy to use")
 	cmd.Flags().StringVar(&tag, "version", "v1.33.0", "Image tag version of the kubemark container")
 	cmd.Flags().IntVar(&churnPercent, "churn-percent", 10, "Percentage of job iterations that kube-burner will churn each round")
 	cmd.Flags().IntVar(&iterations, "iterations", 0, "Number of iterations/namespaces")

--- a/node-scale.go
+++ b/node-scale.go
@@ -15,9 +15,7 @@
 package ocp
 
 import (
-	"encoding/base64"
 	"fmt"
-	"io"
 	"os"
 	"time"
 
@@ -32,33 +30,13 @@ func NewNodeScale(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 	var metricsProfiles []string
 	var iterations, churnCycles, churnPercent, cpu, memory, maxPods int
 	var podReadyThreshold, churnDuration, churnDelay, probesPeriod time.Duration
-	var churnDeletionStrategy, tag string
+	var deletionStrategy, kubeconfig, tag string
 	var churn bool
 	cmd := &cobra.Command{
 		Use:          variant,
 		Short:        fmt.Sprintf("Runs %v workload", variant),
 		SilenceUsage: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			// Read and encode KUBECONFIG file
-			kubeconfigPath := os.Getenv("KUBECONFIG")
-			if kubeconfigPath != "" {
-				kubeconfigFile, err := os.Open(kubeconfigPath)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "Error opening KUBECONFIG file %s: %v\n", kubeconfigPath, err)
-					os.Exit(1)
-				}
-				defer kubeconfigFile.Close()
-
-				kubeconfigContent, err := io.ReadAll(kubeconfigFile)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "Error reading KUBECONFIG file %s: %v\n", kubeconfigPath, err)
-					os.Exit(1)
-				}
-
-				kubeconfigB64 := base64.StdEncoding.EncodeToString(kubeconfigContent)
-				AdditionalVars["KUBECONFIGB64"] = kubeconfigB64
-			}
-
 			AdditionalVars["CHURN"] = churn
 			AdditionalVars["CHURN_CYCLES"] = churnCycles
 			AdditionalVars["CHURN_DURATION"] = churnDuration
@@ -66,6 +44,7 @@ func NewNodeScale(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 			AdditionalVars["CHURN_PERCENT"] = churnPercent
 			AdditionalVars["DELETION_STRATEGY"] = deletionStrategy
 			AdditionalVars["JOB_ITERATIONS"] = iterations
+			AdditionalVars["KUBECONFIG"] = kubeconfig
 			AdditionalVars["PROBES_PERIOD"] = probesPeriod.Seconds()
 			AdditionalVars["POD_READY_THRESHOLD"] = podReadyThreshold
 			AdditionalVars["CPU"] = cpu


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->

- [ ]  Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [x] Documentation
- [ ] CI

## Description

Leverages [Kubemark](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-scalability/kubemark-guide.md) to create a number of hollow nodes and allow to run experiments on simulated clusters. The primary use case is scalability testing, as simulated clusters can be much bigger than the real ones. The objective is to expose problems with the master components (API server, controller manager or scheduler) that appear only on bigger clusters (e.g. small memory leaks).

```
$ oc get node
NAME              STATUS   ROLES                         AGE   VERSION
vlan604           Ready    control-plane,master,worker   11h   v1.31.11

$ ./kube-burner-ocp node-scale -h
Runs node-scale workload
Usage:
  kube-burner-ocp node-scale [flags]
Flags:
      --churn                            Enable churning
      --churn-cycles int                 Churn cycles to execute
      --churn-delay duration             Time to wait between each churn (default 2m0s)
      --churn-deletion-strategy string   Churn deletion strategy to use (default "gvr")
      --churn-duration duration          Churn duration (default 1h0m0s)
      --churn-percent int                Percentage of job iterations that kube-burner will churn each round (default 10)
      --cpu int                          CPU capacity of each hollow node (default 1)
  -h, --help                             help for node-scale
      --iterations int                   Number of iterations/namespaces
      --max-pods int                     Max number of pods of each hollow node (default 250)
      --memory int                       Memory (G) of each hollow node (default 4)
      --metrics-profile strings          Comma separated list of metrics profiles to use (default [metrics.yml])
      --pod-ready-threshold duration     Pod ready timeout threshold (default 2m0s)
      --version string                   Image tag version of the kubemark container (default "v1.33.0")

$ ./kube-burner-ocp node-scale --iterations 10 --gc=false --cpu=80 --memory=376
time="2025-08-24 20:48:29" level=info msg="❤️ Checking for Cluster Health" file="cluster_health.go:46"
time="2025-08-24 20:48:29" level=info msg="Cluster is Healthy" file="cluster_health.go:54"
time="2025-08-24 20:48:29" level=info msg="🔥 Starting kube-burner (node-scale@a51f6b5e1097185b86f6aecdf21c69ad10cb21f1) with UUID 9d3dab84-199b-4de5-ae67-36ffd7b589ec" file="job.go:90"
time="2025-08-24 20:48:29" level=info msg="📈 Registered measurement: podLatency" file="factory.go:109"
time="2025-08-24 20:48:29" level=info msg="QPS: 20" file="job.go:370"
time="2025-08-24 20:48:29" level=info msg="Burst: 20" file="job.go:377"
time="2025-08-24 20:48:29" level=info msg="Job pre-reqs: 1 iterations with 1 Namespace replicas" file="create.go:84"
time="2025-08-24 20:48:29" level=info msg="Job pre-reqs: 1 iterations with 1 RoleBinding replicas" file="create.go:84"
time="2025-08-24 20:48:29" level=info msg="Job pre-reqs: 1 iterations with 1 Secret replicas" file="create.go:84"
time="2025-08-24 20:48:29" level=info msg="QPS: 20" file="job.go:370"
time="2025-08-24 20:48:29" level=info msg="Burst: 20" file="job.go:377"
time="2025-08-24 20:48:29" level=info msg="Job node-scale: 10 iterations with 1 Pod replicas" file="create.go:84"
time="2025-08-24 20:48:29" level=info msg="Pre-load: images from job node-scale" file="pre_load.go:73"
time="2025-08-24 20:48:29" level=info msg="Pre-load: Creating DaemonSet using images [quay.io/cluster-api-provider-kubemark/kubemark:v1.33.0] in namespace preload-kube-burner" file="pre_load.go:195"
time="2025-08-24 20:48:29" level=info msg="Pre-load: Sleeping for 10s" file="pre_load.go:86"
time="2025-08-24 20:48:39" level=info msg="Deleting 1 namespaces with label: kube-burner-preload=true" file="namespaces.go:67"
time="2025-08-24 20:48:45" level=info msg="Creating /v1, Resource=pods latency watcher for pre-reqs" file="base_measurement.go:69"
time="2025-08-24 20:48:45" level=info msg="Triggering job: pre-reqs" file="job.go:121"
time="2025-08-24 20:48:45" level=info msg="0/1 iterations completed" file="create.go:119"
time="2025-08-24 20:48:45" level=info msg="Verifying created objects" file="utils.go:119"
time="2025-08-24 20:48:45" level=info msg="Job pre-reqs took 0s" file="job.go:190"
time="2025-08-24 20:48:45" level=info msg="Stopping measurement: podLatency" file="factory.go:150"
time="2025-08-24 20:48:45" level=info msg="Evaluating latency thresholds" file="metrics.go:48"
time="2025-08-24 20:48:45" level=info msg="Creating /v1, Resource=pods latency watcher for node-scale" file="base_measurement.go:69"
time="2025-08-24 20:48:46" level=info msg="Triggering job: node-scale" file="job.go:121"
time="2025-08-24 20:48:46" level=info msg="Deleting Pods labeled with kube-burner-job=node-scale in kubemark" file="namespaces.go:55"
time="2025-08-24 20:48:46" level=info msg="1/10 iterations completed" file="create.go:119"
time="2025-08-24 20:48:46" level=info msg="2/10 iterations completed" file="create.go:119"
time="2025-08-24 20:48:46" level=info msg="3/10 iterations completed" file="create.go:119"
time="2025-08-24 20:48:46" level=info msg="4/10 iterations completed" file="create.go:119"
time="2025-08-24 20:48:46" level=info msg="5/10 iterations completed" file="create.go:119"
time="2025-08-24 20:48:46" level=info msg="6/10 iterations completed" file="create.go:119"
time="2025-08-24 20:48:46" level=info msg="7/10 iterations completed" file="create.go:119"
time="2025-08-24 20:48:46" level=info msg="8/10 iterations completed" file="create.go:119"
time="2025-08-24 20:48:46" level=info msg="9/10 iterations completed" file="create.go:119"
time="2025-08-24 20:48:46" level=info msg="Waiting up to 4h0m0s for actions to be completed" file="create.go:169"
time="2025-08-24 20:48:48" level=info msg="Actions completed" file="waiters.go:76"
time="2025-08-24 20:48:48" level=info msg="Actions completed" file="waiters.go:76"
time="2025-08-24 20:48:48" level=info msg="Actions completed" file="waiters.go:76"
time="2025-08-24 20:48:48" level=info msg="Actions completed" file="waiters.go:76"
time="2025-08-24 20:48:48" level=info msg="Actions completed" file="waiters.go:76"
time="2025-08-24 20:48:48" level=info msg="Actions completed" file="waiters.go:76"
time="2025-08-24 20:48:48" level=info msg="Actions completed" file="waiters.go:76"
time="2025-08-24 20:48:48" level=info msg="Actions completed" file="waiters.go:76"
time="2025-08-24 20:48:48" level=info msg="Actions completed" file="waiters.go:76"
time="2025-08-24 20:48:48" level=info msg="Actions completed" file="waiters.go:76"
time="2025-08-24 20:48:48" level=info msg="Verifying created objects" file="utils.go:119"
time="2025-08-24 20:48:48" level=info msg="Job node-scale took 2s" file="job.go:190"
time="2025-08-24 20:48:48" level=info msg="Stopping measurement: podLatency" file="factory.go:150"
time="2025-08-24 20:48:48" level=info msg="Evaluating latency thresholds" file="metrics.go:48"
time="2025-08-24 20:48:48" level=info msg="node-scale: PodScheduled 99th: 0 max: 0 avg: 0" file="base_measurement.go:111"
time="2025-08-24 20:48:48" level=info msg="node-scale: ContainersReady 99th: 1000 max: 1000 avg: 800" file="base_measurement.go:111"
time="2025-08-24 20:48:48" level=info msg="node-scale: Initialized 99th: 0 max: 0 avg: 0" file="base_measurement.go:111"
time="2025-08-24 20:48:48" level=info msg="node-scale: Ready 99th: 1000 max: 1000 avg: 800" file="base_measurement.go:111"
time="2025-08-24 20:48:48" level=info msg="node-scale: PodReadyToStartContainers 99th: 0 max: 0 avg: 0" file="base_measurement.go:111"
time="2025-08-24 20:48:48" level=info msg="Finished execution with UUID: 9d3dab84-199b-4de5-ae67-36ffd7b589ec" file="job.go:263"
time="2025-08-24 20:48:48" level=info msg="👋 kube-burner run completed with rc 0 for UUID 9d3dab84-199b-4de5-ae67-36ffd7b589ec" file="helpers.go:104"

$ oc get node
NAME              STATUS   ROLES                         AGE   VERSION
kubemark-node-0   Ready    <none>                        14s   v1.33.0
kubemark-node-1   Ready    <none>                        14s   v1.33.0
kubemark-node-2   Ready    <none>                        14s   v1.33.0
kubemark-node-3   Ready    <none>                        14s   v1.33.0
kubemark-node-4   Ready    <none>                        15s   v1.33.0
kubemark-node-5   Ready    <none>                        14s   v1.33.0
kubemark-node-6   Ready    <none>                        14s   v1.33.0
kubemark-node-7   Ready    <none>                        15s   v1.33.0
kubemark-node-8   Ready    <none>                        14s   v1.33.0
kubemark-node-9   Ready    <none>                        14s   v1.33.0
vlan604           Ready    control-plane,master,worker   22h   v1.31.11

$ oc describe node kubemark-node-0 | grep Capacity -A 3
Capacity:
  cpu:                80
  ephemeral-storage:  0
  memory:             376G

$ kubectl label node kubemark-node-0 node-role.kubernetes.io/worker=""

$ ./kube-burner-ocp node-density --pods-per-node=200 --gc=false
time="2025-08-24 21:03:36" level=info msg="❤️ Checking for Cluster Health" file="cluster_health.go:46"
time="2025-08-24 21:03:36" level=info msg="Cluster is Healthy" file="cluster_health.go:54"
time="2025-08-24 21:03:37" level=info msg="🔥 Starting kube-burner (node-scale@a51f6b5e1097185b86f6aecdf21c69ad10cb21f1) with UUID 0f7eb9ec-1120-4655-833b-bf4797893022" file="job.go:90"
time="2025-08-24 21:03:37" level=info msg="📈 Registered measurement: podLatency" file="factory.go:109"
time="2025-08-24 21:03:37" level=info msg="QPS: 20" file="job.go:370"
time="2025-08-24 21:03:37" level=info msg="Burst: 20" file="job.go:377"
time="2025-08-24 21:03:37" level=info msg="Job node-density: 192 iterations with 1 Pod replicas" file="create.go:84"
time="2025-08-24 21:03:37" level=info msg="Pre-load: images from job node-density" file="pre_load.go:73"
time="2025-08-24 21:03:37" level=info msg="Pre-load: Creating DaemonSet using images [registry.k8s.io/pause:3.1] in namespace preload-kube-burner" file="pre_load.go:195"
time="2025-08-24 21:03:37" level=info msg="Pre-load: Sleeping for 10s" file="pre_load.go:86"
time="2025-08-24 21:03:47" level=info msg="Deleting 1 namespaces with label: kube-burner-preload=true" file="namespaces.go:67"
time="2025-08-24 21:03:53" level=info msg="Creating /v1, Resource=pods latency watcher for node-density" file="base_measurement.go:69"
time="2025-08-24 21:03:53" level=info msg="Triggering job: node-density" file="job.go:121"
time="2025-08-24 21:03:53" level=info msg="Deleting 1 namespaces with label: kube-burner-job=node-density" file="namespaces.go:67"
time="2025-08-24 21:04:22" level=info msg="19/192 iterations completed" file="create.go:119"
time="2025-08-24 21:04:23" level=info msg="38/192 iterations completed" file="create.go:119"
time="2025-08-24 21:04:24" level=info msg="57/192 iterations completed" file="create.go:119"
time="2025-08-24 21:04:25" level=info msg="76/192 iterations completed" file="create.go:119"
time="2025-08-24 21:04:26" level=info msg="95/192 iterations completed" file="create.go:119"
time="2025-08-24 21:04:26" level=info msg="114/192 iterations completed" file="create.go:119"
time="2025-08-24 21:04:27" level=info msg="133/192 iterations completed" file="create.go:119"
time="2025-08-24 21:04:28" level=info msg="152/192 iterations completed" file="create.go:119"
time="2025-08-24 21:04:29" level=info msg="171/192 iterations completed" file="create.go:119"
time="2025-08-24 21:04:30" level=info msg="190/192 iterations completed" file="create.go:119"
time="2025-08-24 21:04:30" level=info msg="Waiting up to 4h0m0s for actions to be completed" file="create.go:169"
time="2025-08-24 21:04:44" level=info msg="Actions in namespace node-density-0 completed" file="waiters.go:74"
time="2025-08-24 21:04:44" level=info msg="Verifying created objects" file="utils.go:119"
time="2025-08-24 21:04:44" level=info msg="Job node-density took 52s" file="job.go:190"
time="2025-08-24 21:04:44" level=info msg="Stopping measurement: podLatency" file="factory.go:150"
time="2025-08-24 21:04:44" level=info msg="Evaluating latency thresholds" file="metrics.go:48"
time="2025-08-24 21:04:44" level=info msg="node-density: ContainersReady 99th: 9000 max: 9000 avg: 5468" file="base_measurement.go:111"
time="2025-08-24 21:04:44" level=info msg="node-density: Initialized 99th: 0 max: 0 avg: 0" file="base_measurement.go:111"
time="2025-08-24 21:04:44" level=info msg="node-density: Ready 99th: 9000 max: 9000 avg: 5468" file="base_measurement.go:111"
time="2025-08-24 21:04:44" level=info msg="node-density: PodReadyToStartContainers 99th: 0 max: 0 avg: 0" file="base_measurement.go:111"
time="2025-08-24 21:04:44" level=info msg="node-density: PodScheduled 99th: 0 max: 0 avg: 0" file="base_measurement.go:111"
time="2025-08-24 21:04:44" level=info msg="Finished execution with UUID: 0f7eb9ec-1120-4655-833b-bf4797893022" file="job.go:263"
time="2025-08-24 21:04:44" level=info msg="👋 kube-burner run completed with rc 0 for UUID 0f7eb9ec-1120-4655-833b-bf4797893022" file="helpers.go:104"

$ oc get po -n node-density-0 -owide | grep kubemark-node-0 | grep Running | wc -l
40
```
