### PR TITLE
[DNM] custom config for cluster density

### DIFF
--- a/cmd/config/cluster-density-v2/cluster-density-v2.yml
+++ b/cmd/config/cluster-density-v2/cluster-density-v2.yml
@@ -67,24 +67,23 @@ jobs:
       pod-security.kubernetes.io/audit: privileged
       pod-security.kubernetes.io/warn: privileged
     objects:
+      {{- $serviceReplicas := randInt 2 11}}
+      {{- $routeReplicas := randInt 1 $serviceReplicas}}
 
       - objectTemplate: imagestream.yml
         replicas: 1
 
-      - objectTemplate: build.yml
-        replicas: 1
-
       - objectTemplate: service.yml
-        replicas: 5
+        replicas: {{$serviceReplicas}}
         
       - objectTemplate: route.yml
-        replicas: 2
+        replicas: {{$routeReplicas}}
 
       - objectTemplate: secret.yml
-        replicas: 10
+        replicas: {{randInt 4 11}}
 
       - objectTemplate: configmap.yml
-        replicas: 10
+        replicas: {{randInt 4 11}}
 
       - objectTemplate: np-deny-all.yml
         replicas: 1
@@ -96,12 +95,14 @@ jobs:
         replicas: 1
 
       - objectTemplate: deployment-server.yml
-        replicas: 3
+        replicas: {{randInt 3 6}}
         inputVars:
           podReplicas: 2
 
       - objectTemplate: deployment-client.yml
-        replicas: 2
+        replicas: {{randInt 3 6}}
         inputVars:
           podReplicas: 2
           ingressDomain: {{.INGRESS_DOMAIN}}
+          serviceReplicas: {{$serviceReplicas}}
+          routeReplicas: {{$routeReplicas}}

--- a/cmd/config/cluster-density-v2/deployment-client.yml
+++ b/cmd/config/cluster-density-v2/deployment-client.yml
@@ -83,9 +83,9 @@ spec:
         - name: ENVVAR4
           value: "{{randAlphaNum 250}}"
         - name: ROUTE_ENDPOINT
-          value: "https://cluster-density-{{.Replica}}-cluster-density-v2-{{.Iteration}}.{{ .ingressDomain }}/256.html"
+          value: "https://cluster-density-{{randInt 1 .routeReplicas}}-cluster-density-v2-{{.Iteration}}.{{ .ingressDomain }}/256.html"
         - name: SERVICE_ENDPOINT
-          value: "http://cluster-density-{{randInt 1 6}}/256.html"
+          value: "http://cluster-density-{{randInt 1 .serviceReplicas}}/256.html"
       volumes:
       - name: secret-1
         secret:


### PR DESCRIPTION
kube-burner AI needs CI runs for cdv2 job with different config options. We want cdv2 to create variable number of cluster resources in each test run instead of predefined number of them.
Each iteration in the test run, choses a random number between the min and max provided for the resource.

Please don't review or merge this change as it is a temporary change for our CI runs.

## Type of change

<!-- Choose a type of change -->

- Refactor
- New feature
- Bug fix
- Optimization
- Documentation
- CI

## Description

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #
- Closes #

