### PR TITLE
Fix build-farm to use metrics profile-type flag for ES indexing

### DIFF
--- a/cmd/config/build-farm/build-farm.yml
+++ b/cmd/config/build-farm/build-farm.yml
@@ -8,7 +8,7 @@ global:
 
 metricsEndpoints:
 {{ if .ES_SERVER }}
-  - metrics: [metrics.yml]
+  - metrics: [{{.METRICS}}]
     alerts: [{{.ALERTS}}]
     indexer:
       esServers: ["{{.ES_SERVER}}"]


### PR DESCRIPTION
The ES_SERVER metrics endpoint had metrics.yml hardcoded instead of using the {{.METRICS}} template variable, causing the --profile-type flag to be ignored when indexing to Elasticsearch.