### PR TITLE
Parameterize rds-core hugepages size.

### DIFF
--- a/cmd/config/rds-core/deployment-dpdk.yml
+++ b/cmd/config/rds-core/deployment-dpdk.yml
@@ -34,11 +34,11 @@ spec:
             requests:
               cpu: {{.dpdk_cores}}
               memory: 1024M
-              hugepages-1Gi: 16Gi
+              hugepages-1Gi: {{.dpdk_hugepages}}
             limits:
               cpu: {{.dpdk_cores}}
               memory: 1024M
-              hugepages-1Gi: 16Gi
+              hugepages-1Gi: {{.dpdk_hugepages}}
           env:
             - name: stress_cpu
               value: "4"

--- a/cmd/config/rds-core/rds-core.yml
+++ b/cmd/config/rds-core/rds-core.yml
@@ -116,5 +116,6 @@ jobs:
         inputVars:
           podReplicas: 1
           dpdk_cores: {{.DPDK_CORES}}
+          dpdk_hugepages: {{.DPDK_HUGEPAGES}}
           perf_profile: {{.PERF_PROFILE}}
 

--- a/rds-core.go
+++ b/rds-core.go
@@ -29,7 +29,7 @@ func NewRDSCore(wh *workloads.WorkloadHelper) *cobra.Command {
 	var iterations, churnPercent, churnCycles, dpdkCores int
 	var churn, svcLatency bool
 	var churnDelay, churnDuration, podReadyThreshold time.Duration
-	var deletionStrategy, perfProfile string
+	var deletionStrategy, perfProfile, dpdkHugepages string
 	var metricsProfiles []string
 	var rc int
 	cmd := &cobra.Command{
@@ -49,6 +49,7 @@ func NewRDSCore(wh *workloads.WorkloadHelper) *cobra.Command {
 			AdditionalVars["CHURN_PERCENT"] = churnPercent
 			AdditionalVars["DELETION_STRATEGY"] = deletionStrategy
 			AdditionalVars["DPDK_CORES"] = dpdkCores
+			AdditionalVars["DPDK_HUGEPAGES"] = dpdkHugepages
 			AdditionalVars["JOB_ITERATIONS"] = iterations
 			AdditionalVars["PERF_PROFILE"] = perfProfile
 			AdditionalVars["POD_READY_THRESHOLD"] = podReadyThreshold
@@ -67,6 +68,7 @@ func NewRDSCore(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().IntVar(&churnPercent, "churn-percent", 10, "Percentage of job iterations that kube-burner will churn each round")
 	cmd.Flags().StringVar(&deletionStrategy, "churn-deletion-strategy", "default", "Churn deletion strategy to use")
 	cmd.Flags().IntVar(&dpdkCores, "dpdk-cores", 2, "Number of cores per DPDK pod")
+	cmd.Flags().StringVar(&dpdkHugepages, "dpdk-hugepages", "16Gi", "Number of hugepages per DPDK pod. Must be a multiple of 1Gi")
 	cmd.Flags().IntVar(&iterations, "iterations", 0, "Number of iterations/namespaces")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
 	cmd.Flags().StringVar(&perfProfile, "perf-profile", "default", "Performance profile implemented in the cluster")


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->

- New feature

## Description

hugepages were hard-coded in the rds-core workload. Now we have an argument to allow them to be configured easily and without modifying the configs.