### PR TITLE
Skip cloudinitdisk when listing devices in the check_resize function

### DIFF
--- a/cmd/config/scripts/check.sh
+++ b/cmd/config/scripts/check.sh
@@ -101,7 +101,7 @@ check_resize() {
     fi
 
     local datavolume_sizes
-    datavolume_sizes=$(echo "${blk_devices}" | jq .blockdevices | jq -r --arg name "vda" '.[] | select(.name != $name) | .size')
+    datavolume_sizes=$(echo "${blk_devices}" | jq -r --arg name "vda" '.blockdevices[] | select(.name != $name and .size != "1M") | .size')
     for datavolume_size in ${datavolume_sizes}; do
         if [[ $datavolume_size != "${EXPECTED_DATA_SIZE}" ]]; then
             return 1


### PR DESCRIPTION
## Type of change

- Bug fix

## Description

Since the inclusion of `cloudinitdisk` in [this commit](https://github.com/kube-burner/kube-burner-ocp/commit/67084014387835c33cd75a15412fc1c913bb1156), the `check_resize` function in `check.sh` started failing, causing the virt-capacity-benchmark scenario to hang indefinitely.

With this fix, the `cloudinitdisk` device is excluded from the `check_resize` logic, as it is not a resizable disk. This prevents incorrect device detection and avoids false resize validation errors.

The issue was initially observed in [issue #367](https://github.com/kube-burner/kube-burner-ocp/issues/367), although the root cause was not identified at that time.

## Related Tickets & Documents

- Related Issue #
- Closes #

