### PR TITLE
Set default latency thresholds value to 0

### DIFF
--- a/cmd/config/anp-density-pods/anp-density-pods.yml
+++ b/cmd/config/anp-density-pods/anp-density-pods.yml
@@ -4,10 +4,12 @@ global:
   gcMetrics: {{.GC_METRICS}}
   measurements:
     - name: podLatency
+{{ if ne .POD_READY_THRESHOLD 0 }}
       thresholds:
         - conditionType: Ready
           metric: P99
           threshold: {{.POD_READY_THRESHOLD}}
+{{ end }}
 {{ if .PPROF }}
     - name: pprof
       pprofInterval: {{.PPROF_INTERVAL}}

--- a/cmd/config/cluster-density-ms/cluster-density-ms.yml
+++ b/cmd/config/cluster-density-ms/cluster-density-ms.yml
@@ -5,10 +5,12 @@ global:
   deletionStrategy: {{.DELETION_STRATEGY}}
   measurements:
     - name: podLatency
+{{ if ne .POD_READY_THRESHOLD 0 }}
       thresholds:
         - conditionType: Ready
           metric: P99
           threshold: {{.POD_READY_THRESHOLD}}
+{{ end }}
 metricsEndpoints:
 {{ if .ES_SERVER }}
   - metrics: [{{.METRICS}}]

--- a/cmd/config/cluster-density-v2/cluster-density-v2.yml
+++ b/cmd/config/cluster-density-v2/cluster-density-v2.yml
@@ -5,10 +5,12 @@ global:
   deletionStrategy: {{.DELETION_STRATEGY}}
   measurements:
     - name: podLatency
+{{ if ne .POD_READY_THRESHOLD 0 }}
       thresholds:
         - conditionType: Ready
           metric: P99
           threshold: {{.POD_READY_THRESHOLD}}
+{{ end }}
 {{ if .PPROF }}
     - name: pprof
       pprofInterval: {{.PPROF_INTERVAL}}

--- a/cmd/config/cudn-density/cudn-density.yml
+++ b/cmd/config/cudn-density/cudn-density.yml
@@ -109,10 +109,12 @@ jobs:
     preLoadImages: true
     measurements:
       - name: podLatency
+{{ if ne .POD_READY_THRESHOLD 0 }}
         thresholds:
           - conditionType: Ready
             metric: P99
             threshold: {{.POD_READY_THRESHOLD}}
+{{ end }}
     churnConfig:
       cycles: {{.CHURN_CYCLES}}
       duration: {{.CHURN_DURATION}}

--- a/cmd/config/egressip/egressip.yml
+++ b/cmd/config/egressip/egressip.yml
@@ -7,10 +7,12 @@ global:
   gcMetrics: {{.GC_METRICS}}
   measurements:
     - name: podLatency
+{{ if ne .POD_READY_THRESHOLD 0 }}
       thresholds:
         - conditionType: Ready
           metric: P99
-          threshold: 15s
+          threshold: {{.POD_READY_THRESHOLD}}
+{{ end }}
 metricsEndpoints:
 {{ if .ES_SERVER }}
   - metrics: [{{.METRICS}}]

--- a/cmd/config/evpn/evpn.yml
+++ b/cmd/config/evpn/evpn.yml
@@ -7,10 +7,12 @@ global:
   gcMetrics: {{.GC_METRICS}}
   measurements:
     - name: podLatency
+{{ if ne .POD_READY_THRESHOLD 0 }}
       thresholds:
         - conditionType: Ready
           metric: P99
           threshold: {{.POD_READY_THRESHOLD}}
+{{ end }}
 metricsEndpoints:
 {{ if .ES_SERVER }}
   - metrics: [{{.METRICS}}]

--- a/cmd/config/network-policy/network-policy.yml
+++ b/cmd/config/network-policy/network-policy.yml
@@ -5,10 +5,12 @@ global:
   measurements:
 {{ if .NETPOL_LATENCY }}
     - name: netpolLatency
