### PR TITLE
Replace deprecated running VM parameter with runStrategy

### DIFF
--- a/cmd/config/virt-capacity-benchmark/templates/vm.yml
+++ b/cmd/config/virt-capacity-benchmark/templates/vm.yml
@@ -51,7 +51,7 @@ spec:
           requests:
             storage: {{ $dataVolumeSize }}
   {{ end }}
-  running: true
+  runStrategy: RerunOnFailure
   template:
     spec:
       accessCredentials:


### PR DESCRIPTION
## Type of change

- Bug fix

## Description

Replace the deprecated `running` parameter in VM definitions with the recommended `runStrategy`

## Related Tickets & Documents

- Related Issue #
- Closes #

