### PR TITLE
Reduce build-farm default to a more reasonable 12 iterations

### DIFF
--- a/pkg/workloads/build-farm.go
+++ b/pkg/workloads/build-farm.go
@@ -115,7 +115,7 @@ func NewBuildFarm(wh *workloads.WorkloadHelper) *cobra.Command {
 	}
 
 	// Standard workload flags
-	cmd.Flags().IntVar(&jobIterations, "job-iterations", 100, "Number of job iterations to create")
+	cmd.Flags().IntVar(&jobIterations, "job-iterations", 12, "Number of job iterations to create")
 	cmd.Flags().IntVar(&iterationsPerNamespace, "iterations-per-namespace", 100, "Number of iterations per namespace")
 	cmd.Flags().Float64Var(&qps, "qps", 40, "QPS for client rate limiting")
 	cmd.Flags().Float64Var(&burst, "burst", 40, "Burst for client rate limiting")


### PR DESCRIPTION
## Type of change

- Bug fix

## Description

The default job-iterations of 100 of build-farm is more of a chaos scenario. It completely destroys a simple 3x control plane , 3x worker cluster of small 8vCPU x 18GB memory VMs.

Quick tests reveal that 14 iterations can be run without any control plane components crashing. Control plane starts to crash at only 15 iterations.

Changing the default to a more reasonable number for a better user experience out of the box.