+{{ if ne .NETPOL_READY_THRESHOLD 0 }}
       thresholds:
         - conditionType: Ready
           metric: P99
           threshold: {{.NETPOL_READY_THRESHOLD}}
+{{ end }}
 {{ end }}        
 metricsEndpoints:
 {{ if .ES_SERVER }}

--- a/cmd/config/node-density-cni/node-density-cni.yml
+++ b/cmd/config/node-density-cni/node-density-cni.yml
@@ -5,10 +5,12 @@ global:
   deletionStrategy: {{.DELETION_STRATEGY}}
   measurements:
     - name: podLatency
+{{ if ne .POD_READY_THRESHOLD 0 }}
       thresholds:
         - conditionType: Ready
           metric: P99
           threshold: {{.POD_READY_THRESHOLD}}
+{{ end }}
 {{ if .PPROF }}
     - name: pprof
       pprofInterval: {{.PPROF_INTERVAL}}

--- a/cmd/config/node-density-heavy/node-density-heavy.yml
+++ b/cmd/config/node-density-heavy/node-density-heavy.yml
@@ -5,10 +5,12 @@ global:
   deletionStrategy: {{.DELETION_STRATEGY}}
   measurements:
     - name: podLatency
+{{ if ne .POD_READY_THRESHOLD 0 }}
       thresholds:
         - conditionType: Ready
           metric: P99
           threshold: {{.POD_READY_THRESHOLD}}
+{{ end }}
 {{ if .PPROF }}
     - name: pprof
       pprofInterval: {{.PPROF_INTERVAL}}

--- a/cmd/config/node-density/node-density.yml
+++ b/cmd/config/node-density/node-density.yml
@@ -5,10 +5,12 @@ global:
   deletionStrategy: {{.DELETION_STRATEGY}}
   measurements:
     - name: podLatency
+{{ if ne .POD_READY_THRESHOLD 0 }}
       thresholds:
         - conditionType: Ready
           metric: P99
           threshold: {{.POD_READY_THRESHOLD}}
+{{ end }}
 {{ if .PPROF }}
     - name: pprof
       pprofInterval: {{.PPROF_INTERVAL}}

--- a/cmd/config/node-scale/node-scale.yml
+++ b/cmd/config/node-scale/node-scale.yml
@@ -5,10 +5,12 @@ global:
   deletionStrategy: {{.DELETION_STRATEGY}}
   measurements:
     - name: podLatency
+{{ if ne .POD_READY_THRESHOLD 0 }}
       thresholds:
         - conditionType: Ready
           metric: P99
           threshold: {{.POD_READY_THRESHOLD}}
+{{ end }}
 metricsEndpoints:
 {{ if .ES_SERVER }}
   - metrics: [{{.METRICS}}]

--- a/cmd/config/rds-core/rds-core.yml
+++ b/cmd/config/rds-core/rds-core.yml
@@ -8,10 +8,12 @@ global:
   deletionStrategy: {{.DELETION_STRATEGY}}
   measurements:
     - name: podLatency
+{{ if ne .POD_READY_THRESHOLD 0 }}
       thresholds:
         - conditionType: Ready
           metric: P99
           threshold: {{.POD_READY_THRESHOLD}}
+{{ end }}
 {{ if .SVC_LATENCY }}
     - name: serviceLatency
       svcTimeout: 1m

--- a/cmd/config/udn-density-pods/udn-density-pods.yml
+++ b/cmd/config/udn-density-pods/udn-density-pods.yml
@@ -5,10 +5,12 @@ global:
   deletionStrategy: {{.DELETION_STRATEGY}}
   measurements:
     - name: podLatency
+{{ if ne .POD_READY_THRESHOLD 0 }}
       thresholds:
         - conditionType: Ready
           metric: P99
           threshold: {{.POD_READY_THRESHOLD}}
+{{ end }}
 {{ if .PPROF }}
     - name: pprof
       pprofInterval: {{.PPROF_INTERVAL}}

