### PR TITLE
Replace global measurements with per-job measurements in virt workloads

### DIFF
--- a/cmd/config/virt-capacity-benchmark/virt-capacity-benchmark.yml
+++ b/cmd/config/virt-capacity-benchmark/virt-capacity-benchmark.yml
@@ -17,10 +17,6 @@
 {{- $testNamespacesLabelValue := $testName -}}
 {{- $metricsBaseDirectory := $testName -}}
 ---
-global:
-  measurements:
-  - name: vmiLatency
-
 metricsEndpoints:
 - indexer:
     type: local
@@ -41,6 +37,9 @@ jobs:
 {{ end }}
 
 - name: create-vms
+  measurements:
+  - name: vmiLatency
+  - name: dataVolumeLatency
   jobType: create
   jobIterations: 1
   qps: 20
@@ -164,6 +163,8 @@ jobs:
       {{ $jobCounterLabelKey }}: {{ $jobCounterLabelValue }}
 
 - name: snapshot-vms
+  measurements:
+  - name: volumeSnapshotLatency
   jobType: create
   qps: 20
   burst: 20
@@ -202,6 +203,8 @@ jobs:
 
 {{ if not .skipMigrationJob }}
 - name: migrate-vms
+  measurements:
+  - name: vmimLatency
   jobType: kubevirt
   qps: 20
   burst: 20

--- a/cmd/config/virt-clone/virt-clone.yml
+++ b/cmd/config/virt-clone/virt-clone.yml
@@ -12,11 +12,6 @@
 {{- $createCloneVMJobName := "create-clone-vms" -}}
 {{- $cloneVMName := "clone-vm" -}}
 
-global:
-  measurements:
-  - name: vmiLatency
-  - name: dataVolumeLatency
-
 metricsEndpoints:
 - indexer:
     type: local
@@ -34,6 +29,9 @@ jobs:
       {{ $testNamespacesLabelKey }}: {{ $testNamespacesLabelValue }}
 
 - name: {{ $createBaseVMJobName }}
+  measurements:
+  - name: vmiLatency
+  - name: dataVolumeLatency
   jobType: create
   jobIterations: 1
   qps: 20
@@ -92,6 +90,8 @@ jobs:
 
 # Create the DV in a separate job to make sure it is ready before continuing
 - name: create-base-image-dv
+  measurements:
+  - name: dataVolumeLatency
   jobType: create
   jobIterations: 1
   qps: 20
@@ -179,6 +179,9 @@ jobs:
         value: "True"
 
 - name: {{ $createCloneVMJobName }}
+  measurements:
+  - name: vmiLatency
+  - name: dataVolumeLatency
   jobType: create
   jobIterations: {{ .iterations }}
   qps: 20

--- a/cmd/config/virt-ephemeral-restart/virt-ephemeral-restart.yml
+++ b/cmd/config/virt-ephemeral-restart/virt-ephemeral-restart.yml
@@ -7,11 +7,6 @@
 {{- $vmName := "ephemeral-vm" -}}
 {{- $sshPublicKeySecretName := "burner-clone-virt-ephemeral-restart" -}}
 
-global:
-  measurements:
-  - name: vmiLatency
-  - name: dataVolumeLatency
-
 metricsEndpoints:
 - indexer:
     type: local
@@ -29,7 +24,9 @@ jobs:
       {{ $testNamespacesLabelKey }}: {{ $testNamespacesLabelValue }}
 
 # Create the DV in a separate job to make sure it is ready before continuing
-- name: create-base-image-dv
+- name: create-base-image-dv-ephemeral
+  measurements:
+  - name: dataVolumeLatency
   jobType: create
   jobIterations: 1
   qps: 20
@@ -109,6 +106,9 @@ jobs:
         value: "True"
 
 - name: {{ $createVMsJobName }}
+  measurements:
+  - name: vmiLatency
+  - name: dataVolumeLatency
   jobType: create
   jobIterations: {{ .vmGroups | len }}
   qps: 20

--- a/cmd/config/virt-migration/virt-migration.yml
+++ b/cmd/config/virt-migration/virt-migration.yml
@@ -5,11 +5,6 @@
 {{- $createMigratingVMsJobName := "create-migrating-vms" -}}
 {{- $createLoadVMsJobName := "create-load-vms" -}}
 ---
-global:
-  measurements:
-  - name: vmiLatency
-  - name: vmimLatency
-
 metricsEndpoints:
 - indexer:
     type: local
@@ -27,6 +22,9 @@ jobs:
       {{ $testNamespacesLabelKey }}: {{ $testName }}
 
 - name: {{ $createMigratingVMsJobName }}
+  measurements:
+  - name: vmiLatency
+  - name: dataVolumeLatency
   jobType: create
   jobIterations: {{ .vmCreateIterations }}
   qps: 20
@@ -73,6 +71,9 @@ jobs:
 
 {{- if gt .loadVMsPerIteration 0 }}
 - name: {{ $createLoadVMsJobName }}
+  measurements:
+  - name: vmiLatency
+  - name: dataVolumeLatency
   jobType: create
   jobIterations: {{ .loadVMsIterations }}
   qps: 20
@@ -127,6 +128,8 @@ jobs:
       objectTemplate: templates/remove_affinity_patch.yml
 
 - name: migrate-vms
+  measurements:
+  - name: vmimLatency
   jobType: kubevirt
   qps: {{ .migrationQPS }}
   burst: {{ .migrationQPS }}


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->

- Bug fix

## Description

This PR moves measurement configuration from a global scope to a per-job level for virt workloads, allowing each job to define its own metrics independently and improving flexibility for analysis

## Related Tickets & Documents

- Related Issue #
- Closes #

