### PR TITLE
Add virt-density --mounts config option

### DIFF
--- a/cmd/config/virt-density/virt-density.yml
+++ b/cmd/config/virt-density/virt-density.yml
@@ -49,7 +49,14 @@ jobs:
       pod-security.kubernetes.io/warn: privileged
     objects:
 
+{{ if .MOUNTS }}
       - objectTemplate: vm.yml
         replicas: 1
         inputVars:
           vmImage: {{.VM_IMAGE}}
+{{ else }}
+      - objectTemplate: vm-nomnt.yml
+        replicas: 1
+        inputVars:
+          vmImage: {{.VM_IMAGE}}
+{{ end }}

--- a/cmd/config/virt-density/vm-nomnt.yml
+++ b/cmd/config/virt-density/vm-nomnt.yml
@@ -1,0 +1,26 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: virt-density-nomnt-{{.Iteration}}
+spec:
+  runStrategy: Always
+  template:
+    metadata:
+      labels:
+        kubevirt.io/os: fedora
+    spec:
+      terminationGracePeriodSeconds: 0
+      domain:
+        resources:
+          requests:
+            memory: 1Gi
+        devices:
+          disks:
+          - name: containerdisk
+            disk:
+              bus: virtio
+      volumes:
+      - name: containerdisk
+        containerDisk:
+          image: {{.vmImage}}
+          imagePullPolicy: IfNotPresent

--- a/pkg/workloads/virt-density.go
+++ b/pkg/workloads/virt-density.go
@@ -30,7 +30,7 @@ func NewVirtDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 	var vmImage, deletionStrategy, churnMode string
 	var vmsPerNode, iterationsPerNamespace, churnPercent, churnCycles int
 	var vmiRunningThreshold time.Duration
-	var namespacedIterations bool
+	var namespacedIterations, mounts bool
 	var churnDelay, churnDuration time.Duration
 	var metricsProfiles []string
 	var rc int
@@ -56,6 +56,7 @@ func NewVirtDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 			AdditionalVars["CHURN_PERCENT"] = churnPercent
 			AdditionalVars["CHURN_MODE"] = churnMode
 			AdditionalVars["DELETION_STRATEGY"] = deletionStrategy
+			AdditionalVars["MOUNTS"] = mounts
 			setMetrics(cmd, metricsProfiles)
 			AddVirtMetadata(wh, vmImage, "", "")
 
@@ -71,6 +72,7 @@ func NewVirtDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().BoolVar(&namespacedIterations, "namespaced-iterations", false, "Namespaced iterations")
 	cmd.Flags().IntVar(&iterationsPerNamespace, "iterations-per-namespace", 10, "Iterations per namespace")
 	cmd.Flags().StringVar(&vmImage, "vm-image", "quay.io/openshift-cnv/qe-cnv-tests-fedora:40", "Vm Image to be deployed")
+	cmd.Flags().BoolVar(&mounts, "mounts", true, "Include cloud-init and emptyDir disks (true) or only the containerDisk (false)")
 	cmd.Flags().StringVar(&deletionStrategy, "deletion-strategy", config.GVRDeletionStrategy, "GC deletion mode, default deletes entire namespaces and gvr deletes objects within namespaces before deleting the parent namespace")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
 	cmd.Flags().IntVar(&churnCycles, "churn-cycles", 0, "Churn cycles to execute")


### PR DESCRIPTION
## Type of change

- New feature

## Description
Adding a --mounts option to control if cloud-init and emptyDisk volumes are included in the VM definition. Default is "true" which keeps the existing behavior. 