--- a/cmd/config/virt-density/virt-density.yml
+++ b/cmd/config/virt-density/virt-density.yml
@@ -5,10 +5,12 @@ global:
   deletionStrategy: {{.DELETION_STRATEGY}}
   measurements:
     - name: vmiLatency
+{{ if ne .VMI_RUNNING_THRESHOLD 0 }}
       thresholds:
         - conditionType: VMIRunning
           metric: P99
           threshold: {{.VMI_RUNNING_THRESHOLD}}
+{{ end }}
 metricsEndpoints:
 {{ if .ES_SERVER }}
   - metrics: [{{.METRICS}}]

--- a/cmd/config/virt-udn-density/virt-udn-density.yml
+++ b/cmd/config/virt-udn-density/virt-udn-density.yml
@@ -5,10 +5,12 @@ global:
   deletionStrategy: {{.DELETION_STRATEGY}}
   measurements:
     - name: vmiLatency
+{{ if ne .VMI_RUNNING_THRESHOLD 0 }}
       thresholds:
         - conditionType: VMIRunning
           metric: P99
           threshold: {{.VMI_RUNNING_THRESHOLD}}
+{{ end }}
 {{ if .PPROF }}
     - name: pprof
       pprofInterval: {{.PPROF_INTERVAL}}

--- a/cmd/config/web-burner-cluster-density/web-burner-cluster-density.yml
+++ b/cmd/config/web-burner-cluster-density/web-burner-cluster-density.yml
@@ -5,10 +5,12 @@ global:
   gcMetrics: {{.GC_METRICS}}
   measurements:
     - name: podLatency
+{{ if ne .POD_READY_THRESHOLD 0 }}
       thresholds:
         - conditionType: Ready
           metric: P99
           threshold: {{.POD_READY_THRESHOLD}}
+{{ end }}
 metricsEndpoints:
 {{ if .ES_SERVER }}
   - metrics: [{{.METRICS}}]

--- a/cmd/config/web-burner-init/web-burner-init.yml
+++ b/cmd/config/web-burner-init/web-burner-init.yml
@@ -5,10 +5,12 @@ global:
   gcMetrics: {{.GC_METRICS}}
   measurements:
     - name: podLatency
+{{ if ne .POD_READY_THRESHOLD 0 }}
       thresholds:
         - conditionType: Ready
           metric: P99
           threshold: {{.POD_READY_THRESHOLD}}
+{{ end }}
 metricsEndpoints:
 {{ if .ES_SERVER }}
   - metrics: [{{.METRICS}}]

--- a/cmd/config/web-burner-node-density/web-burner-node-density.yml
+++ b/cmd/config/web-burner-node-density/web-burner-node-density.yml
@@ -5,10 +5,12 @@ global:
   gcMetrics: {{.GC_METRICS}}
   measurements:
     - name: podLatency
+{{ if ne .POD_READY_THRESHOLD 0 }}
       thresholds:
         - conditionType: Ready
           metric: P99
           threshold: {{.POD_READY_THRESHOLD}}
+{{ end }}
 metricsEndpoints:
 {{ if .ES_SERVER }}
   - metrics: [{{.METRICS}}]

--- a/cmd/config/whereabouts/whereabouts.yml
+++ b/cmd/config/whereabouts/whereabouts.yml
@@ -4,10 +4,12 @@ global:
   gcMetrics: {{.GC_METRICS}}
   measurements:
     - name: podLatency
+{{ if ne .POD_READY_THRESHOLD 0 }}
       thresholds:
         - conditionType: Ready
           metric: P99
           threshold: {{.POD_READY_THRESHOLD}}
+{{ end }}
 metricsEndpoints:
 {{ if .ES_SERVER }}
   - metrics: [{{.METRICS}}]

--- a/pkg/workloads/anp-density-pods.go
+++ b/pkg/workloads/anp-density-pods.go
@@ -347,7 +347,7 @@ func NewANPDensityPods(wh *workloads.WorkloadHelper, variant string) *cobra.Comm
 	cmd.Flags().IntVar(&churnPercent, "churn-percent", 10, "Percentage of job iterations that kube-burner will churn each round")
 	cmd.Flags().IntVar(&iterations, "iterations", 0, "Iterations")
 	cmd.Flags().BoolVar(&svcLatency, "service-latency", false, "Enable service latency measurement")
