### PR TITLE
Fix egressIP metrics/alerts exporting

### DIFF
--- a/cmd/config/egressip/egressip.yml
+++ b/cmd/config/egressip/egressip.yml
@@ -13,14 +13,18 @@ global:
           threshold: 15s
 metricsEndpoints:
 {{ if .ES_SERVER }}
-  - indexer:
+  - metrics: [{{.METRICS}}]
+    alerts: [{{.ALERTS}}]
+    indexer:
       esServers: ["{{.ES_SERVER}}"]
       insecureSkipVerify: true
       defaultIndex: {{.ES_INDEX}}
       type: opensearch
 {{ end }}
 {{ if .LOCAL_INDEXING }}
-  - indexer:
+  - metrics: [{{.METRICS}}]
+    alerts: [{{.ALERTS}}]
+    indexer:
       type: local
       metricsDirectory: collected-metrics-{{.UUID}}
 {{ end }}


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation
- [ ] CI

## Description

egreessip workload is not currently indexing any metrics besides the natives ones (podLatency, etc.).
