### PR TITLE
Remove pprof collection from non-existent ovn-controller endpoint

### DIFF
--- a/cmd/config/cluster-density-v2/cluster-density-v2.yml
+++ b/cmd/config/cluster-density-v2/cluster-density-v2.yml
@@ -17,10 +17,6 @@ global:
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-node}
         url: http://localhost:29103/debug/pprof/profile?seconds=30
-      - name: ovn-controller
-        namespace: "openshift-ovn-kubernetes"
-        labelSelector: {app: ovnkube-node}
-        url: http://localhost:29105/debug/pprof/profile?seconds=30
       - name: ovnk-control-plane
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-control-plane}

--- a/cmd/config/node-density-cni/node-density-cni.yml
+++ b/cmd/config/node-density-cni/node-density-cni.yml
@@ -17,10 +17,6 @@ global:
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-node}
         url: http://localhost:29103/debug/pprof/profile?seconds=30
-      - name: ovn-controller
-        namespace: "openshift-ovn-kubernetes"
-        labelSelector: {app: ovnkube-node}
-        url: http://localhost:29105/debug/pprof/profile?seconds=30
       - name: ovnk-control-plane
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-control-plane}

--- a/cmd/config/node-density-heavy/node-density-heavy.yml
+++ b/cmd/config/node-density-heavy/node-density-heavy.yml
@@ -17,10 +17,6 @@ global:
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-node}
         url: http://localhost:29103/debug/pprof/profile?seconds=30
-      - name: ovn-controller
-        namespace: "openshift-ovn-kubernetes"
-        labelSelector: {app: ovnkube-node}
-        url: http://localhost:29105/debug/pprof/profile?seconds=30
       - name: ovnk-control-plane
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-control-plane}

--- a/cmd/config/node-density/node-density.yml
+++ b/cmd/config/node-density/node-density.yml
@@ -17,10 +17,6 @@ global:
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-node}
         url: http://localhost:29103/debug/pprof/profile?seconds=30
-      - name: ovn-controller
-        namespace: "openshift-ovn-kubernetes"
-        labelSelector: {app: ovnkube-node}
-        url: http://localhost:29105/debug/pprof/profile?seconds=30
       - name: ovnk-control-plane
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-control-plane}

--- a/cmd/config/udn-density-pods/udn-density-pods.yml
+++ b/cmd/config/udn-density-pods/udn-density-pods.yml
@@ -17,10 +17,6 @@ global:
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-node}
         url: http://localhost:29103/debug/pprof/profile?seconds=30
-      - name: ovn-controller
-        namespace: "openshift-ovn-kubernetes"
-        labelSelector: {app: ovnkube-node}
-        url: http://localhost:29105/debug/pprof/profile?seconds=30
       - name: ovnk-control-plane
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-control-plane}


### PR DESCRIPTION
## Type of change

- Bug fix

## Description

ovn-controller does not expose a pprof endpoint, so we can remove it from the pprof section to reduce confusion.

```
[root@vm00228 ~]# curl http://localhost:29105/debug/pprof/profile?seconds=5
404 page not found
```