-	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 1*time.Minute, "Pod ready timeout threshold")
+	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 0, "Pod ready timeout threshold")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
 	cmd.MarkFlagRequired("iterations")
 	return cmd

--- a/pkg/workloads/cluster-density.go
+++ b/pkg/workloads/cluster-density.go
@@ -71,7 +71,7 @@ func NewClusterDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Comm
 			os.Exit(rc)
 		},
 	}
-	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 2*time.Minute, "Pod ready timeout threshold")
+	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 0, "Pod ready timeout threshold")
 	cmd.Flags().IntVar(&iterations, "iterations", 0, fmt.Sprintf("%v iterations", variant))
 	cmd.Flags().BoolVar(&pprof, "pprof", false, "Enable pprof collection")
 	cmd.Flags().DurationVar(&pprofInterval, "pprof-interval", 0, "Interval between pprof collections")

--- a/pkg/workloads/cudn-density.go
+++ b/pkg/workloads/cudn-density.go
@@ -92,7 +92,7 @@ func NewCudnDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().StringVar(&churnMode, "churn-mode", string(config.ChurnObjects), "Churn mode: objects (namespaces mode is not supported due to CUDN finalizer constraints)")
 	cmd.Flags().IntVar(&iterations, "iterations", 0, "Total number of namespaces to create")
 	cmd.Flags().IntVar(&namespacesPerCudn, "namespaces-per-cudn", 5, "Number of namespaces sharing the same CUDN")
-	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 2*time.Minute, "Pod ready timeout threshold")
+	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 0, "Pod ready timeout threshold")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
 	cmd.MarkFlagRequired("iterations")
 	return cmd

--- a/pkg/workloads/egressip.go
+++ b/pkg/workloads/egressip.go
@@ -166,7 +166,7 @@ func NewEgressIP(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 			os.Exit(rc)
 		},
 	}
-	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 2*time.Minute, "Pod ready timeout threshold")
+	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 0, "Pod ready timeout threshold")
 	cmd.Flags().IntVar(&iterations, "iterations", 0, fmt.Sprintf("%v iterations", variant))
 	cmd.Flags().StringVar(&externalServerIP, "external-server-ip", "", "External server IP address")
 	cmd.Flags().IntVar(&addressesPerIteration, "addresses-per-iteration", 1, fmt.Sprintf("%v iterations", variant))

--- a/pkg/workloads/evpn.go
+++ b/pkg/workloads/evpn.go
@@ -104,7 +104,7 @@ func NewEVPN(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 			os.Exit(rc)
 		},
 	}
-	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 2*time.Minute, "Pod ready timeout threshold")
+	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 0, "Pod ready timeout threshold")
 	cmd.Flags().IntVar(&iterations, "iterations", 10, fmt.Sprintf("%v iterations", variant))
 	cmd.Flags().IntVar(&namespacePerCudn, "namespaces-per-cudn", 1, "Number of namespaces sharing the same cluster udn")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")

--- a/pkg/workloads/network-policy.go
+++ b/pkg/workloads/network-policy.go
@@ -76,7 +76,7 @@ func NewNetworkPolicy(wh *workloads.WorkloadHelper, variant string) *cobra.Comma
 		},
 	}
 	cmd.Flags().IntVar(&iterations, "iterations", 10, fmt.Sprintf("%v iterations", variant))
-	cmd.Flags().DurationVar(&netpolReadyThreshold, "netpol-ready-threshold", 10*time.Second, "Network policy ready timeout threshold")
+	cmd.Flags().DurationVar(&netpolReadyThreshold, "netpol-ready-threshold", 0, "Network policy ready timeout threshold")
 	cmd.Flags().IntVar(&podsPerNamespace, "pods-per-namespace", 10, "Number of pods created in a namespace")
 	cmd.Flags().IntVar(&netpolPerNamespace, "netpol-per-namespace", 10, "Number of network policies created in a namespace")
 	cmd.Flags().IntVar(&localPods, "local-pods", 2, "Number of pods on the local namespace to receive traffic from remote namespace pods")

