### PR TITLE
Remove ok-to-test label requirement from build workflow

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -19,7 +19,6 @@ jobs:
     uses: ./.github/workflows/build-matrix.yml
 
   build:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     uses: ./.github/workflows/builders.yml
 
   tests:


### PR DESCRIPTION
## Type of change

- Optimization

## Description

To merge a PR this test is required to pass. As it only builds and install the kube-burner-ocp, we can consider it safe because it doesn't interact with the CI cluster.

## Related Tickets & Documents

- Related Issue #
- Closes #

