### PR TITLE
Adding VM support for udn-bgp scenario

### DIFF
--- a/cmd/config/udn-bgp/udn-bgp.yml
+++ b/cmd/config/udn-bgp/udn-bgp.yml
@@ -65,6 +65,7 @@ jobs:
         inputVars:
           namespaces_per_cudn: {{.NAMESPACES_PER_CUDN}}
           total_namespaces: {{.JOB_ITERATIONS}}
+          enable_vm: {{.ENABLE_VM}}
 
   - name: udn-bgp-create-pods
     namespace: udn-bgp
@@ -86,10 +87,15 @@ jobs:
       pod-security.kubernetes.io/warn: privileged
       k8s.ovn.org/primary-user-defined-network: ""
     objects:
+    {{ if .ENABLE_VM }}
+      - objectTemplate: vm.yml
+        replicas: 1
+    {{ else }}
       - objectTemplate: pod.yml
         replicas: 1 
         inputVars:
           podReplicas: 1
+    {{ end }}
 
   - name: udn-bgp-route-advertisements
     {{- $numCudn := div .JOB_ITERATIONS .NAMESPACES_PER_CUDN }}

--- a/cmd/config/udn-bgp/vm.yml
+++ b/cmd/config/udn-bgp/vm.yml
@@ -1,0 +1,53 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: vm-test-{{.Replica}}
+  labels:
+    kubevirt.io/os: fedora
+spec:
+  runStrategy: Always
+  template:
+    metadata:
+      labels:
+        kubevirt.io/os: fedora
+    spec:
+      terminationGracePeriodSeconds: 0
+      domain:
+        resources:
+          requests:
+            memory: 256Mi
+        devices:
+          disks:
+          - name: containerdisk
+            disk:
+              bus: virtio
+          - disk:
+              bus: virtio
+            name: cloudinitdisk
+          - name: emptydisk
+            disk:
+              bus: virtio
+          interfaces:
+          - name: default
+            binding:
+              name: l2bridge
+      networks:
+      - name: default
+        pod: {}
+      volumes:
+      - name: containerdisk
+        containerDisk:
+          image: quay.io/openshift-cnv/qe-cnv-tests-fedora:40
+          imagePullPolicy: IfNotPresent
+      - name: cloudinitdisk
+        cloudInitNoCloud:
+          userData: |-
+            #cloud-config
+            password: perfscale
+            chpasswd: { expire: False }
+            runcmd:
+              - dnf install -y --nodocs httpd
+              - httpd -p 8080 -h /var/www/html
+      - name: emptydisk
+        emptyDisk:
+          capacity: "50Mi"

--- a/pkg/workloads/udn-bgp.go
+++ b/pkg/workloads/udn-bgp.go
@@ -32,6 +32,7 @@ var additionalMeasurementFactoryMap = map[string]kubeburnermeasurements.NewMeasu
 // NewUdnBgp holds udn-bgp workload
 func NewUdnBgp(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 	var iterations, namespacePerCudn int
+	var enableVm bool
 	var metricsProfiles []string
 	var rc int
 	cmd := &cobra.Command{
@@ -41,6 +42,7 @@ func NewUdnBgp(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 			setMetrics(cmd, metricsProfiles)
 			AdditionalVars["JOB_ITERATIONS"] = iterations
 			AdditionalVars["NAMESPACES_PER_CUDN"] = namespacePerCudn
+			AdditionalVars["ENABLE_VM"] = enableVm
 			wh.SetMeasurements(additionalMeasurementFactoryMap)
 			wh.SetVariables(AdditionalVars, SetVars)
 			rc = wh.Run(cmd.Name() + ".yml")
@@ -50,6 +52,7 @@ func NewUdnBgp(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 		},
 	}
 	cmd.Flags().IntVar(&iterations, "iterations", 10, fmt.Sprintf("%v iterations", variant))
+	cmd.Flags().BoolVar(&enableVm, "vm", false, "Deploy a VM for the test instead of a pod")
 	cmd.Flags().IntVar(&namespacePerCudn, "namespaces-per-cudn", 1, "Number of namespaces sharing the same cluster udn")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
 	return cmd


### PR DESCRIPTION
## Type of change

- New feature

## Description

Instead of deploying pods in udn-bgp scenario, it deploys VMs. It ensures the connectivity is working with VM configuration is working as attended.
Tested on PerformanceLab.

