### PR TITLE
Add cudn-density workload for CUDN scale testing

### DIFF
--- a/cmd/config/cudn-density/README.md
+++ b/cmd/config/cudn-density/README.md
@@ -1,0 +1,404 @@
+# cudn-density Workload
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Architecture](#architecture)
+  - [CUDN Grouping Model](#cudn-grouping-model)
+  - [Network Topology](#network-topology)
+  - [Per-Namespace Objects](#per-namespace-objects)
+  - [Communication Model](#communication-model)
+  - [Cross-Namespace Traffic Pattern](#cross-namespace-traffic-pattern)
+  - [OVN-K Load Profile](#ovn-k-load-profile)
+- [Job Pipeline](#job-pipeline)
+  - [Why the DaemonSet Step?](#why-the-daemonset-step)
+  - [Why the CUDN Cleanup Step?](#why-the-cudn-cleanup-step)
+- [Measurements](#measurements)
+  - [Pod Latency](#pod-latency)
+  - [CUDN Latency](#cudn-latency-job-2)
+  - [Metrics Profiles](#metrics-profiles)
+  - [pprof Collection](#pprof-collection)
+- [Usage](#usage)
+  - [Basic Run](#basic-run)
+  - [Layer 3 with Local Indexing](#layer-3-with-local-indexing)
+  - [Simple Mode](#simple-mode-no-npsegressfwquotas)
+  - [With Churn](#with-churn)
+  - [With pprof and OpenSearch Indexing](#with-pprof-and-opensearch-indexing)
+- [CLI Flags](#cli-flags)
+- [Scale Considerations](#scale-considerations)
+  - [Scaling Knobs](#scaling-knobs)
+- [Cleanup](#cleanup)
+- [File Inventory](#file-inventory)
+
+---
+
+## Overview
+
+`cudn-density` is a kube-burner-ocp workload that stress-tests **OVN-Kubernetes** networking at scale using **ClusterUserDefinedNetworks (CUDNs)**. It simulates a multi-tenant environment where groups of namespaces share a primary CUDN and run a 3-tier microservice application with cross-namespace communication, network policies, egress firewalls, and resource quotas.
+
+The workload measures:
+
+- **CUDN creation latency** — how fast OVN-K can provision a new shared network
+- **Cross-namespace pod readiness** — how fast pods can communicate across namespace boundaries on a CUDN primary network
+- **OVN-K control plane resource consumption** — CPU, memory, and flow programming metrics under load
+
+---
+
+## Architecture
+
+### CUDN Grouping Model
+
+Namespaces are organized into **CUDN groups**. Each group shares a single ClusterUserDefinedNetwork as its primary network. By default, each group contains 5 namespaces (configurable via [`--namespaces-per-cudn`](#cli-flags)). Traffic flows only within each group — cross-group traffic is blocked by [NetworkPolicies](#3-tier-communication-model).
+
+```
+CUDN-0 (primary network)          CUDN-1 (primary network)
+├── cudn-density-0                 ├── cudn-density-5
+├── cudn-density-1                 ├── cudn-density-6
+├── cudn-density-2                 ├── cudn-density-7
+├── cudn-density-3                 ├── cudn-density-8
+└── cudn-density-4                 └── cudn-density-9
+```
+
+With `--iterations=10 --namespaces-per-cudn=5`, 2 CUDNs are created, each spanning 5 namespaces. The `--iterations` value must be divisible by `--namespaces-per-cudn`.
+
+### Network Topology
+
+Each CUDN can use either **Layer 2** (default) or **Layer 3** (`--layer3`) topology:
+
+| Topology | Subnet | Routing | Use Case |
+|----------|--------|---------|----------|
+| **Layer 2** | Shared `10.132.0.0/16` per CUDN | Flat L2, direct pod-to-pod | Default, simpler |
+| **Layer 3** | Unique `/16` per CUDN (e.g., `40.0.0.0/16`) | Per-node `/24` host subnets, routed | Production-like, scalable |
+
+### Per-Namespace Objects
+
+Each namespace contains the following objects (in full mode):
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Namespace: cudn-density-N                     │
+│                                                                  │
+│  Deployments (9 pods total)          Services (5)                │
+│  ┌─────────────────────┐             ┌──────────────────────┐    │
+│  │ server-1 (3 pods)   │◄────────────│ cudn-svc (8080/8443) │    │
+│  │ server-2 (3 pods)   │◄────────────│ server-1-svc         │    │
+│  │ app-1    (2 pods)   │◄────────────│ server-2-svc         │    │
+│  │ client-1 (1 pod)    │             │ cudn-app-headless    │    │
+│  └─────────────────────┘             └──────────────────────┘    │
+│                                                                  │
+│  NetworkPolicies (5)                 Other                       │
+│  ┌─────────────────────┐             ┌──────────────────────┐    │
+│  │ deny-all            │             │ EgressFirewall (9    │    │
+│  │ allow-cudn-ingress  │             │   rules)             │    │
+│  │ allow-cudn-egress   │             │ ResourceQuota        │    │
+│  │ allow-app-ingress   │             │ LimitRange           │    │
+│  │ allow-app-egress    │             │ ConfigMap            │    │
+│  └─────────────────────┘             └──────────────────────┘    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+With [`--simple`](#cli-flags), only the main service, deployments, and configmap are created (no NPs, EgressFirewall, quotas, or limits).
+
+### Communication Model
+
+The workload deploys a 3-tier structure (client, app, server) but only the **client → server** path carries actual traffic. The app tier and its network policies exist to generate additional OVN-K load (logical ports, ACLs, address sets).
+
+```
+  Actual traffic:
+  ───────────────
+
+   ┌──────────┐                           ┌──────────┐         ┌──────────┐
+   │  CLIENT  │──── HTTP :8080 ──────────►│  SERVER  │         │   APP    │
+   │  (curl)  │     via cudn-svc          │  (nginx) │         │(sampleapp│
+   └──────────┘                           │  :8080   │         │  :8080   │
+     1 pod/ns                             │  :8443   │         │          │
+                                          └──────────┘         └──────────┘
+                                        6 pods/ns (2 x 3)      2 pods/ns
+```
+
+**NetworkPolicy enforcement:**
+
+| Policy | Selector | Allows | Exercised? |
+|--------|----------|--------|------------|
+| `deny-all` | all pods | Nothing (baseline) | Yes — blocks cross-group traffic |
+| `allow-cudn-ingress` | `app=nginx` | Ingress from `client` and `sampleapp` within CUDN group | **Yes** — client curls nginx |
+| `allow-cudn-egress` | `app=client` | Egress to `nginx` and `sampleapp` within CUDN group + DNS | **Yes** — client curls + DNS |
+| `allow-app-ingress` | `app=sampleapp` | Ingress from `client` within CUDN group | No — OVN-K load only |
+| `allow-app-egress` | `app=sampleapp` | Egress to `nginx` within CUDN group + DNS | No — OVN-K load only |
+
+> **Note:** NetworkPolicies use **named ports** (`http`, `https`) instead of numeric ports, forcing OVN-K to resolve port names against pod specs — a more expensive code path that generates more ACL computation.
+
+### Cross-Namespace Traffic Pattern
+
+Each client generates continuous HTTP traffic to peer namespaces within its CUDN group:
+
+```
+CUDN-0 group (namespaces 0-4):
+
+  Continuous traffic (every 10s):             Readiness probes (every 1s):
+  ─────────────────────────                   ────────────────────────────
+  client in ns-0 → curls ns-1, ns-2, ns-3, ns-4    probes ns-1
+  client in ns-1 → curls ns-2, ns-3, ns-4          probes ns-2
+  client in ns-2 → curls ns-3, ns-4                probes ns-3
+  client in ns-3 → curls ns-4                      probes ns-4
+  client in ns-4 → sleeps (last in group)           probes ns-0 (wraps)
+```
+
+**Key design choices:**
+
+- **Readiness probes target peer namespaces** — the client pod only becomes `Ready` when cross-namespace CUDN networking is fully plumbed. The `Ready` latency directly measures end-to-end CUDN network readiness, not just local container startup.
+- **Directed pipeline** — each client curls namespaces ahead of it, avoiding redundant bidirectional traffic.
+- **Wrap-around readiness** — the last namespace in each group probes the first, forming a ring that validates the entire CUDN group.
+
+### OVN-K Load Profile
+
+| OVN-K Component | Load Source |
+|-----------------|------------|
+| **Logical switch ports** | 9 pods/ns + transient DaemonSet pods |
+| **OVN load balancers** | 5 services/ns, each with dual ports (8080+8443) |
+| **ACLs** | 5 NetworkPolicies/ns with cross-namespace selectors and named ports |
+| **Address sets** | Each NP with `namespaceSelector` creates an address set spanning the CUDN group |
+| **EgressFirewall rules** | 8 rules/ns (CIDR + DNS-based) |
+| **NADs** | 1 per namespace, managed by the CUDN controller |
+| **Network plumbing** | CNI plugin creates OVS ports + flows for each pod on the primary CUDN |
+| **Endpoint tracking** | EndpointSlices for 5 services, headless service resolves to individual pod IPs |
+
+---
+
+## Job Pipeline
+
+```
+Job 1          Job 2           Job 3         Job 4          Job 5          Job 6         Job 7        Job 8
+Create         Create          Deploy        Remove         Deploy         Deploy        Cleanup      Cleanup
+Namespaces     CUDNs           DaemonSets    DaemonSets     Infra          Workload      Namespaces   CUDNs
+───────── ──►  ────────── ──►  ────────── ►  ────────── ►  ────────── ──►  ────────── ►  ────────── ► ──────
+ N ns          N/G CUDNs       N DaemonSets  (delete)       Services       Deployments   (GC only)    (GC only)
+ + configmap   wait for        force OVN                    NPs            Pods          no-wait       wait
+               NetworkCreated  allocation                   EgressFW       2m metrics
+               measure latency on all nodes                 Quotas         pause
+```
+
+| # | Job Name | Type | What It Does |
+|---|----------|------|-------------|
+| 1 | `cudn-density-create-namespaces` | create | Creates N namespaces with UDN labels + a configmap per namespace |
+| 2 | `cudn-density-create-cudn-l2/l3` | create | Creates N/group_size CUDNs, waits for `NetworkCreated=True`. [Measures CUDN latency](#cudn-latency-job-2) |
+| 3 | `cudn-density-ds` | create | Deploys a DaemonSet per namespace to [force OVN network allocation](#why-the-daemonset-step) on all worker nodes |
+| 4 | `cudn-density-remove-ds` | delete | Removes DaemonSets (they served their purpose) |
+| 5 | `cudn-density-infra` | create | Deploys services, NetworkPolicies, EgressFirewall, ResourceQuota, and LimitRange (skipped with `--simple`) |
+| 6 | `cudn-density-workload` | create | Deploys server, app, and client deployments. Pauses 2m after deployment for [metrics collection](#metrics-profiles) |
+| 7 | `cudn-density-cleanup-namespaces` | delete | [Deletes namespaces](#why-the-cudn-cleanup-step) without waiting (only when `--gc=true`). Pods are killed, NADs start terminating |
+| 8 | `cudn-density-cleanup-cudns` | delete | [Deletes CUDNs](#why-the-cudn-cleanup-step), releasing NAD finalizers so namespaces finish terminating (only when `--gc=true`) |
+
+### Why the DaemonSet Step?
+
+CUDNs currently only report a `NetworkCreated` condition (confirming NADs were created), but not `NetworkAllocationSucceeded` (confirming the network is allocated on every node). The DaemonSet forces pods onto all worker nodes, which triggers OVN to complete network allocation before the real workload deploys. This prevents pod scheduling failures due to unallocated networks.
+
+### Why the CUDN Cleanup Step?
+
+CUDNs have a finalizer (`k8s.ovn.org/user-defined-network-protection`) that prevents deletion while NADs exist. NADs live inside namespaces and have their own finalizers managed by the CUDN controller. This creates a dependency chain:
+
+```
+Namespace deletion blocked by → NAD finalizer blocked by → CUDN existence
+```
+
+Job 7 deletes namespaces without waiting (`waitForDeletion: false`), then Job 8 deletes CUDNs (`waitForDeletion: true`), releasing the finalizers so namespaces finish terminating. See [Cleanup](#cleanup) for manual cleanup instructions.
+
+---
+
+## Measurements
+
+### Pod Latency
+
+Standard kube-burner pod latency measurement tracking `PodScheduled`, `Initialized`, `ContainersReady`, and `Ready` conditions. Only indexed for Jobs 2 and 6:
+
+- **Job 2**: Empty (CUDNs are cluster-scoped, no pods)
+- **Job 6**: The meaningful measurement — includes OVN network plumbing time + cross-namespace readiness probe validation
+
+> **Note:** The `Ready` latency in Job 6 is higher than typical workloads because the readiness probe validates **cross-namespace** connectivity over the CUDN, not just local container readiness. This is by design — it directly measures CUDN network plumbing time.
+
+### CUDN Latency (Job 2)
+
+Custom measurement (`cudnLatency`) that tracks how long each CUDN takes from creation to `NetworkCreated=True`. Uses the condition's `lastTransitionTime` for accurate measurement rather than wall-clock time. Results are indexed as `cudnLatencyMeasurement` documents with `NetworkCreatedLatency` in milliseconds.
+
+### Metrics Profiles
+
+Two metrics profiles are collected by default:
+
+- **`metrics.yml`**: Standard OpenShift/kube metrics
+- **`metrics-cudn.yml`**: OVN-K specific metrics including:
+  - ovnkube-controller CPU/memory per pod per node
+  - ovnkube-cluster-manager CPU/memory
+  - ovs-vswitchd CPU/memory
+  - CRI-O network setup/teardown latency P99
+  - NetworkPolicy count
+  - OVN Northbound DB tx/rx bytes
+  - OpenFlow rule count per bridge
+
+### pprof Collection
+
+With [`--pprof`](#cli-flags), CPU and heap profiles are collected from ovnkube-controller and ovnkube-control-plane at configurable intervals (`--pprof-interval`).
+
+---
+
+## Usage
+
+### Basic Run
+
+```bash
+kube-burner-ocp cudn-density --iterations=50
+```
+
+### Layer 3 with Local Indexing
+
+```bash
+kube-burner-ocp cudn-density \
+  --iterations=100 \
+  --layer3 \
+  --namespaces-per-cudn=10 \
+  --local-indexing
+```
+
+### Simple Mode (no NPs/EgressFW/Quotas)
+
+```bash
+kube-burner-ocp cudn-density \
+  --iterations=50 \
+  --simple
+```
+
+### With Churn
+
+> **Important:** Only `--churn-mode=objects` is supported. Namespace churn is not supported because [CUDN finalizers block namespace deletion](#why-the-cudn-cleanup-step).
+
+```bash
+kube-burner-ocp cudn-density \
+  --iterations=50 \
+  --churn-duration=30m \
+  --churn-percent=20 \
+  --churn-delay=1m
+```
+
+### With pprof and OpenSearch Indexing
+
+```bash
+kube-burner-ocp cudn-density \
+  --iterations=100 \
+  --pprof \
+  --pprof-interval=5m \
+  --es-server=https://opensearch.example.com \
+  --es-index=cudn-density
+```
+
+---
+
+## CLI Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--iterations` | *(required)* | Total number of namespaces to create |
+| `--namespaces-per-cudn` | `5` | Namespaces per CUDN group. `iterations` must be divisible by this value |
+| `--layer3` | `false` | Use Layer3 topology (default is Layer2). See [Network Topology](#network-topology) |
+| `--simple` | `false` | Skip NetworkPolicies, EgressFirewall, ResourceQuota, LimitRange, and per-server services |
+| `--pod-ready-threshold` | `2m` | P99 pod ready timeout threshold |
+| `--pprof` | `false` | Enable [pprof collection](#pprof-collection) for ovnkube components |
+| `--pprof-interval` | `0` | Interval between pprof collections |
+| `--churn-cycles` | `0` | Number of churn cycles to execute |
+| `--churn-duration` | `0` | Total churn duration |
+| `--churn-delay` | `2m` | Delay between churn rounds |
+| `--churn-percent` | `10` | Percentage of iterations churned per round |
+| `--churn-mode` | `objects` | Churn mode (`objects` only; `namespaces` [not supported](#why-the-cudn-cleanup-step)) |
+| `--metrics-profile` | `metrics.yml,metrics-cudn.yml` | Comma-separated list of [metrics profiles](#metrics-profiles) to use |
+| `--gc` | `true` | Garbage collect created resources on completion. See [Cleanup](#cleanup) |
+
+---
+
+## Scale Considerations
+
+With default `--namespaces-per-cudn=5`:
+
+| Iterations | CUDNs | Namespaces | Pods/ns | Total Pods | Services/ns | NPs/ns | OVN LB entries |
+|-----------|-------|------------|---------|------------|-------------|--------|----------------|
+| 10 | 2 | 10 | 9 | 90 | 5 | 5 | 100 |
+| 50 | 10 | 50 | 9 | 450 | 5 | 5 | 500 |
+| 100 | 20 | 100 | 9 | 900 | 5 | 5 | 1,000 |
+| 500 | 100 | 500 | 9 | 4,500 | 5 | 5 | 5,000 |
+
+OVN LB entries = services/ns x 2 ports x namespaces. DaemonSet pods (transient, [Job 3-4](#job-pipeline)) add `worker_nodes x namespaces` pods temporarily.
+
+### Scaling Knobs
+
+| Knob | Impact | Description |
+|------|--------|-------------|
+| `--namespaces-per-cudn` | **High** | Most impactful for NP/address-set load. Each NP with cross-namespace selectors creates address sets spanning all namespaces in the CUDN group. Going from 5 → 20 quadruples the address set size |
+| `--iterations` | **High** | Controls total namespace count. More namespaces = more pods, services, NPs, and OVN logical ports |
+| `--simple` | **Medium** | Removes all infra objects (NPs, services, EgressFW, quotas). Useful to isolate pure pod/network plumbing performance from policy overhead |
+| `--layer3` | **Low** | L3 uses per-node subnets and routing, slightly more OVN-K work than flat L2 |
+
+---
+
+## Cleanup
+
+Due to CUDN finalizers, manual cleanup requires a specific order:
+
+```bash
+# 1. Delete namespaces first (removes pods, then NADs start terminating)
+oc delete ns -l kube-burner.io/uuid --wait=false
+
+# 2. Delete CUDNs (releases NAD finalizers, allowing namespaces to finish terminating)
+oc delete clusteruserdefinednetworks --all
+```
+
+> **Note:** With `--gc=true`, this is handled automatically by [Job 7](#job-pipeline).
+
+---
+
+## File Inventory
+
+### Job Configuration
+
+| File | Description |
+|------|-------------|
+| [`cudn-density.yml`](cudn-density.yml) | Main job configuration with 8-job pipeline |
+
+### Network Templates
+
+| File | Description |
+|------|-------------|
+| [`cudn-l2.yml`](cudn-l2.yml) | ClusterUserDefinedNetwork template (Layer2 topology) |
+| [`cudn-l3.yml`](cudn-l3.yml) | ClusterUserDefinedNetwork template (Layer3 topology) |
+
+### Workload Templates
+
+| File | Description |
+|------|-------------|
+| [`deployment-server.yml`](deployment-server.yml) | nginx server deployment (named ports: `http`/`https`) |
+| [`deployment-app.yml`](deployment-app.yml) | sampleapp middleware deployment |
+| [`deployment-client.yml`](deployment-client.yml) | curl client with cross-namespace traffic + [readiness probes](#cross-namespace-traffic-pattern) |
+| [`ds.yml`](ds.yml) | DaemonSet to [trigger network allocation](#why-the-daemonset-step) on all nodes |
+| [`configmap.yml`](configmap.yml) | Configmap to trigger namespace creation |
+
+### Service Templates
+
+| File | Description |
+|------|-------------|
+| [`service.yml`](service.yml) | ClusterIP service for nginx (dual port: 8080+8443) |
+| [`service-headless.yml`](service-headless.yml) | Headless service for sampleapp |
+| [`service-server.yml`](service-server.yml) | Per-server-deployment ClusterIP service (dual port) |
+
+### NetworkPolicy Templates
+
+| File | Description |
+|------|-------------|
+| [`np-deny-all.yml`](np-deny-all.yml) | Default deny-all NetworkPolicy (ingress + egress) |
+| [`np-allow-cudn-ingress.yml`](np-allow-cudn-ingress.yml) | Ingress to nginx from client/app (named ports, CUDN group scoped) |
+| [`np-allow-cudn-egress.yml`](np-allow-cudn-egress.yml) | Egress from client to nginx/app (named ports, CUDN group scoped) |
+| [`np-allow-app-ingress.yml`](np-allow-app-ingress.yml) | Ingress to sampleapp from client (CUDN group scoped) |
+| [`np-allow-app-egress.yml`](np-allow-app-egress.yml) | Egress from sampleapp to nginx (named ports, CUDN group scoped) |
+
+### Infrastructure Templates
+
+| File | Description |
+|------|-------------|
+| [`egressfirewall.yml`](egressfirewall.yml) | OVN EgressFirewall (9 rules: RFC1918, DNS, registries, monitoring) |
+| [`resourcequota.yml`](resourcequota.yml) | ResourceQuota per namespace |
+| [`limitrange.yml`](limitrange.yml) | LimitRange per namespace |

--- a/cmd/config/cudn-density/configmap.yml
+++ b/cmd/config/cudn-density/configmap.yml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{.JobName}}-{{.Replica}}
+data:
+  key1: "{{randAlphaNum 2048}}"

--- a/cmd/config/cudn-density/cudn-density.yml
+++ b/cmd/config/cudn-density/cudn-density.yml
@@ -2,13 +2,8 @@
 global:
   gc: {{.GC}}
   gcMetrics: {{.GC_METRICS}}
-  measurements:
-    - name: podLatency
-      thresholds:
-        - conditionType: Ready
-          metric: P99
-          threshold: {{.POD_READY_THRESHOLD}}
 {{ if .PPROF }}
+  measurements:
     - name: pprof
       pprofInterval: {{.PPROF_INTERVAL}}
       pprofDirectory: pprof-data
@@ -77,7 +72,6 @@ jobs:
     burst: {{.BURST}}
     namespacedIterations: false
     waitWhenFinished: true
-    jobPause: 2m
     measurements:
       - name: cudnLatency
     objects:
@@ -202,6 +196,12 @@ jobs:
     namespacedIterations: true
     waitWhenFinished: true
     preLoadImages: true
+    measurements:
+      - name: podLatency
+        thresholds:
+          - conditionType: Ready
+            metric: P99
+            threshold: {{.POD_READY_THRESHOLD}}
     churnConfig:
       cycles: {{.CHURN_CYCLES}}
       duration: {{.CHURN_DURATION}}

--- a/cmd/config/cudn-density/cudn-density.yml
+++ b/cmd/config/cudn-density/cudn-density.yml
@@ -1,0 +1,268 @@
+---
+global:
+  gc: {{.GC}}
+  gcMetrics: {{.GC_METRICS}}
+  measurements:
+    - name: podLatency
+      thresholds:
+        - conditionType: Ready
+          metric: P99
+          threshold: {{.POD_READY_THRESHOLD}}
+{{ if .PPROF }}
+    - name: pprof
+      pprofInterval: {{.PPROF_INTERVAL}}
+      pprofDirectory: pprof-data
+      pprofTargets:
+      - name: ovnkube-controller-heap
+        namespace: "openshift-ovn-kubernetes"
+        labelSelector: {app: ovnkube-node}
+        url: http://localhost:29103/debug/pprof/heap
+      - name: ovnkube-controller-cpu
+        namespace: "openshift-ovn-kubernetes"
+        labelSelector: {app: ovnkube-node}
+        url: http://localhost:29103/debug/pprof/profile?seconds=30
+      - name: ovnk-control-plane-heap
+        namespace: "openshift-ovn-kubernetes"
+        labelSelector: {app: ovnkube-control-plane}
+        url: http://localhost:29108/debug/pprof/heap
+      - name: ovnk-control-plane-cpu
+        namespace: "openshift-ovn-kubernetes"
+        labelSelector: {app: ovnkube-control-plane}
+        url: http://localhost:29108/debug/pprof/profile?seconds=30
+{{ end }}
+metricsEndpoints:
+{{ if .ES_SERVER }}
+  - metrics: [{{.METRICS}}]
+    alerts: [{{.ALERTS}}]
+    indexer:
+      esServers: ["{{.ES_SERVER}}"]
+      insecureSkipVerify: true
+      defaultIndex: {{.ES_INDEX}}
+      type: opensearch
+{{ end }}
+{{ if .LOCAL_INDEXING }}
+  - metrics: [{{.METRICS}}]
+    alerts: [{{.ALERTS}}]
+    indexer:
+      type: local
+      metricsDirectory: collected-metrics-{{.UUID}}
+{{ end }}
+
+{{ $cudnJobName := ternary "cudn-density-create-cudn-l3" "cudn-density-create-cudn-l2" .ENABLE_LAYER_3 }}
+jobs:
+  # Job 1: Create namespaces with CUDN labels
+  - name: cudn-density-create-namespaces
+    namespace: cudn-density
+    jobIterations: {{.JOB_ITERATIONS}}
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    namespacedIterations: true
+    waitWhenFinished: true
+    skipIndexing: true
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+      k8s.ovn.org/primary-user-defined-network: ""
+    objects:
+      - objectTemplate: configmap.yml
+        replicas: 1
+
+  # Job 2: Create CUDNs (cluster-scoped)
+  - name: {{ $cudnJobName }}
+    {{- $numCudn := div .JOB_ITERATIONS .NAMESPACES_PER_CUDN }}
+    jobIterations: {{$numCudn}}
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    namespacedIterations: false
+    waitWhenFinished: true
+    jobPause: 2m
+    measurements:
+      - name: cudnLatency
+    objects:
+      {{ if .ENABLE_LAYER_3 }}
+      - objectTemplate: cudn-l3.yml
+        replicas: 1
+        inputVars:
+          namespaces_per_cudn: {{.NAMESPACES_PER_CUDN}}
+          total_namespaces: {{.JOB_ITERATIONS}}
+        waitOptions:
+          customStatusPaths:
+            - key: .conditions[] | select(.type=="NetworkCreated") | .status
+              value: "True"
+      {{ else }}
+      - objectTemplate: cudn-l2.yml
+        replicas: 1
+        inputVars:
+          namespaces_per_cudn: {{.NAMESPACES_PER_CUDN}}
+          total_namespaces: {{.JOB_ITERATIONS}}
+        waitOptions:
+          customStatusPaths:
+            - key: .conditions[] | select(.type=="NetworkCreated") | .status
+              value: "True"
+      {{ end }}
+
+  # Job 3: Deploy DaemonSets to trigger network allocation on all nodes
+  - name: cudn-density-ds
+    namespace: cudn-density
+    jobIterations: {{.JOB_ITERATIONS}}
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    namespacedIterations: true
+    waitWhenFinished: true
+    skipIndexing: true
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+      k8s.ovn.org/primary-user-defined-network: ""
+    objects:
+      - objectTemplate: ds.yml
+        replicas: 1
+
+  # Job 4: Remove DaemonSets
+  - name: cudn-density-remove-ds
+    jobType: delete
+    waitForDeletion: true
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    skipIndexing: true
+    objects:
+      - kind: DaemonSet
+        apiVersion: apps/v1
+        labelSelector: {kube-burner.io/job: cudn-density-ds}
+
+  # Job 5: Deploy infrastructure objects (services, NPs, EgressFirewall, quotas)
+  {{ if not .SIMPLE }}
+  - name: cudn-density-infra
+    namespace: cudn-density
+    jobIterations: {{.JOB_ITERATIONS}}
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    namespacedIterations: true
+    waitWhenFinished: true
+    skipIndexing: true
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+      k8s.ovn.org/primary-user-defined-network: ""
+    objects:
+      - objectTemplate: service.yml
+        replicas: 1
+
+      - objectTemplate: service-headless.yml
+        replicas: 1
+
+      - objectTemplate: service-server.yml
+        replicas: 2
+
+      - objectTemplate: np-deny-all.yml
+        replicas: 1
+
+      - objectTemplate: np-allow-cudn-ingress.yml
+        replicas: 1
+        inputVars:
+          namespaces_per_cudn: {{.NAMESPACES_PER_CUDN}}
+
+      - objectTemplate: np-allow-cudn-egress.yml
+        replicas: 1
+        inputVars:
+          namespaces_per_cudn: {{.NAMESPACES_PER_CUDN}}
+
+      - objectTemplate: np-allow-app-ingress.yml
+        replicas: 1
+        inputVars:
+          namespaces_per_cudn: {{.NAMESPACES_PER_CUDN}}
+
+      - objectTemplate: np-allow-app-egress.yml
+        replicas: 1
+        inputVars:
+          namespaces_per_cudn: {{.NAMESPACES_PER_CUDN}}
+
+      - objectTemplate: egressfirewall.yml
+        replicas: 1
+
+      - objectTemplate: resourcequota.yml
+        replicas: 1
+
+      - objectTemplate: limitrange.yml
+        replicas: 1
+  {{ end }}
+
+  # Job 6: Deploy workload (servers + clients with tiered pipeline communication)
+  - name: cudn-density-workload
+    namespace: cudn-density
+    jobIterations: {{.JOB_ITERATIONS}}
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    namespacedIterations: true
+    waitWhenFinished: true
+    preLoadImages: true
+    churnConfig:
+      cycles: {{.CHURN_CYCLES}}
+      duration: {{.CHURN_DURATION}}
+      percent: {{.CHURN_PERCENT}}
+      delay: {{.CHURN_DELAY}}
+      mode: {{.CHURN_MODE}}
+    jobPause: 2m
+    metricsClosing: afterJobPause
+    cleanup: false
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+      k8s.ovn.org/primary-user-defined-network: ""
+    objects:
+      {{ if .SIMPLE }}
+      - objectTemplate: service.yml
+        replicas: 1
+      {{ end }}
+
+      - objectTemplate: deployment-server.yml
+        replicas: 2
+        inputVars:
+          podReplicas: 3
+
+      - objectTemplate: deployment-app.yml
+        replicas: 1
+        inputVars:
+          podReplicas: 2
+
+      - objectTemplate: deployment-client.yml
+        replicas: 1
+        inputVars:
+          podReplicas: 1
+          namespaces_per_cudn: {{.NAMESPACES_PER_CUDN}}
+
+{{ if .GC }}
+  # Job 7: Delete workload namespaces (kills pods, NADs start terminating)
+  # Uses waitForDeletion: false because namespaces will be stuck in Terminating
+  # until CUDNs are deleted in Job 8 (NAD finalizers block namespace deletion).
+  - name: cudn-density-cleanup-namespaces
+    jobType: delete
+    waitForDeletion: false
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    skipIndexing: true
+    objects:
+      - kind: Namespace
+        apiVersion: v1
+        labelSelector: {kube-burner.io/job: cudn-density-create-namespaces}
+
+  # Job 8: Delete CUDNs (releases NAD finalizers, namespaces finish terminating)
+  - name: cudn-density-cleanup-cudns
+    jobType: delete
+    waitForDeletion: true
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    skipIndexing: true
+    objects:
+      - kind: ClusterUserDefinedNetwork
+        apiVersion: k8s.ovn.org/v1
+        labelSelector: {kube-burner.io/job: {{ $cudnJobName }} }
+{{ end }}

--- a/cmd/config/cudn-density/cudn-l2.yml
+++ b/cmd/config/cudn-density/cudn-l2.yml
@@ -1,0 +1,25 @@
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: cudn-{{.Iteration}}
+  labels:
+    cudn-{{.Iteration}}: ""
+spec:
+  {{- $nsList := list }}
+  {{- $nsStart := mul $.Iteration $.namespaces_per_cudn }}
+  {{- range $i, $v := until $.namespaces_per_cudn }}
+    {{- $nextNs := mod (add $nsStart $i) $.total_namespaces }}
+    {{- $next_namespace := print "cudn-density-" $nextNs }}
+    {{- $nsList = append $nsList $next_namespace }}
+  {{- end }}
+  {{- $nsNames := toJson $nsList }}
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values: {{$nsNames}}
+  network:
+    topology: Layer2
+    layer2:
+      role: Primary
+      subnets: ["10.132.0.0/16"]

--- a/cmd/config/cudn-density/cudn-l3.yml
+++ b/cmd/config/cudn-density/cudn-l3.yml
@@ -1,0 +1,30 @@
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: cudn-{{.Iteration}}
+  labels:
+    cudn-{{.Iteration}}: ""
+spec:
+  {{- $nsList := list }}
+  {{- $nsStart := mul $.Iteration $.namespaces_per_cudn }}
+  {{- range $i, $v := until $.namespaces_per_cudn }}
+    {{- $nextNs := mod (add $nsStart $i) $.total_namespaces }}
+    {{- $next_namespace := print "cudn-density-" $nextNs }}
+    {{- $nsList = append $nsList $next_namespace }}
+  {{- end }}
+  {{- $nsNames := toJson $nsList }}
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values: {{$nsNames}}
+  {{- $firstOctet := add (div $.Iteration 256) 40 }}
+  {{- $secondOctet := mod $.Iteration 256 }}
+  {{- $cudnCidr := print $firstOctet "." $secondOctet ".0.0/16" }}
+  network:
+    topology: Layer3
+    layer3:
+      role: Primary
+      subnets:
+        - cidr: {{$cudnCidr}}
+          hostSubnet: 24

--- a/cmd/config/cudn-density/deployment-app.yml
+++ b/cmd/config/cudn-density/deployment-app.yml
@@ -1,0 +1,48 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: app-{{.Replica}}
+spec:
+  replicas: {{.podReplicas}}
+  selector:
+    matchLabels:
+      name: cudn-density-app-{{.Replica}}
+  template:
+    metadata:
+      labels:
+        name: cudn-density-app-{{.Replica}}
+        app: sampleapp
+    spec:
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: sampleapp
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/worker
+                operator: Exists
+              - key: node-role.kubernetes.io/infra
+                operator: DoesNotExist
+              - key: node-role.kubernetes.io/workload
+                operator: DoesNotExist
+      containers:
+      - name: sampleapp
+        image: quay.io/cloud-bulldozer/sampleapp:latest
+        resources:
+          requests:
+            memory: "10Mi"
+            cpu: "10m"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        securityContext:
+          privileged: false
+      restartPolicy: Always

--- a/cmd/config/cudn-density/deployment-client.yml
+++ b/cmd/config/cudn-density/deployment-client.yml
@@ -1,0 +1,89 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: client-{{.Replica}}
+spec:
+  replicas: {{.podReplicas}}
+  selector:
+    matchLabels:
+      name: cudn-density-client-{{.Replica}}
+  template:
+    metadata:
+      labels:
+        name: cudn-density-client-{{.Replica}}
+        app: client
+    spec:
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: client
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/worker
+                operator: Exists
+              - key: node-role.kubernetes.io/infra
+                operator: DoesNotExist
+              - key: node-role.kubernetes.io/workload
+                operator: DoesNotExist
+      containers:
+      - name: client-app
+        image: quay.io/cloud-bulldozer/curl:latest
+        {{- $position := mod .Iteration .namespaces_per_cudn }}
+        {{- $cudnBase := mul (div .Iteration .namespaces_per_cudn) .namespaces_per_cudn }}
+        {{- $lastPosition := sub .namespaces_per_cudn 1 }}
+        {{ if lt $position $lastPosition }}
+        command:
+          - "/bin/sh"
+          - "-c"
+          - |
+            while true; do
+              {{- range $offset := until (int $lastPosition) }}
+                {{- $peerOffset := add $offset 1 }}
+                {{- if lt (add $position $peerOffset) $.namespaces_per_cudn }}
+                  {{- $peerIter := add $cudnBase (add $position $peerOffset) }}
+              curl --fail -sS http://cudn-svc.cudn-density-{{ $peerIter }}.svc.cluster.local:8080 -o /dev/null 2>/dev/null && echo "OK->ns-{{ $peerIter }}" || echo "FAIL->ns-{{ $peerIter }}";
+                {{- end }}
+              {{- end }}
+              sleep 10
+            done
+        {{ else }}
+        command: ["sleep", "inf"]
+        {{ end }}
+        resources:
+          requests:
+            memory: "10Mi"
+            cpu: "10m"
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: false
+        {{- $nextPosition := mod (add $position 1) .namespaces_per_cudn }}
+        {{- $peerNs := add $cudnBase $nextPosition }}
+        readinessProbe:
+          exec:
+            command:
+            - "/bin/sh"
+            - "-c"
+            - "curl --fail -sS http://cudn-svc.cudn-density-{{ $peerNs }}.svc.cluster.local:8080/ -o /dev/null"
+          periodSeconds: 1
+          timeoutSeconds: 5
+          failureThreshold: 60
+        volumeMounts:
+        - name: podinfo
+          mountPath: /etc/podlabels
+      volumes:
+      - name: podinfo
+        downwardAPI:
+          items:
+            - path: "labels"
+              fieldRef:
+                fieldPath: metadata.labels
+      restartPolicy: Always
+  strategy:
+    type: RollingUpdate

--- a/cmd/config/cudn-density/deployment-server.yml
+++ b/cmd/config/cudn-density/deployment-server.yml
@@ -1,0 +1,59 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: server-{{.Replica}}
+spec:
+  replicas: {{.podReplicas}}
+  selector:
+    matchLabels:
+      name: cudn-density-server-{{.Replica}}
+  template:
+    metadata:
+      labels:
+        name: cudn-density-server-{{.Replica}}
+        app: nginx
+    spec:
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: nginx
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/worker
+                operator: Exists
+              - key: node-role.kubernetes.io/infra
+                operator: DoesNotExist
+              - key: node-role.kubernetes.io/workload
+                operator: DoesNotExist
+      containers:
+      - image: quay.io/cloud-bulldozer/nginx:latest
+        resources:
+          requests:
+            memory: "10Mi"
+            cpu: "10m"
+        volumeMounts:
+        - name: podinfo
+          mountPath: /etc/podlabels
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+        - name: https
+          containerPort: 8443
+          protocol: TCP
+        name: nginx
+      volumes:
+      - name: podinfo
+        downwardAPI:
+          items:
+            - path: "labels"
+              fieldRef:
+                fieldPath: metadata.labels

--- a/cmd/config/cudn-density/ds.yml
+++ b/cmd/config/cudn-density/ds.yml
@@ -1,3 +1,9 @@
+# DaemonSet to trigger CUDN network allocation on every worker node.
+# Runs a minimal pod on each node, forcing OVN-K to plumb the CUDN network.
+# The pod reaching Running state confirms the CNI plugin successfully set up
+# the network interface. Deleted in Job 4 after allocation is complete.
+# Cross-node CUDN connectivity is validated later in Job 6 via the client
+# readiness probes that curl cudn-svc in peer namespaces.
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:

--- a/cmd/config/cudn-density/ds.yml
+++ b/cmd/config/cudn-density/ds.yml
@@ -1,0 +1,29 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: cudn-density
+spec:
+  selector:
+    matchLabels:
+      name: cudn-density
+  template:
+    metadata:
+      labels:
+        name: cudn-density
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/worker
+                operator: Exists
+              - key: node-role.kubernetes.io/infra
+                operator: DoesNotExist
+              - key: node-role.kubernetes.io/workload
+                operator: DoesNotExist
+      containers:
+      - name: pause
+        image: quay.io/cloud-bulldozer/curl:latest
+        command: [sleep, inf]
+        imagePullPolicy: IfNotPresent

--- a/cmd/config/cudn-density/egressfirewall.yml
+++ b/cmd/config/cudn-density/egressfirewall.yml
@@ -1,0 +1,47 @@
+# EgressFirewall: OVN-level firewall applied to all pods in the namespace.
+# Evaluated independently of NetworkPolicies — even if a NP allows egress,
+# the EgressFirewall can still block it at the OVN level.
+#
+# Rules (evaluated in order):
+#   1-3. Allow egress to RFC1918 private ranges (cluster-internal traffic)
+#   4.   Allow DNS to cluster.local
+#   5-6. Allow egress to container registries (quay.io, registry.redhat.io)
+#   7.   Allow egress to Prometheus monitoring endpoint
+#   8.   Deny everything else (block all external/internet traffic)
+#
+# Creates 8 OVN ACL rules per namespace for density testing.
+apiVersion: k8s.ovn.org/v1
+kind: EgressFirewall
+metadata:
+  name: default
+spec:
+  egress:
+  # Internal cluster networks
+  - type: Allow
+    to:
+      cidrSelector: 10.0.0.0/8
+  - type: Allow
+    to:
+      cidrSelector: 172.16.0.0/12
+  - type: Allow
+    to:
+      cidrSelector: 192.168.0.0/16
+  # Cluster DNS
+  - type: Allow
+    to:
+      dnsName: "cluster.local"
+  # Container registry
+  - type: Allow
+    to:
+      dnsName: "quay.io"
+  - type: Allow
+    to:
+      dnsName: "registry.redhat.io"
+  # Monitoring endpoints
+  - type: Allow
+    to:
+      dnsName: "prometheus-k8s.openshift-monitoring.svc"
+  # Deny everything else
+  - type: Deny
+    to:
+      cidrSelector: 0.0.0.0/0

--- a/cmd/config/cudn-density/limitrange.yml
+++ b/cmd/config/cudn-density/limitrange.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: cudn-density-limits
+spec:
+  limits:
+  - default:
+      cpu: "500m"
+      memory: "512Mi"
+    defaultRequest:
+      cpu: "10m"
+      memory: "10Mi"
+    type: Container

--- a/cmd/config/cudn-density/np-allow-app-egress.yml
+++ b/cmd/config/cudn-density/np-allow-app-egress.yml
@@ -1,0 +1,52 @@
+# allow-app-egress: Opens egress from sampleapp middleware pods (app=sampleapp).
+#
+# Selects: pods with app=sampleapp (2 pods)
+# Allows egress to:
+#   - Pods with app=nginx in any namespace within the CUDN group, on ports http + https
+#   - Any destination on port 53 UDP/TCP (DNS resolution)
+# Effect: Sampleapp pods can reach any nginx server in the CUDN group and resolve DNS.
+#
+# Note: This policy exists primarily for OVN-K load generation. No actual traffic
+# exercises this rule — sampleapp pods don't initiate connections to nginx.
+# The policy creates ACLs and address sets that OVN-K must maintain at scale.
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-app-egress-{{.Replica}}
+spec:
+  podSelector:
+    matchLabels:
+      app: sampleapp
+  egress:
+  {{- $cudnGroupIdx := div .Iteration .namespaces_per_cudn }}
+  {{- $cudnBase := mul $cudnGroupIdx .namespaces_per_cudn }}
+  {{- $nsList := list }}
+  {{- range $i, $v := until .namespaces_per_cudn }}
+    {{- $nsIter := add $cudnBase $i }}
+    {{- $nsName := print "cudn-density-" $nsIter }}
+    {{- $nsList = append $nsList $nsName }}
+  {{- end }}
+  {{- $nsNames := toJson $nsList }}
+  - to:
+    - namespaceSelector:
+        matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values: {{$nsNames}}
+      podSelector:
+        matchLabels:
+          app: nginx
+    ports:
+    - protocol: TCP
+      port: http
+    - protocol: TCP
+      port: https
+  # Allow DNS resolution
+  - to: []
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  policyTypes:
+  - Egress

--- a/cmd/config/cudn-density/np-allow-app-ingress.yml
+++ b/cmd/config/cudn-density/np-allow-app-ingress.yml
@@ -1,0 +1,43 @@
+# allow-app-ingress: Opens ingress to sampleapp middleware pods (app=sampleapp).
+#
+# Selects: pods with app=sampleapp (2 pods)
+# Allows ingress from:
+#   - Pods with app=client in any namespace within the CUDN group, on port 8080
+# Effect: Any client pod in the CUDN group can reach sampleapp in this namespace.
+#
+# Note: This policy exists primarily for OVN-K load generation. No actual traffic
+# exercises this rule in the current workload — clients only curl cudn-svc (nginx),
+# not sampleapp. The policy creates ACLs, address sets, and port group entries
+# that OVN-K must compute and maintain.
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-app-ingress-{{.Replica}}
+spec:
+  podSelector:
+    matchLabels:
+      app: sampleapp
+  ingress:
+  {{- $cudnGroupIdx := div .Iteration .namespaces_per_cudn }}
+  {{- $cudnBase := mul $cudnGroupIdx .namespaces_per_cudn }}
+  {{- $nsList := list }}
+  {{- range $i, $v := until .namespaces_per_cudn }}
+    {{- $nsIter := add $cudnBase $i }}
+    {{- $nsName := print "cudn-density-" $nsIter }}
+    {{- $nsList = append $nsList $nsName }}
+  {{- end }}
+  {{- $nsNames := toJson $nsList }}
+  - from:
+    - namespaceSelector:
+        matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values: {{$nsNames}}
+      podSelector:
+        matchLabels:
+          app: client
+    ports:
+    - protocol: TCP
+      port: 8080
+  policyTypes:
+  - Ingress

--- a/cmd/config/cudn-density/np-allow-cudn-egress.yml
+++ b/cmd/config/cudn-density/np-allow-cudn-egress.yml
@@ -1,0 +1,65 @@
+# allow-cudn-egress: Opens egress from client pods (app=client).
+#
+# Selects: pods with app=client (1 pod)
+# Allows egress to:
+#   - Pods with app=nginx in any namespace within the CUDN group, on ports http + https
+#   - Pods with app=sampleapp in any namespace within the CUDN group, on port 8080
+#   - Any destination on port 53 UDP/TCP (DNS resolution)
+# Effect: The client pod can reach any nginx or sampleapp in the CUDN group,
+#         and can resolve DNS for cross-namespace service discovery.
+#
+# This is the actively exercised egress policy — client pods generate continuous
+# HTTP traffic to cudn-svc in peer namespaces and use DNS to resolve service names.
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-cudn-egress-{{.Replica}}
+spec:
+  podSelector:
+    matchLabels:
+      app: client
+  egress:
+  {{- $cudnGroupIdx := div .Iteration .namespaces_per_cudn }}
+  {{- $cudnBase := mul $cudnGroupIdx .namespaces_per_cudn }}
+  {{- $nsList := list }}
+  {{- range $i, $v := until .namespaces_per_cudn }}
+    {{- $nsIter := add $cudnBase $i }}
+    {{- $nsName := print "cudn-density-" $nsIter }}
+    {{- $nsList = append $nsList $nsName }}
+  {{- end }}
+  {{- $nsNames := toJson $nsList }}
+  - to:
+    - namespaceSelector:
+        matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values: {{$nsNames}}
+      podSelector:
+        matchLabels:
+          app: nginx
+    ports:
+    - protocol: TCP
+      port: http
+    - protocol: TCP
+      port: https
+  - to:
+    - namespaceSelector:
+        matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values: {{$nsNames}}
+      podSelector:
+        matchLabels:
+          app: sampleapp
+    ports:
+    - protocol: TCP
+      port: 8080
+  # Allow DNS resolution
+  - to: []
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  policyTypes:
+  - Egress

--- a/cmd/config/cudn-density/np-allow-cudn-ingress.yml
+++ b/cmd/config/cudn-density/np-allow-cudn-ingress.yml
@@ -1,0 +1,61 @@
+# allow-cudn-ingress: Opens ingress to nginx server pods (app=nginx).
+#
+# Selects: pods with app=nginx (server-1 and server-2, 6 pods)
+# Allows ingress from:
+#   - Pods with app=client in any namespace within the CUDN group, on ports http + https
+#   - Pods with app=sampleapp in any namespace within the CUDN group, on ports http + https
+# Effect: Any client or sampleapp pod in the CUDN group can reach nginx in this namespace.
+#
+# Uses named ports (http, https) which forces OVN-K to resolve port names
+# against pod container specs — more expensive than numeric ports.
+#
+# The template computes the list of namespace names in the CUDN group using
+# the iteration index and namespaces_per_cudn to build the namespaceSelector.
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-cudn-ingress-{{.Replica}}
+spec:
+  podSelector:
+    matchLabels:
+      app: nginx
+  ingress:
+  {{- $cudnGroupIdx := div .Iteration .namespaces_per_cudn }}
+  {{- $cudnBase := mul $cudnGroupIdx .namespaces_per_cudn }}
+  {{- $nsList := list }}
+  {{- range $i, $v := until .namespaces_per_cudn }}
+    {{- $nsIter := add $cudnBase $i }}
+    {{- $nsName := print "cudn-density-" $nsIter }}
+    {{- $nsList = append $nsList $nsName }}
+  {{- end }}
+  {{- $nsNames := toJson $nsList }}
+  - from:
+    - namespaceSelector:
+        matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values: {{$nsNames}}
+      podSelector:
+        matchLabels:
+          app: client
+    ports:
+    - protocol: TCP
+      port: http
+    - protocol: TCP
+      port: https
+  - from:
+    - namespaceSelector:
+        matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values: {{$nsNames}}
+      podSelector:
+        matchLabels:
+          app: sampleapp
+    ports:
+    - protocol: TCP
+      port: http
+    - protocol: TCP
+      port: https
+  policyTypes:
+  - Ingress

--- a/cmd/config/cudn-density/np-deny-all.yml
+++ b/cmd/config/cudn-density/np-deny-all.yml
@@ -1,0 +1,13 @@
+# deny-all: Baseline policy that blocks ALL ingress and egress for every pod
+# in the namespace. All other NetworkPolicies punch specific holes through this.
+# Without this, pods would have unrestricted network access by default.
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: deny-all
+spec:
+  podSelector: {}
+  ingress: []
+  policyTypes:
+  - Ingress
+  - Egress

--- a/cmd/config/cudn-density/resourcequota.yml
+++ b/cmd/config/cudn-density/resourcequota.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: cudn-density-quota
+spec:
+  hard:
+    pods: "100"
+    requests.cpu: "10"
+    requests.memory: "10Gi"
+    limits.cpu: "20"
+    limits.memory: "20Gi"

--- a/cmd/config/cudn-density/service-headless.yml
+++ b/cmd/config/cudn-density/service-headless.yml
@@ -2,6 +2,11 @@
 # Selects pods with app=sampleapp (2 endpoints).
 # Returns individual pod IPs instead of a VIP — more expensive for OVN-K
 # endpoint tracking than ClusterIP services.
+#
+# Note: Headless services do not work with UDN/CUDN primary networks
+# (DNS won't resolve to CUDN pod IPs). This service is not actively used
+# by any traffic in the workload — it exists purely for OVN-K load generation
+# (EndpointSlice tracking, logical port associations).
 kind: Service
 apiVersion: v1
 metadata:

--- a/cmd/config/cudn-density/service-headless.yml
+++ b/cmd/config/cudn-density/service-headless.yml
@@ -1,0 +1,17 @@
+# cudn-app-headless: Headless service for sampleapp pods.
+# Selects pods with app=sampleapp (2 endpoints).
+# Returns individual pod IPs instead of a VIP — more expensive for OVN-K
+# endpoint tracking than ClusterIP services.
+kind: Service
+apiVersion: v1
+metadata:
+  name: cudn-app-headless
+spec:
+  selector:
+    app: sampleapp
+  ports:
+  - name: http
+    protocol: TCP
+    port: 8080
+    targetPort: 8080
+  clusterIP: None

--- a/cmd/config/cudn-density/service-server.yml
+++ b/cmd/config/cudn-density/service-server.yml
@@ -1,0 +1,22 @@
+# Per-server-deployment service: Creates server-1-svc and server-2-svc.
+# Each selects only its own deployment's pods (3 endpoints each) using the
+# deployment-specific label (name=cudn-density-server-{replica}).
+# Exposes ports 8080 (http) and 8443 (https).
+# Creates additional OVN load balancer entries beyond the aggregate cudn-svc.
+kind: Service
+apiVersion: v1
+metadata:
+  name: server-{{.Replica}}-svc
+spec:
+  selector:
+    name: cudn-density-server-{{.Replica}}
+  ports:
+  - name: http
+    protocol: TCP
+    port: 8080
+    targetPort: 8080
+  - name: https
+    protocol: TCP
+    port: 8443
+    targetPort: 8443
+  type: ClusterIP

--- a/cmd/config/cudn-density/service.yml
+++ b/cmd/config/cudn-density/service.yml
@@ -1,0 +1,21 @@
+# cudn-svc: Main ClusterIP service for nginx servers.
+# Selects all pods with app=nginx (both server-1 and server-2 = 6 endpoints).
+# Exposes ports 8080 (http) and 8443 (https).
+# This is the service targeted by client cross-namespace traffic and readiness probes.
+kind: Service
+apiVersion: v1
+metadata:
+  name: cudn-svc
+spec:
+  selector:
+    app: nginx
+  ports:
+  - name: http
+    protocol: TCP
+    port: 8080
+    targetPort: 8080
+  - name: https
+    protocol: TCP
+    port: 8443
+    targetPort: 8443
+  type: ClusterIP

--- a/cmd/ocp.go
+++ b/cmd/ocp.go
@@ -131,6 +131,7 @@ func openShiftCmd() *cobra.Command {
 		ocpWorkloads.NewClusterDensity(&wh, "cluster-density-v2"),
 		ocpWorkloads.NewClusterDensity(&wh, "cluster-density-ms"),
 		ocpWorkloads.NewCrdScale(&wh),
+		ocpWorkloads.NewCudnDensity(&wh),
 		ocpWorkloads.NewUdnBgp(&wh, "udn-bgp"),
 		ocpWorkloads.NewEVPN(&wh, "evpn"),
 		ocpWorkloads.NewNetworkPolicy(&wh, "network-policy"),

--- a/pkg/measurements/cudn-latency.go
+++ b/pkg/measurements/cudn-latency.go
@@ -1,0 +1,240 @@
+// Copyright 2025 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package measurements
+
+import (
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/kube-burner/kube-burner/v2/pkg/config"
+	"github.com/kube-burner/kube-burner/v2/pkg/measurements"
+	"github.com/kube-burner/kube-burner/v2/pkg/measurements/types"
+	"github.com/kube-burner/kube-burner/v2/pkg/util/fileutils"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	cudnLatencyMeasurementName      = "cudnLatencyMeasurement"
+	cudnLatencyQuantilesMeasurement = "cudnLatencyQuantilesMeasurement"
+	cudnReadyConditionType          = "NetworkCreated"
+)
+
+var (
+	supportedCudnLatencyJobTypes = []config.JobType{config.CreationJob}
+	cudnGVRForLatency            = schema.GroupVersionResource{
+		Group:    "k8s.ovn.org",
+		Version:  "v1",
+		Resource: "clusteruserdefinednetworks",
+	}
+)
+
+type cudnMetric struct {
+	Timestamp             time.Time `json:"timestamp"`
+	MetricName            string    `json:"metricName"`
+	UUID                  string    `json:"uuid"`
+	JobName               string    `json:"jobName,omitempty"`
+	Name                  string    `json:"cudnName"`
+	Metadata              any       `json:"metadata,omitempty"`
+	NetworkCreatedLatency int       `json:"networkAllocLatency"`
+}
+
+type cudnLatency struct {
+	measurements.BaseMeasurement
+	stopCh        chan struct{}
+	dynamicClient dynamic.Interface
+}
+
+type cudnLatencyMeasurementFactory struct {
+	measurements.BaseMeasurementFactory
+}
+
+func NewCudnLatencyMeasurementFactory(configSpec config.Spec, measurement types.Measurement, metadata map[string]any, labelSelector string) (measurements.MeasurementFactory, error) {
+	return cudnLatencyMeasurementFactory{
+		measurements.NewBaseMeasurementFactory(configSpec, measurement, metadata, labelSelector),
+	}, nil
+}
+
+func (clmf cudnLatencyMeasurementFactory) NewMeasurement(jobConfig *config.Job, clientSet kubernetes.Interface, restConfig *rest.Config, embedCfg *fileutils.EmbedConfiguration) measurements.Measurement {
+	return &cudnLatency{
+		BaseMeasurement: clmf.NewBaseLatency(jobConfig, clientSet, restConfig, cudnLatencyMeasurementName, cudnLatencyQuantilesMeasurement, embedCfg),
+		dynamicClient:   dynamic.NewForConfigOrDie(restConfig),
+	}
+}
+
+func (c *cudnLatency) handleAdd(obj any) {
+	cudn := obj.(*unstructured.Unstructured)
+	cudnName, found, _ := unstructured.NestedString(cudn.UnstructuredContent(), "metadata", "name")
+	if !found || cudnName == "" {
+		log.Error("CUDN object missing metadata.name, skipping")
+		return
+	}
+	ts, found, _ := unstructured.NestedString(cudn.UnstructuredContent(), "metadata", "creationTimestamp")
+	if !found || ts == "" {
+		log.Errorf("CUDN %s missing creationTimestamp, skipping", cudnName)
+		return
+	}
+	t, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		log.Errorf("Error parsing CUDN %s creation timestamp: %v", cudnName, err)
+		return
+	}
+
+	// Check if NetworkCreated is already True at creation time
+	if transitionTime, ok := getNetworkAllocTransitionTime(cudn); ok {
+		latency := transitionTime.Sub(t).Milliseconds()
+		log.Debugf("CUDN %s already has NetworkCreated=True, latency: %dms", cudnName, latency)
+		c.Metrics.LoadOrStore(cudnName, cudnMetric{
+			Name:                  cudnName,
+			Timestamp:             t.UTC(),
+			MetricName:            cudnLatencyMeasurementName,
+			UUID:                  c.Uuid,
+			Metadata:              c.Metadata,
+			JobName:               c.JobConfig.Name,
+			NetworkCreatedLatency: int(latency),
+		})
+		return
+	}
+
+	// Store creation timestamp, latency will be computed on update
+	c.Metrics.LoadOrStore(cudnName, cudnMetric{
+		Name:                  cudnName,
+		Timestamp:             t.UTC(),
+		MetricName:            cudnLatencyMeasurementName,
+		UUID:                  c.Uuid,
+		Metadata:              c.Metadata,
+		JobName:               c.JobConfig.Name,
+		NetworkCreatedLatency: -1, // Not yet ready
+	})
+	log.Debugf("CUDN %s created at %v, waiting for NetworkCreated", cudnName, t.UTC())
+}
+
+func (c *cudnLatency) handleUpdate(oldObj, newObj any) {
+	cudn := newObj.(*unstructured.Unstructured)
+	cudnName, _, _ := unstructured.NestedString(cudn.UnstructuredContent(), "metadata", "name")
+
+	transitionTime, succeeded := getNetworkAllocTransitionTime(cudn)
+	if !succeeded {
+		return
+	}
+
+	val, ok := c.Metrics.Load(cudnName)
+	if !ok {
+		return
+	}
+	m := val.(cudnMetric)
+	if m.NetworkCreatedLatency >= 0 {
+		return // Already recorded
+	}
+
+	latency := transitionTime.Sub(m.Timestamp).Milliseconds()
+	m.NetworkCreatedLatency = int(latency)
+	c.Metrics.Store(cudnName, m)
+	log.Debugf("CUDN %s NetworkCreated after %dms", cudnName, latency)
+}
+
+// getNetworkAllocTransitionTime returns the lastTransitionTime of the
+// NetworkCreated=True condition, and true if found.
+func getNetworkAllocTransitionTime(cudn *unstructured.Unstructured) (time.Time, bool) {
+	conditions, found, err := unstructured.NestedSlice(cudn.UnstructuredContent(), "status", "conditions")
+	if err != nil || !found {
+		return time.Time{}, false
+	}
+	for _, c := range conditions {
+		condition, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		condType, _, _ := unstructured.NestedString(condition, "type")
+		condStatus, _, _ := unstructured.NestedString(condition, "status")
+		if condType == cudnReadyConditionType && condStatus == "True" {
+			ltt, _, _ := unstructured.NestedString(condition, "lastTransitionTime")
+			if t, err := time.Parse(time.RFC3339, ltt); err == nil {
+				return t, true
+			}
+			// Fall back to current time if lastTransitionTime is missing
+			log.Warnf("CUDN %s: NetworkCreated=True but missing lastTransitionTime, using current time", cudn.GetName())
+			return time.Now().UTC(), true
+		}
+	}
+	return time.Time{}, false
+}
+
+func (c *cudnLatency) Start(measurementWg *sync.WaitGroup) error {
+	defer measurementWg.Done()
+
+	c.LatencyQuantiles, c.NormLatencies = nil, nil
+	c.Metrics = sync.Map{}
+
+	if c.JobConfig.SkipIndexing {
+		return nil
+	}
+
+	c.stopCh = make(chan struct{})
+	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(c.dynamicClient, 0, "", nil)
+	cudnInformer := factory.ForResource(cudnGVRForLatency).Informer()
+	cudnInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.handleAdd,
+		UpdateFunc: c.handleUpdate,
+	})
+
+	log.Infof("Starting CUDN latency watcher for job %s", c.JobConfig.Name)
+	factory.Start(c.stopCh)
+	factory.WaitForCacheSync(c.stopCh)
+	return nil
+}
+
+func (c *cudnLatency) Collect(measurementWg *sync.WaitGroup) {
+	defer measurementWg.Done()
+}
+
+func (c *cudnLatency) Stop() error {
+	if c.JobConfig.SkipIndexing {
+		return nil
+	}
+	close(c.stopCh)
+	return c.StopMeasurement(c.normalizeMetrics, c.getLatency)
+}
+
+func (c *cudnLatency) normalizeMetrics() float64 {
+	c.Metrics.Range(func(key, value any) bool {
+		m := value.(cudnMetric)
+		if m.NetworkCreatedLatency < 0 {
+			log.Warnf("CUDN %s never reached NetworkCreated=True, excluding from latency metrics", m.Name)
+			return true
+		}
+		c.NormLatencies = append(c.NormLatencies, m)
+		return true
+	})
+	return 0
+}
+
+func (c *cudnLatency) getLatency(normLatency any) map[string]float64 {
+	m := normLatency.(cudnMetric)
+	return map[string]float64{
+		"NetworkCreatedLatency": float64(m.NetworkCreatedLatency),
+	}
+}
+
+func (c *cudnLatency) IsCompatible() bool {
+	return slices.Contains(supportedCudnLatencyJobTypes, c.JobConfig.JobType)
+}

--- a/pkg/workloads/cudn-density.go
+++ b/pkg/workloads/cudn-density.go
@@ -1,0 +1,102 @@
+// Copyright 2025 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workloads
+
+import (
+	"os"
+	"time"
+
+	"github.com/kube-burner/kube-burner/v2/pkg/config"
+	kubeburnermeasurements "github.com/kube-burner/kube-burner/v2/pkg/measurements"
+	"github.com/kube-burner/kube-burner/v2/pkg/workloads"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/kube-burner/kube-burner-ocp/pkg/measurements"
+)
+
+var cudnMeasurementFactoryMap = map[string]kubeburnermeasurements.NewMeasurementFactory{
+	"cudnLatency": measurements.NewCudnLatencyMeasurementFactory,
+}
+
+// NewCudnDensity holds cudn-density workload
+func NewCudnDensity(wh *workloads.WorkloadHelper) *cobra.Command {
+	var churnPercent, churnCycles, iterations, namespacesPerCudn int
+	var l3, simple, pprof bool
+	var churnDelay, churnDuration, podReadyThreshold, pprofInterval time.Duration
+	var churnMode string
+	var metricsProfiles []string
+	var rc int
+	cmd := &cobra.Command{
+		Use:          "cudn-density",
+		Short:        "Runs cudn-density workload with tiered cross-namespace communication",
+		SilenceUsage: true,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			if iterations%namespacesPerCudn != 0 {
+				log.Fatalf("iterations (%d) must be divisible by namespaces-per-cudn (%d)", iterations, namespacesPerCudn)
+			}
+			if churnMode == string(config.ChurnNamespaces) && (churnDuration > 0 || churnCycles > 0) {
+				log.Fatal("churn-mode=namespaces is not supported for cudn-density: CUDN finalizers block namespace deletion. Use --churn-mode=objects instead")
+			}
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			setMetrics(cmd, metricsProfiles)
+			if l3 {
+				log.Info("Layer 3 topology enabled")
+			} else {
+				log.Info("Layer 2 topology enabled")
+			}
+			if simple {
+				log.Info("Simple mode: skipping network policies, services, egressfirewall, quotas")
+			}
+			if churnDuration > 0 || churnCycles > 0 {
+				log.Info("Churn is enabled")
+			}
+
+			AdditionalVars["PPROF"] = pprof
+			AdditionalVars["PPROF_INTERVAL"] = pprofInterval.String()
+			AdditionalVars["SIMPLE"] = simple
+			AdditionalVars["CHURN_CYCLES"] = churnCycles
+			AdditionalVars["CHURN_DURATION"] = churnDuration
+			AdditionalVars["CHURN_DELAY"] = churnDelay
+			AdditionalVars["CHURN_PERCENT"] = churnPercent
+			AdditionalVars["CHURN_MODE"] = churnMode
+			AdditionalVars["JOB_ITERATIONS"] = iterations
+			AdditionalVars["NAMESPACES_PER_CUDN"] = namespacesPerCudn
+			AdditionalVars["POD_READY_THRESHOLD"] = podReadyThreshold
+			AdditionalVars["ENABLE_LAYER_3"] = l3
+			wh.SetMeasurements(cudnMeasurementFactoryMap)
+			rc = RunWorkload(cmd, wh, cmd.Name()+".yml")
+		},
+		PostRun: func(cmd *cobra.Command, args []string) {
+			os.Exit(rc)
+		},
+	}
+	cmd.Flags().BoolVar(&l3, "layer3", false, "Use Layer3 topology instead of Layer2")
+	cmd.Flags().BoolVar(&pprof, "pprof", false, "Enable pprof collection for ovnkube components")
+	cmd.Flags().DurationVar(&pprofInterval, "pprof-interval", 0, "Interval between pprof collections")
+	cmd.Flags().BoolVar(&simple, "simple", false, "Skip network policies, egressfirewall, quotas, and extra services")
+	cmd.Flags().IntVar(&churnCycles, "churn-cycles", 0, "Churn cycles to execute")
+	cmd.Flags().DurationVar(&churnDuration, "churn-duration", 0, "Churn duration")
+	cmd.Flags().DurationVar(&churnDelay, "churn-delay", 2*time.Minute, "Time to wait between each churn")
+	cmd.Flags().IntVar(&churnPercent, "churn-percent", 10, "Percentage of job iterations that kube-burner will churn each round")
+	cmd.Flags().StringVar(&churnMode, "churn-mode", string(config.ChurnObjects), "Churn mode: objects (namespaces mode is not supported due to CUDN finalizer constraints)")
+	cmd.Flags().IntVar(&iterations, "iterations", 0, "Total number of namespaces to create")
+	cmd.Flags().IntVar(&namespacesPerCudn, "namespaces-per-cudn", 5, "Number of namespaces sharing the same CUDN")
+	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 2*time.Minute, "Pod ready timeout threshold")
+	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
+	cmd.MarkFlagRequired("iterations")
+	return cmd
+}

--- a/test/test-ocp.bats
+++ b/test/test-ocp.bats
@@ -136,15 +136,11 @@ teardown_file() {
 }
 
 @test "cudn-density-l2: gc=true" {
+  oc delete clusteruserdefinednetworks --all --ignore-not-found
+  # Extract cudn-density templates to override any stale files from previous tests
+  run_cmd ${KUBE_BURNER_OCP} cudn-density --extract
   run_cmd ${KUBE_BURNER_OCP} cudn-density --iterations=10 --namespaces-per-cudn=5 --gc=true --uuid=${UUID}
-  # Verify GC cleaned up CUDNs
   verify_object_count clusteruserdefinednetworks 0 "" kube-burner.io/job=cudn-density-create-cudn-l2
-}
-
-@test "cudn-density-l3: simple=true" {
-  run_cmd ${KUBE_BURNER_OCP} cudn-density --iterations=10 --namespaces-per-cudn=5 --layer3 --simple --gc=true --uuid=${UUID}
-  # Verify GC cleaned up CUDNs
-  verify_object_count clusteruserdefinednetworks 0 "" kube-burner.io/job=cudn-density-create-cudn-l3
 }
 
 @test "cluster-health" {

--- a/test/test-ocp.bats
+++ b/test/test-ocp.bats
@@ -135,6 +135,18 @@ teardown_file() {
   run_cmd ${KUBE_BURNER_OCP} udn-density-pods --iterations=2 --layer3=true
 }
 
+@test "cudn-density-l2: gc=true" {
+  run_cmd ${KUBE_BURNER_OCP} cudn-density --iterations=10 --namespaces-per-cudn=5 --gc=true --uuid=${UUID}
+  # Verify GC cleaned up CUDNs
+  verify_object_count clusteruserdefinednetworks 0 "" kube-burner.io/job=cudn-density-create-cudn-l2
+}
+
+@test "cudn-density-l3: simple=true" {
+  run_cmd ${KUBE_BURNER_OCP} cudn-density --iterations=10 --namespaces-per-cudn=5 --layer3 --simple --gc=true --uuid=${UUID}
+  # Verify GC cleaned up CUDNs
+  verify_object_count clusteruserdefinednetworks 0 "" kube-burner.io/job=cudn-density-create-cudn-l3
+}
+
 @test "cluster-health" {
   run_cmd ${KUBE_BURNER_OCP} cluster-health
 }


### PR DESCRIPTION
Introduces a new kube-burner-ocp workload that stress-tests OVN-Kubernetes networking with ClusterUserDefinedNetworks (CUDNs). The workload creates groups of namespaces sharing a primary CUDN, deploys a 3-tier microservice application with cross-namespace communication, and exercises network policies, egress firewalls, and service load balancing over the CUDN primary network.

Key features:
- CUDN creation latency measurement via custom cudnLatency metric
- Cross-namespace readiness probes forming a ring topology
- 5 NetworkPolicies per namespace with named ports and cross-ns selectors
- Layer2 and Layer3 CUDN topology support
- DaemonSet-based network pre-allocation on all worker nodes
- Object-level churn support (namespace churn blocked by CUDN finalizers)
- Proper GC cleanup handling CUDN finalizer dependency chain

Considerations
NetworkAllocationSucceeded is not available in CUDN, for now default to NetworkCreated

## Type of change
- New feature



