### PR TITLE
Virt tests doc - move virtctl requirement to top

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,26 @@ The different variants are:
 - [virt-ephemeral-restart](#virt-ephemeral-restart)
 - [virt-migration](#virt-migration)
 
+### Environment Requirements
+
+#### Virtctl
+
+The tests listed below verify that the `VirtualMachine` completed their boot using `virtctl ssh`.
+Therefore, `virtctl` must be installed and available in the `PATH`.
+
+- [virt-capacity-benchmark](#virt-capacity-benchmark).
+- [virt-clone](#virt-clone)
+- [virt-ephemeral-restart](#virt-ephemeral-restart)
+- [virt-migration](#virt-migration)
+
+See the [Temporary SSH Keys](#temporary-ssh-keys) for details on the SSH keys used for the test
+
+#### Temporary SSH Keys
+
+The test generated the SSH keys automatically.
+By default, it stores the pair in a temporary directory.
+Users may choose the store the key in a specified directory by setting `--ssh-key-path`
+
 ### Virt Density
 
 Similar to node-density, fills with VirtualMachines the worker nodes of the cluster (**kubevirt/OpenShift Virtualization is required** to run this workload). Meant to detect issues derived from spinning up high amounts VMs in a short amount of time and to track runningthe latencies of the different VM bootstrap stages.
@@ -464,13 +484,6 @@ This scenario is meant to test how many UDNs can be deployed in parallel and how
 ### Virt Capacity Benchmark
 
 Test the capacity of Virtual Machines and Volumes supported by the cluster and a specific storage class.
-
-#### Environment Requirements
-
-In order to verify that the `VirtualMachine` completed their boot and that volume resize propagated successfully, the test uses `virtctl ssh`.
-Therefore, `virtctl` must be installed and available in the `PATH`.
-
-See the [Temporary SSH Keys](#temporary-ssh-keys) for details on the SSH keys used for the test
 
 #### Test Sequence
 
@@ -513,12 +526,6 @@ Users may control the workload sizes by passing the following arguments:
 - `--data-volume-count` - Number of data volumes for each VM (default 9)
 - `--min-vol-size` - Set the minimal volume size supported by the storage class
 - `--min-vol-inc-size` - Set the minimal volume size increment supported by the storage class
-
-#### Temporary SSH Keys
-
-The test generated the SSH keys automatically.
-By default, it stores the pair in a temporary directory.
-Users may choose the store the key in a specified directory by setting `--ssh-key-path`
 
 #### Skip test parts
 
@@ -581,12 +588,6 @@ For example, to change the test to wait for a minute between iterations instead 
 By default, volumes are created with `ReadWriteMany` access mode as this is the recommended configuration for `VirtualMachines`.
 If not supported, the access mode may be changes by setting `--access-mode`. The supported values are `RO`, `RWO` and `RWX`.
 
-#### Temporary SSH Keys
-
-In order to verify that the VMs actually completed booting, the test generates an SSH key pair.
-By default, it stores the pair in a temporary directory.
-Users may choose the store the key in a specified directory by setting `--ssh-key-path`
-
 ### Virt Ephemeral Restart
 
 Test the performance of restarting ephemeral `VirtalMachine`s. Kubernetes native ephemeral volumes use local node storage. As a result, the cannot be used on large scale deployment.
@@ -629,12 +630,6 @@ Users may control the workload sizes by passing the following arguments:
 
 By default, volumes are created with `ReadWriteMany` access mode as this is the recommended configuration for `VirtualMachines`.
 If not supported, the access mode may be changes by setting `--access-mode`. The supported values are `RO`, `RWO` and `RWX`.
-
-#### Temporary SSH Keys
-
-In order to verify that the VMs actually completed booting, the test generates an SSH key pair.
-By default, it stores the pair in a temporary directory.
-Users may choose the store the key in a specified directory by setting `--ssh-key-path`
 
 ### Virt Migration
 
@@ -699,13 +694,6 @@ If not set, the test will randomly choose one
 All `VirtualMachines` are created in the same namespace.
 
 By default, the namespace is `virt-migation`. Set it by passing `--namespace` (or `-n`)
-
-#### Temporary SSH Keys
-
-In order to verify that the VMs actually completed booting, the test generates an SSH key pair.
-By default, it stores the pair in a temporary directory.
-Users may choose the store the key in a specified directory by setting `--ssh-key-path`
-
 
 ### DataVolume Clone
 


### PR DESCRIPTION
## Type of change

- Documentation

## Description

Move the virtctl requirement to its own section to avoid duplications or misses

