### PR TITLE
add CHURN_MODE for create-clusterextensions job

### DIFF
--- a/cmd/config/olm/olm.yml
+++ b/cmd/config/olm/olm.yml
@@ -85,6 +85,7 @@ jobs:
       duration: {{.CHURN_DURATION}}
       percent: {{.CHURN_PERCENT}}
       delay: {{.CHURN_DELAY}}
+      mode: {{.CHURN_MODE}}
     executionMode: parallel
     verifyObjects: true
     errorOnVerify: true


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->


- Bug fix


## Description

<!--- Describe your changes in detail -->

Address the panic issue: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/72959/rehearse-72959-periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-gcp-4.20-nightly-x86-olmv1-benchmark-test/2005452436046614528/artifacts/olmv1-benchmark-test/olmv1-performance/build-log.txt
```go
+ /tmp/kube-burner-ocp olm --log-level=debug --qps=20 --burst=20 --gc=true --uuid b5de6be0-b7be-4d6c-910a-c6dfd5d2bb9a --churn-duration=5m --timeout=50m --churn-mode objects --metrics-profile=/tmp/olm-metrics.yml,/tmp/extended-metrics.yml --gc-metrics=false --profile-type=both --iterations=50 --es-server=https://XXXXXX:XXXXXXXXXXXXXXXXXXXXXXXXX@search-XXXXXX-perf-scale-test-elk-hcm7wtsqpxy7xogbu72bor4uve.us-east-1.es.amazonaws.com --es-index=ripsaw-kube-burner
time="2025-12-29 02:49:48" level=info msg="❤️ Checking for Cluster Health" file="cluster-health.go:46"
...
...
time="2025-12-29 03:20:53" level=debug msg="Creating object replicas from iteration 0" file="create.go:140"
E1229 03:20:53.071580     167 panic.go:262] "Observed a panic" panic="runtime error: invalid memory address or nil pointer dereference" panicGoValue="\"invalid memory address or nil pointer dereference\"" stacktrace=<
	goroutine 5420 [running]:
	k8s.io/apimachinery/pkg/util/runtime.logPanic({0x2f664c8, 0x48d1ee0}, {0x26d5080, 0x487b690})
		/home/runner/go/pkg/mod/k8s.io/apimachinery@v0.31.1/pkg/util/runtime/runtime.go:107 +0xbc
	k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x2f664c8, 0x48d1ee0}, {0x26d5080, 0x487b690}, {0x48d1ee0, 0x0, 0x437465?})
		/home/runner/go/pkg/mod/k8s.io/apimachinery@v0.31.1/pkg/util/runtime/runtime.go:82 +0x5e
	k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc00002e540?})
		/home/runner/go/pkg/mod/k8s.io/apimachinery@v0.31.1/pkg/util/runtime/runtime.go:59 +0x108
	panic({0x26d5080?, 0x487b690?})
		/opt/hostedtoolcache/go/1.23.12/x64/src/runtime/panic.go:791 +0x132
	k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.(*Unstructured).GetKind(...)
		/home/runner/go/pkg/mod/k8s.io/apimachinery@v0.31.1/pkg/apis/meta/v1/unstructured/unstructured.go:231
	github.com/kube-burner/kube-burner/v2/pkg/burner.(*JobExecutor).createRequest.func1()
		/home/runner/go/pkg/mod/github.com/kube-burner/kube-burner/v2@v2.1.0/pkg/burner/create.go:352 +0x635
	k8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtection(0xc00114fde8?)
		/home/runner/go/pkg/mod/k8s.io/apimachinery@v0.31.1/pkg/util/wait/wait.go:145 +0x3e
	k8s.io/apimachinery/pkg/util/wait.ExponentialBackoff({0x3b9aca00, 0x4008000000000000, 0x0, 0x9, 0x0}, 0xc00202ae70)
		/home/runner/go/pkg/mod/k8s.io/apimachinery@v0.31.1/pkg/util/wait/backoff.go:461 +0x5a
	github.com/kube-burner/kube-burner/v2/pkg/util.RetryWithExponentialBackOff(0xc00114fe70, 0x3b9aca00, 0x4008000000000000, 0x0, 0x2?)
		/home/runner/go/pkg/mod/github.com/kube-burner/kube-burner/v2@v2.1.0/pkg/util/utils.go:41 +0xd6
	github.com/kube-burner/kube-burner/v2/pkg/burner.(*JobExecutor).createRequest(0xc00071e540?, {0x2f66650?, 0xc0002e15e0?}, {{0xc000765350, 0x18}, {0xc00067b15c, 0x2}, {0xc00067b160, 0xf}}, {0x0, ...}, ...)
		/home/runner/go/pkg/mod/github.com/kube-burner/kube-burner/v2@v2.1.0/pkg/burner/create.go:310 +0x1d4
	github.com/kube-burner/kube-burner/v2/pkg/burner.(*JobExecutor).replicaHandler.func1.1({0xc000894818?, 0x1?})
		/home/runner/go/pkg/mod/github.com/kube-burner/kube-burner/v2@v2.1.0/pkg/burner/create.go:251 +0x129
	created by github.com/kube-burner/kube-burner/v2/pkg/burner.(*JobExecutor).replicaHandler.func1 in goroutine 5419
		/home/runner/go/pkg/mod/github.com/kube-burner/kube-burner/v2@v2.1.0/pkg/burner/create.go:246 +0x616
 >
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x22d4975]
```
## Related Tickets & Documents

- Related Issue https://github.com/openshift/release/pull/72959
- Closes #

