### PR TITLE
Add virt-stop job to stabilize garbage collection

### DIFF
--- a/cmd/config/virt-density/virt-density.yml
+++ b/cmd/config/virt-density/virt-density.yml
@@ -45,3 +45,12 @@ jobs:
         replicas: 1
         inputVars:
           vmImage: {{.VM_IMAGE}}
+  - name: virt-stop
+    namespace: virt-density
+    jobType: kubevirt
+    jobIterations: 1
+    waitWhenFinished: true
+    objects:
+
+      - kubeVirtOp: stop
+        labelSelector: {kube-burner-job: virt-density}


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->

- Optimization


## Description

Adding a job to run `kubeVirtOp: stop` at the end of the test to stop all VMs which helps stabilize namespace garbage collection at scale. 