--- a/pkg/workloads/node-density.go
+++ b/pkg/workloads/node-density.go
@@ -128,14 +128,14 @@ func NewNodeDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Command
 	cmd.Flags().DurationVar(&pprofInterval, "pprof-interval", 0, "Interval between pprof collections")
 	switch variant {
 	case "node-density":
-		cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 15*time.Second, "Pod ready timeout threshold")
+		cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 0, "Pod ready timeout threshold")
 		cmd.Flags().StringVar(&containerImage, "container-image", "gcr.io/google_containers/pause:3.1", "Container image")
 	case "node-density-heavy":
-		cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 2*time.Minute, "Pod ready timeout threshold")
+		cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 0, "Pod ready timeout threshold")
 		cmd.Flags().DurationVar(&probesPeriod, "probes-period", 10*time.Second, "Perf app readiness/liveness probes period")
 		cmd.Flags().BoolVar(&svcLatency, "service-latency", false, "Enable service latency measurement")
 	case "node-density-cni":
-		cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 1*time.Minute, "Pod ready timeout threshold")
+		cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 0, "Pod ready timeout threshold")
 		cmd.Flags().BoolVar(&svcLatency, "service-latency", false, "Enable service latency measurement")
 		cmd.Flags().IntVar(&numSriovs, "num-sriovs", 0, "Number of SR-IOV interfaces per pod")
 		cmd.Flags().StringVar(&sriovNetworkName, "sriov-networkname", "sriov-net", "SR-IOV network name for IPAM configuration")

--- a/pkg/workloads/node-scale.go
+++ b/pkg/workloads/node-scale.go
@@ -68,7 +68,7 @@ func NewNodeScale(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 	cmd.Flags().IntVar(&cpu, "cpu", 1, "CPU capacity of each hollow node")
 	cmd.Flags().IntVar(&memory, "memory", 4, "Memory (G) of each hollow node")
 	cmd.Flags().IntVar(&maxPods, "max-pods", 250, "Max number of pods of each hollow node")
-	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 2*time.Minute, "Pod ready timeout threshold")
+	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 0, "Pod ready timeout threshold")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
 	return cmd
 }

--- a/pkg/workloads/rds-core.go
+++ b/pkg/workloads/rds-core.go
@@ -77,7 +77,7 @@ func NewRDSCore(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().IntVar(&iterations, "iterations", 0, "Number of iterations/namespaces")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
 	cmd.Flags().StringVar(&perfProfile, "perf-profile", "default", "Performance profile implemented in the cluster")
-	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 2*time.Minute, "Pod ready timeout threshold")
+	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 0, "Pod ready timeout threshold")
 	cmd.Flags().BoolVar(&svcLatency, "service-latency", false, "Enable service latency measurement")
 	return cmd
 }

--- a/pkg/workloads/udn-density-pods.go
+++ b/pkg/workloads/udn-density-pods.go
@@ -77,7 +77,7 @@ func NewUDNDensityPods(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().StringVar(&churnMode, "churn-mode", string(config.ChurnNamespaces), "Either namespaces, to churn entire namespaces or objects, to churn individual objects")
 	cmd.Flags().StringVar(&deletionStrategy, "deletion-strategy", config.DefaultDeletionStrategy, "GC deletion mode, default deletes entire namespaces and gvr deletes objects within namespaces before deleting the parent namespace")
 	cmd.Flags().IntVar(&iterations, "iterations", 0, "Job iterations, (One UDN will be created per iteration)")
-	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 1*time.Minute, "Pod ready timeout threshold")
+	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 0, "Pod ready timeout threshold")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
 	cmd.MarkFlagRequired("iterations")
 	return cmd

