### PR TITLE
Remove 'edited' rom pull request types

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
   workflow_dispatch:
   pull_request_target:
-    types: [opened, edited, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, labeled]
     branches:
       - master
       - main


### PR DESCRIPTION
## Type of change

- CI

## Description

The edit event fires when a PR description is modified, it shouldn't trigger the workflow