### PR TITLE
add instantaneous ovs metrics to metrics aggregated

### DIFF
--- a/cmd/config/metrics-profiles/metrics-aggregated.yml
+++ b/cmd/config/metrics-profiles/metrics-aggregated.yml
@@ -187,3 +187,12 @@
   metricName: cgroupMemoryRSS-namespaces
   instant: true
   captureStart: true
+
+# cgroup CPU instantaneous per-second rate of increase over the last 2 minutes
+- query: sum (  irate( container_cpu_usage_seconds_total { id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice" }[2m])  )  by   (   id , instance )
+  metricName: cgroupCPU
+
+# RSS Memory
+- query: sum( container_memory_rss { id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice"}) by (id, instance)
+  metricName: cgroupMemoryRSS
+


### PR DESCRIPTION
added it to metrics-aggregated.yml in addition to metrics.yml so that it can be consumed by cdv2 orion config files
similar to 
https://github.com/kube-burner/kube-burner-ocp/pull/285/files 