--- a/pkg/workloads/virt-density.go
+++ b/pkg/workloads/virt-density.go
@@ -66,7 +66,7 @@ func NewVirtDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 		},
 	}
 	cmd.Flags().IntVar(&vmsPerNode, "vms-per-node", 245, "VMs per node")
-	cmd.Flags().DurationVar(&vmiRunningThreshold, "vmi-ready-threshold", 25*time.Second, "VMI ready timeout threshold")
+	cmd.Flags().DurationVar(&vmiRunningThreshold, "vmi-ready-threshold", 0, "VMI ready timeout threshold")
 	cmd.Flags().BoolVar(&namespacedIterations, "namespaced-iterations", false, "Namespaced iterations")
 	cmd.Flags().IntVar(&iterationsPerNamespace, "iterations-per-namespace", 10, "Iterations per namespace")
 	cmd.Flags().StringVar(&vmImage, "vm-image", "quay.io/openshift-cnv/qe-cnv-tests-fedora:40", "Vm Image to be deployed")

--- a/pkg/workloads/virt-udn-density.go
+++ b/pkg/workloads/virt-udn-density.go
@@ -92,7 +92,7 @@ func NewVirtUDNDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().StringVar(&deletionStrategy, "deletion-strategy", config.DefaultDeletionStrategy, "GC deletion mode, default deletes entire namespaces and gvr deletes objects within namespaces before deleting the parent namespace")
 	cmd.Flags().IntVar(&iterations, "iterations", 1, "Job iterations, (One UDN will be created per iteration)")
 	cmd.Flags().IntVar(&vmsPerNode, "vms-per-node", 50, "VMs per node")
-	cmd.Flags().DurationVar(&vmiRunningThreshold, "vmi-ready-threshold", 60*time.Second, "VMI ready timeout threshold")
+	cmd.Flags().DurationVar(&vmiRunningThreshold, "vmi-ready-threshold", 0, "VMI ready timeout threshold")
 	cmd.Flags().BoolVar(&pprof, "pprof", false, "Enable pprof collection")
 	cmd.Flags().DurationVar(&pprofInterval, "pprof-interval", 0, "Interval between pprof collections")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")

--- a/pkg/workloads/web-burner.go
+++ b/pkg/workloads/web-burner.go
@@ -52,7 +52,7 @@ func NewWebBurner(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 			os.Exit(rc)
 		},
 	}
-	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 2*time.Minute, "Pod ready timeout threshold")
+	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 0, "Pod ready timeout threshold")
 	cmd.Flags().IntVar(&limitcount, "limitcount", 1, "Limitcount")
 	cmd.Flags().IntVar(&scale, "scale", 1, "Scale")
 	cmd.Flags().BoolVar(&bfd, "bfd", true, "Enable BFD")

--- a/pkg/workloads/whereabouts.go
+++ b/pkg/workloads/whereabouts.go
@@ -49,7 +49,7 @@ func NewWhereabouts(wh *workloads.WorkloadHelper) *cobra.Command {
 	}
 	cmd.Flags().IntVar(&iterations, "iterations", 10, "Number of iterations - each iteration is 1 ns and 6 pods")
 	cmd.Flags().BoolVar(&fast, "fast", false, "Use Fast IPAM")
-	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 15*time.Second, "Pod ready timeout threshold")
+	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 0, "Pod ready timeout threshold")
 	cmd.Flags().StringVar(&containerImage, "container-image", "gcr.io/google_containers/pause:3.1", "Container image")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics-aggregated.yml"}, "Comma separated list of metrics profiles to use")
 	return cmd


### PR DESCRIPTION
## Type of change

- Refactor

## Description

It was not previously possible to fully disable the latency threshold check without removing the parameter from the configuration.

This PR changes that behavior: setting the parameter to 0 now disables the check via a conditional in the templates.

In addition, updating the default value to 0 across all workloads. To enable the feature, users must provide a non-zero value going forward.

cc @jtaleric @afcollins @mohit-sheth @josecastillolema 

## Related Tickets & Documents

- Related Issue #
- Closes #

