### PR TITLE
Virt Clone - add no wait test variation

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ Similar to node-density, fills with VirtualMachines the worker nodes of the clus
 
 ### Virt Density Udn
 
-Similar to udn-density-pods scenario. Creates VMs, one Nginx server and several clients (the number depends on the `vms-per-node` variable) reaching it, on the same UDN per iteration. Each UDN-namespace has the same number of VMs, the number of clients deployed per UDN is computed as following: 
+Similar to udn-density-pods scenario. Creates VMs, one Nginx server and several clients (the number depends on the `vms-per-node` variable) reaching it, on the same UDN per iteration. Each UDN-namespace has the same number of VMs, the number of clients deployed per UDN is computed as following:
 ```Nb of client per UDN = (Nb of worker * vms-per-node / Nb of UDN) -1 //-1  because the server is always deployed.```
 This scenario is meant to test how many UDNs can be deployed in parallel and how it scales. It requires a version of OCP higher than 4.18, otherwise, UDN feature is not available.
 
@@ -537,6 +537,17 @@ By default, the `baseName` is `virt-clone`. Set it by passing `--namespace` (or 
 Users may control the workload sizes by passing the following arguments:
 - `--iteration` - Number of iterations to run in step 6. Default is 1
 - `--iteration-clones` - Number of `VirtualMachines` to create in each iteration of step 6. Default is 10
+
+#### Verification of cloned `VirtualMachines` creation
+
+By default, the test waits for all `VirtualMachines` created in an iteration to reach the `Ready` condition.
+Users may configure the test to run differently.
+
+- `--verify-each-iteration` - Whether the test should verify the cloned `VirtualMachines` on each iteration. Default `true`. If set to `false` verification will be postpone to the end of the job
+- `--job-iteration-delay` - Time in `Duration` for the test to wait between iterations. Default is `0`
+- `--verify-max-wait-time` - Time in `Duration` to wait for `VirtualMachines` to become ready either for each iteration or at the end.
+
+For example, to change the test to wait for a minute between iterations instead of the `VirtualMachines` to become `Ready` set: `--verify-each-iteration=false --job-iteration-delay=1m`
 
 #### Volume Access Mode
 

--- a/cmd/config/virt-clone/virt-clone.yml
+++ b/cmd/config/virt-clone/virt-clone.yml
@@ -188,10 +188,12 @@ jobs:
   verifyObjects: true
   errorOnVerify: true
   # wait all VMI be in the Ready Condition
-  waitWhenFinished: false
-  podWait: true
+  waitWhenFinished: {{ not .verifyEachIteration }}
+  podWait: {{ .verifyEachIteration }}
+  # time between job iterations
+  jobIterationDelay: {{ .jobIterationDelay }}
   # timeout time after waiting for all object creation
-  maxWaitTimeout: 1h
+  maxWaitTimeout: {{ .verifyMaxWaitTime }}
   jobPause: 10s
   # cleanup cleans previous execution (not deleted or failed)
   cleanup: false

--- a/virt-clone.go
+++ b/virt-clone.go
@@ -16,6 +16,7 @@ package ocp
 
 import (
 	"os"
+	"time"
 
 	"github.com/cloud-bulldozer/go-commons/v2/ssh"
 	"github.com/cloud-bulldozer/go-commons/v2/virtctl"
@@ -42,6 +43,9 @@ func NewVirtClone(wh *workloads.WorkloadHelper) *cobra.Command {
 	var testNamespaceBaseName string
 	var metricsProfiles []string
 	var volumeAccessMode string
+	var verifyEachIteration bool
+	var jobIterationDelay time.Duration
+	var verifyMaxWaitTime time.Duration
 	var rc int
 	cmd := &cobra.Command{
 		Use:          virtCloneTestName,
@@ -72,6 +76,9 @@ func NewVirtClone(wh *workloads.WorkloadHelper) *cobra.Command {
 			AdditionalVars["accessMode"] = accessModeTranslator[volumeAccessMode]
 			AdditionalVars["iterations"] = iterations
 			AdditionalVars["clonesPerIteration"] = clonesPerIteration
+			AdditionalVars["verifyEachIteration"] = verifyEachIteration
+			AdditionalVars["jobIterationDelay"] = jobIterationDelay
+			AdditionalVars["verifyMaxWaitTime"] = verifyMaxWaitTime
 
 			setMetrics(cmd, metricsProfiles)
 			rc = wh.RunWithAdditionalVars(cmd.Name()+".yml", AdditionalVars, nil)
@@ -87,6 +94,9 @@ func NewVirtClone(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().IntVar(&clonesPerIteration, "iteration-clones", 10, "How many VirtualMachines to create per iteration. The total number of VirtualMachines is iterations*iteration-clones")
 	cmd.Flags().StringVarP(&testNamespaceBaseName, "namespace", "n", virtCloneTestName, "Base name for the namespace to run the test in")
 	cmd.Flags().StringVar(&volumeAccessMode, "access-mode", "RWX", "Access mode for the created volumes - RO, RWO, RWX")
+	cmd.Flags().BoolVar(&verifyEachIteration, "verify-each-iteration", true, "Wait for each iteration to complete and verify before starting the next one")
+	cmd.Flags().DurationVar(&jobIterationDelay, "job-iteration-delay", 0, "Delay between job iterations")
+	cmd.Flags().DurationVar(&verifyMaxWaitTime, "verify-max-wait-time", 1*time.Hour, "Max wait time for clone creation waiting")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
 	return cmd
 }


### PR DESCRIPTION
## Type of change

- New feature
- Optimization
- Documentation

## Description
Support two variations of the clone test - wait on resources or time between iterations
