### PR TITLE
Add CUDN churn support to cudn-density workload

### DIFF
--- a/cmd/config/cudn-density/README.md
+++ b/cmd/config/cudn-density/README.md
@@ -13,6 +13,12 @@
 - [Job Pipeline](#job-pipeline)
   - [CUDN Settling Pause](#cudn-settling-pause)
   - [Why the CUDN Cleanup Step?](#why-the-cudn-cleanup-step)
+- [CUDN Churn](#cudn-churn)
+  - [How It Works](#how-it-works)
+  - [Execution Flow](#execution-flow)
+  - [CUDN Selection](#cudn-selection)
+  - [Metrics During CUDN Churn](#metrics-during-cudn-churn)
+  - [Cleanup with CUDN Churn](#cleanup-with-cudn-churn)
 - [Measurements](#measurements)
   - [Pod Latency](#pod-latency)
   - [CUDN Latency](#cudn-latency-job-2)
@@ -21,7 +27,9 @@
 - [Usage](#usage)
   - [Basic Run](#basic-run)
   - [Layer 3 with Local Indexing](#layer-3-with-local-indexing)
-  - [With Churn](#with-churn)
+  - [With Pod Churn](#with-pod-churn)
+  - [With CUDN Churn](#with-cudn-churn)
+  - [Pod Churn + CUDN Churn Combined](#pod-churn--cudn-churn-combined)
   - [With pprof and OpenSearch Indexing](#with-pprof-and-opensearch-indexing)
 - [CLI Flags](#cli-flags)
 - [Scale Considerations](#scale-considerations)
@@ -40,6 +48,7 @@ The workload measures:
 - **CUDN creation latency** — how fast OVN-K can provision a new shared network
 - **Cross-namespace pod readiness** — how fast pods can communicate across namespace boundaries on a CUDN primary network
 - **OVN-K control plane resource consumption** — CPU, memory, and flow programming metrics under load
+- **CUDN churn resilience** — how OVN-K handles CUDN lifecycle events (deletion + recreation) while other CUDNs remain active
 
 ---
 
@@ -163,29 +172,31 @@ CUDN-0 group (namespaces 0-4):
 
 ## Job Pipeline
 
+### Normal Mode (no CUDN churn)
+
 ```
 Job 1          Job 2              Job 3              Job 4         Job 5
 Create         Create CUDNs +     Deploy Infra +     Cleanup       Cleanup
-Namespaces     Settling Pause     Workload           Namespaces    CUDNs
+Namespaces     Settling Pause     Workload + Churn   Namespaces    CUDNs
 ───────── ──►  ────────────── ──►  ────────────── ──►  ────────── ► ──────
  N ns          N/G CUDNs          Services, NPs      (GC only)    (GC only)
  + configmap   wait for           EgressFW, Quotas   no-wait       wait
-               NetworkCreated     + Deployments
-               measure latency    2m metrics pause
-               + settling pause
+               NetworkAlloc       + Deployments
+               measure latency    + pod object churn
+               + settling pause   2m metrics pause
 ```
 
 | # | Job Name | Type | What It Does |
 |---|----------|------|-------------|
 | 1 | `cudn-density-create-namespaces` | create | Creates N namespaces with UDN labels + a configmap per namespace |
-| 2 | `cudn-density-create-cudn-l2/l3` | create | Creates N/group_size CUDNs, waits for `NetworkCreated=True`. [Measures CUDN latency](#cudn-latency-job-2). Then pauses for [`--job-pause`](#cudn-settling-pause) to allow OVN-K to settle |
+| 2 | `cudn-density-create-cudn-l2/l3` | create | Creates N/group_size CUDNs, waits for `NetworkAllocationSucceeded=True`. [Measures CUDN latency](#cudn-latency-job-2). Then pauses for [`--job-pause`](#cudn-settling-pause) to allow OVN-K to settle |
 | 3 | `cudn-density-workload` | create | Deploys infra (services, NPs, EgressFirewall, ResourceQuota, LimitRange) and workload (server, app, client deployments) in a single job. Infra objects have `churn: false`. Pauses 2m after deployment for [metrics collection](#metrics-profiles) |
 | 4 | `cudn-density-cleanup-namespaces` | delete | [Deletes namespaces](#why-the-cudn-cleanup-step) without waiting (only when `--gc=true`). Pods are killed, NADs start terminating |
 | 5 | `cudn-density-cleanup-cudns` | delete | [Deletes CUDNs](#why-the-cudn-cleanup-step), releasing NAD finalizers so namespaces finish terminating (only when `--gc=true`) |
 
 ### CUDN Settling Pause
 
-After CUDN creation (Job 2), a configurable pause (`--job-pause`, default 30m) allows OVN-K to finish compiling the CUDN logical topology in the NB/SB databases and programming OVS flows on all nodes before workload pods are deployed. This is particularly important for Layer 2 topologies with Interconnect enabled, where the OVN NB DB client becomes a bottleneck when processing CUDN topology changes and pod port bindings simultaneously.
+After CUDN creation (Job 2), a configurable pause (`--job-pause`, default 1m) allows OVN-K to finish compiling the CUDN logical topology in the NB/SB databases and programming OVS flows on all nodes before workload pods are deployed. This is particularly important for Layer 2 topologies with Interconnect enabled, where the OVN NB DB client becomes a bottleneck when processing CUDN topology changes and pod port bindings simultaneously.
 
 ### Why the CUDN Cleanup Step?
 
@@ -199,20 +210,93 @@ Job 4 deletes namespaces without waiting (`waitForDeletion: false`), then Job 5 
 
 ---
 
+## CUDN Churn
+
+CUDN churn tests OVN-K's ability to handle CUDN lifecycle events — deleting and recreating CUDNs along with their dependent namespaces and workloads — while other CUDNs remain active on the cluster.
+
+### How It Works
+
+CUDN churn cannot use kube-burner's built-in `churnConfig` because CUDN deletion requires a specific multi-step sequence (delete namespaces first, then CUDNs) due to NAD finalizer dependencies. Instead, CUDN churn is implemented as a hybrid:
+
+- **Deletion** is handled by Go code that orchestrates the correct finalizer-aware sequence
+- **Recreation** is handled by kube-burner YAML jobs using the `iterationStart` feature to create resources at the correct indices
+
+This approach gives full kube-burner measurement and metrics collection (podLatency, cudnLatency, Prometheus scraping) during the recreation phase.
+
+### Execution Flow
+
+When `--cudn-churn-cycles > 0`, the workload runs in three phases:
+
+```
+Phase 1: wh.Run("cudn-density.yml")
+  ├── Job 1: Create namespaces
+  ├── Job 2: Create CUDNs + settling pause
+  └── Job 3: Deploy workload + pod churn (if enabled)
+      (cleanup jobs skipped — GC disabled)
+
+Phase 2: For each CUDN churn cycle:
+  ├── Go code: Delete namespaces → Delete CUDNs → Wait for termination
+  └── wh.Run("cudn-density.yml") with CUDN_CHURN_RECREATE=true:
+      ├── cudn-churn-create-ns:    Recreate namespaces (iterationStart offset)
+      ├── cudn-churn-create-cudns: Recreate CUDNs (iterationStart offset)
+      │   └── cudnLatency measurement + settling pause
+      └── cudn-churn-workload:     Redeploy workload (iterationStart offset)
+          └── podLatency measurement + Prometheus scraping
+
+Phase 3: wh.Run("cudn-density.yml") with CLEANUP_ONLY=true
+  ├── Job 4: Delete all namespaces (original + churn-recreated)
+  └── Job 5: Delete all CUDNs (original + churn-recreated)
+```
+
+### CUDN Selection
+
+CUDNs are selected **deterministically** — always the last N% of CUDNs. The same CUDNs are churned every cycle.
+
+```
+Example: 500 namespaces, 5 ns/cudn = 100 CUDNs, 10% churn
+
+numToChurn  = ceil(0.10 * 100) = 10
+churnStart  = 100 - 10 = 90
+
+Churned: cudn-90..cudn-99 (namespaces 450-499, 200 pods)
+Stable:  cudn-0..cudn-89  (namespaces 0-449, 1800 pods)
+```
+
+### Metrics During CUDN Churn
+
+Each churn cycle's recreation phase runs through kube-burner's job framework, so all standard measurements are collected:
+
+| Job | Measurement | What's Captured |
+|---|---|---|
+| `cudn-churn-create-cudns` | cudnLatency | Time from CUDN creation to `NetworkAllocationSucceeded=True` |
+| `cudn-churn-workload` | podLatency | Pod scheduling, initialization, containers ready, pod ready |
+| All churn jobs | Prometheus | containerCPU, containerMemory, API rates, node metrics, etc. |
+
+The pod latency watcher uses a job-scoped label selector (`kube-burner.io/job=cudn-churn-workload`), so only pods created during the churn cycle are measured — no double-counting with Phase 1 pods.
+
+### Cleanup with CUDN Churn
+
+The Phase 3 cleanup jobs use dual label selectors to find both original and churn-recreated resources:
+
+- Namespaces: `kube-burner.io/job=cudn-density-create-namespaces` + `kube-burner.io/job=cudn-churn-create-ns`
+- CUDNs: `kube-burner.io/job=cudn-density-create-cudn-l2` + `kube-burner.io/job=cudn-churn-create-cudns`
+
+---
+
 ## Measurements
 
 ### Pod Latency
 
-Standard kube-burner pod latency measurement tracking `PodScheduled`, `Initialized`, `ContainersReady`, and `Ready` conditions. Only indexed for Jobs 2 and 3:
+Standard kube-burner pod latency measurement tracking `PodScheduled`, `Initialized`, `ContainersReady`, and `Ready` conditions. Indexed for:
 
-- **Job 2**: Empty (CUDNs are cluster-scoped, no pods)
-- **Job 3**: The meaningful measurement — includes OVN network plumbing time + cross-namespace readiness probe validation
+- **Job 3 (`cudn-density-workload`)**: Initial deployment + pod churn pods
+- **CUDN churn (`cudn-churn-workload`)**: Pods redeployed after CUDN recreation (when CUDN churn is enabled)
 
-> **Note:** The `Ready` latency in Job 3 is higher than typical workloads because the readiness probe validates **cross-namespace** connectivity over the CUDN, not just local container readiness. This is by design — it directly measures CUDN network plumbing time.
+> **Note:** The `Ready` latency is higher than typical workloads because the readiness probe validates **cross-namespace** connectivity over the CUDN, not just local container readiness. This is by design — it directly measures CUDN network plumbing time.
 
 ### CUDN Latency (Job 2)
 
-Custom measurement (`cudnLatency`) that tracks how long each CUDN takes from creation to `NetworkCreated=True`. Uses the condition's `lastTransitionTime` for accurate measurement rather than wall-clock time. Results are indexed as `cudnLatencyMeasurement` documents with `NetworkCreatedLatency` in milliseconds.
+Custom measurement (`cudnLatency`) that tracks how long each CUDN takes from creation to `NetworkAllocationSucceeded=True`. Uses the condition's `lastTransitionTime` for accurate measurement rather than wall-clock time. Results are indexed as `cudnLatencyMeasurement` documents. Collected during both initial CUDN creation (Job 2) and CUDN churn recreation (`cudn-churn-create-cudns`).
 
 ### Metrics Profiles
 
@@ -252,16 +336,41 @@ kube-burner-ocp cudn-density \
   --local-indexing
 ```
 
-### With Churn
+### With Pod Churn
 
 > **Important:** Only `--churn-mode=objects` is supported. Namespace churn is not supported because [CUDN finalizers block namespace deletion](#why-the-cudn-cleanup-step).
 
 ```bash
 kube-burner-ocp cudn-density \
   --iterations=50 \
-  --churn-duration=30m \
-  --churn-percent=20 \
-  --churn-delay=1m
+  --churn-cycles=5 \
+  --churn-percent=50 \
+  --churn-delay=2m
+```
+
+### With CUDN Churn
+
+```bash
+kube-burner-ocp cudn-density \
+  --iterations=50 \
+  --namespaces-per-cudn=5 \
+  --cudn-churn-cycles=3 \
+  --cudn-churn-percent=10
+```
+
+This churns 1 CUDN per cycle (10% of 10 CUDNs), deleting and recreating 5 namespaces and 20 pods each cycle.
+
+### Pod Churn + CUDN Churn Combined
+
+Pod churn and CUDN churn run as sequential phases — pod churn happens within Job 3, then CUDN churn runs after.
+
+```bash
+kube-burner-ocp cudn-density \
+  --iterations=500 \
+  --namespaces-per-cudn=5 \
+  --churn-cycles=2 --churn-percent=50 \
+  --cudn-churn-cycles=2 --cudn-churn-percent=10 \
+  --job-pause=5m
 ```
 
 ### With pprof and OpenSearch Indexing
@@ -285,15 +394,18 @@ kube-burner-ocp cudn-density \
 | `--namespaces-per-cudn` | `5` | Namespaces per CUDN group. `iterations` must be divisible by this value |
 | `--layer3` | `false` | Use Layer3 topology (default is Layer2). See [Network Topology](#network-topology) |
 | `--job-pause` | `1m` | Pause after CUDN creation to allow OVN-K network settling before workload deployment. See [CUDN Settling Pause](#cudn-settling-pause) |
-| `--pod-ready-threshold` | `2m` | P99 pod ready timeout threshold |
+| `--pod-ready-threshold` | `0` | P99 pod ready timeout threshold |
 | `--pprof` | `false` | Enable [pprof collection](#pprof-collection) for ovnkube components |
 | `--pprof-interval` | `0` | Interval between pprof collections |
-| `--churn-cycles` | `0` | Number of churn cycles to execute |
-| `--churn-duration` | `0` | Total churn duration |
-| `--churn-delay` | `2m` | Delay between churn rounds |
-| `--churn-percent` | `10` | Percentage of iterations churned per round |
+| `--churn-cycles` | `0` | Number of pod churn cycles to execute |
+| `--churn-duration` | `0` | Total pod churn duration |
+| `--churn-delay` | `2m` | Delay between pod churn rounds |
+| `--churn-percent` | `10` | Percentage of deployments churned per round |
 | `--churn-mode` | `objects` | Churn mode (`objects` only; `namespaces` [not supported](#why-the-cudn-cleanup-step)) |
-| `--metrics-profile` | `metrics.yml,metrics-cudn.yml` | Comma-separated list of [metrics profiles](#metrics-profiles) to use |
+| `--cudn-churn-cycles` | `0` | Number of [CUDN churn](#cudn-churn) cycles (0 = disabled) |
+| `--cudn-churn-percent` | `10` | Percentage of CUDNs to churn per cycle (1-99) |
+| `--cudn-churn-delay` | `2m` | Delay between CUDN churn cycles |
+| `--metrics-profile` | `metrics.yml` | Comma-separated list of [metrics profiles](#metrics-profiles) to use |
 | `--gc` | `true` | Garbage collect created resources on completion. See [Cleanup](#cleanup) |
 
 ---
@@ -317,6 +429,7 @@ OVN LB entries = services/ns x 2 ports x namespaces.
 |------|--------|-------------|
 | `--namespaces-per-cudn` | **High** | Most impactful for NP/address-set load. Each NP with cross-namespace selectors creates address sets spanning all namespaces in the CUDN group. Going from 5 → 20 quadruples the address set size |
 | `--iterations` | **High** | Controls total namespace count. More namespaces = more pods, services, NPs, and OVN logical ports |
+| `--cudn-churn-percent` | **Medium** | Higher percentage churns more CUDNs per cycle, generating more OVN-K churn load |
 | `--layer3` | **Low** | L3 uses per-node subnets and routing, slightly more OVN-K work than flat L2 |
 
 ---
@@ -333,7 +446,7 @@ oc delete ns -l kube-burner.io/uuid --wait=false
 oc delete clusteruserdefinednetworks --all
 ```
 
-> **Note:** With `--gc=true`, this is handled automatically by [Job 4](#job-pipeline).
+> **Note:** With `--gc=true`, this is handled automatically by the cleanup jobs. When CUDN churn is enabled, cleanup runs as a separate Phase 3 after all churn cycles complete.
 
 ---
 
@@ -343,7 +456,14 @@ oc delete clusteruserdefinednetworks --all
 
 | File | Description |
 |------|-------------|
-| [`cudn-density.yml`](cudn-density.yml) | Main job configuration with 5-job pipeline |
+| [`cudn-density.yml`](cudn-density.yml) | Main job configuration with setup, churn recreate, and cleanup sections |
+
+### Go Source
+
+| File | Description |
+|------|-------------|
+| `pkg/workloads/cudn-density.go` | CLI flags, validation, and 3-phase orchestration for CUDN churn |
+| `pkg/workloads/cudn-churn.go` | CUDN churn deletion logic (finalizer-aware namespace + CUDN deletion) |
 
 ### Network Templates
 

--- a/cmd/config/cudn-density/cudn-density.yml
+++ b/cmd/config/cudn-density/cudn-density.yml
@@ -45,6 +45,7 @@ metricsEndpoints:
 
 {{ $cudnJobName := ternary "cudn-density-create-cudn-l3" "cudn-density-create-cudn-l2" .ENABLE_LAYER_3 }}
 jobs:
+{{ if and (not .CLEANUP_ONLY) (not .CUDN_CHURN_RECREATE) }}
   # Job 1: Create namespaces with CUDN labels
   - name: cudn-density-create-namespaces
     namespace: cudn-density
@@ -84,7 +85,7 @@ jobs:
           total_namespaces: {{.JOB_ITERATIONS}}
         waitOptions:
           customStatusPaths:
-            - key: .conditions[] | select(.type=="NetworkCreated") | .status
+            - key: .conditions[] | select(.type=="NetworkAllocationSucceeded") | .status
               value: "True"
       {{ else }}
       - objectTemplate: cudn-l2.yml
@@ -94,7 +95,7 @@ jobs:
           total_namespaces: {{.JOB_ITERATIONS}}
         waitOptions:
           customStatusPaths:
-            - key: .conditions[] | select(.type=="NetworkCreated") | .status
+            - key: .conditions[] | select(.type=="NetworkAllocationSucceeded") | .status
               value: "True"
       {{ end }}
 
@@ -199,10 +200,151 @@ jobs:
           podReplicas: 1
           namespaces_per_cudn: {{.NAMESPACES_PER_CUDN}}
 
-{{ if .GC }}
+{{ end }}
+{{ if .CUDN_CHURN_RECREATE }}
+  # CUDN Churn: Recreate namespaces with iteration offset
+  - name: cudn-churn-create-ns
+    namespace: cudn-density
+    jobIterations: {{.CUDN_CHURN_NS_COUNT}}
+    iterationStart: {{.CUDN_CHURN_NS_START}}
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    namespacedIterations: true
+    waitWhenFinished: true
+    skipIndexing: true
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+      k8s.ovn.org/primary-user-defined-network: ""
+    objects:
+      - objectTemplate: configmap.yml
+        replicas: 1
+
+  # CUDN Churn: Recreate CUDNs with iteration offset
+  - name: cudn-churn-create-cudns
+    jobIterations: {{.CUDN_CHURN_CUDN_COUNT}}
+    iterationStart: {{.CUDN_CHURN_CUDN_START}}
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    namespacedIterations: false
+    waitWhenFinished: true
+    jobPause: {{.JOB_PAUSE}}
+    measurements:
+      - name: cudnLatency
+    objects:
+      {{ if .ENABLE_LAYER_3 }}
+      - objectTemplate: cudn-l3.yml
+        replicas: 1
+        inputVars:
+          namespaces_per_cudn: {{.NAMESPACES_PER_CUDN}}
+          total_namespaces: {{.JOB_ITERATIONS}}
+        waitOptions:
+          customStatusPaths:
+            - key: .conditions[] | select(.type=="NetworkAllocationSucceeded") | .status
+              value: "True"
+      {{ else }}
+      - objectTemplate: cudn-l2.yml
+        replicas: 1
+        inputVars:
+          namespaces_per_cudn: {{.NAMESPACES_PER_CUDN}}
+          total_namespaces: {{.JOB_ITERATIONS}}
+        waitOptions:
+          customStatusPaths:
+            - key: .conditions[] | select(.type=="NetworkAllocationSucceeded") | .status
+              value: "True"
+      {{ end }}
+
+  # CUDN Churn: Redeploy workload with iteration offset
+  - name: cudn-churn-workload
+    namespace: cudn-density
+    jobIterations: {{.CUDN_CHURN_NS_COUNT}}
+    iterationStart: {{.CUDN_CHURN_NS_START}}
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    namespacedIterations: true
+    waitWhenFinished: true
+    preLoadImages: true
+    measurements:
+      - name: podLatency
+{{ if ne .POD_READY_THRESHOLD 0 }}
+        thresholds:
+          - conditionType: Ready
+            metric: P99
+            threshold: {{.POD_READY_THRESHOLD}}
+{{ end }}
+    jobPause: 2m
+    metricsClosing: afterJobPause
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+      k8s.ovn.org/primary-user-defined-network: ""
+    objects:
+      - objectTemplate: service.yml
+        replicas: 1
+
+      - objectTemplate: service-headless.yml
+        replicas: 1
+
+      - objectTemplate: service-server.yml
+        replicas: 1
+
+      - objectTemplate: np-deny-all.yml
+        replicas: 1
+
+      - objectTemplate: np-allow-cudn-ingress.yml
+        replicas: 1
+        inputVars:
+          namespaces_per_cudn: {{.NAMESPACES_PER_CUDN}}
+
+      - objectTemplate: np-allow-cudn-egress.yml
+        replicas: 1
+        inputVars:
+          namespaces_per_cudn: {{.NAMESPACES_PER_CUDN}}
+
+      - objectTemplate: np-allow-app-ingress.yml
+        replicas: 1
+        inputVars:
+          namespaces_per_cudn: {{.NAMESPACES_PER_CUDN}}
+
+      - objectTemplate: np-allow-app-egress.yml
+        replicas: 1
+        inputVars:
+          namespaces_per_cudn: {{.NAMESPACES_PER_CUDN}}
+
+      - objectTemplate: egressfirewall.yml
+        replicas: 1
+
+      - objectTemplate: resourcequota.yml
+        replicas: 1
+
+      - objectTemplate: limitrange.yml
+        replicas: 1
+
+      - objectTemplate: deployment-server.yml
+        replicas: 1
+        inputVars:
+          podReplicas: 2
+
+      - objectTemplate: deployment-app.yml
+        replicas: 1
+        inputVars:
+          podReplicas: 1
+
+      - objectTemplate: deployment-client.yml
+        replicas: 1
+        inputVars:
+          podReplicas: 1
+          namespaces_per_cudn: {{.NAMESPACES_PER_CUDN}}
+{{ end }}
+{{ if or (and .GC (not .CUDN_CHURN_ENABLED)) .CLEANUP_ONLY }}
   # Job 4: Delete workload namespaces (kills pods, NADs start terminating)
   # Uses waitForDeletion: false because namespaces will be stuck in Terminating
   # until CUDNs are deleted in Job 5 (NAD finalizers block namespace deletion).
+  # Includes both original and churn-recreated namespaces (different kube-burner.io/job labels).
   - name: cudn-density-cleanup-namespaces
     jobType: delete
     waitForDeletion: false
@@ -213,8 +355,12 @@ jobs:
       - kind: Namespace
         apiVersion: v1
         labelSelector: {kube-burner.io/job: cudn-density-create-namespaces}
+      - kind: Namespace
+        apiVersion: v1
+        labelSelector: {kube-burner.io/job: cudn-churn-create-ns}
 
   # Job 5: Delete CUDNs (releases NAD finalizers, namespaces finish terminating)
+  # Includes both original and churn-recreated CUDNs.
   - name: cudn-density-cleanup-cudns
     jobType: delete
     waitForDeletion: true
@@ -225,4 +371,7 @@ jobs:
       - kind: ClusterUserDefinedNetwork
         apiVersion: k8s.ovn.org/v1
         labelSelector: {kube-burner.io/job: {{ $cudnJobName }} }
+      - kind: ClusterUserDefinedNetwork
+        apiVersion: k8s.ovn.org/v1
+        labelSelector: {kube-burner.io/job: cudn-churn-create-cudns}
 {{ end }}

--- a/pkg/measurements/cudn-latency.go
+++ b/pkg/measurements/cudn-latency.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kube-burner/kube-burner/v2/pkg/measurements/types"
 	"github.com/kube-burner/kube-burner/v2/pkg/util/fileutils"
 	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -36,7 +37,7 @@ import (
 const (
 	cudnLatencyMeasurementName      = "cudnLatencyMeasurement"
 	cudnLatencyQuantilesMeasurement = "cudnLatencyQuantilesMeasurement"
-	cudnReadyConditionType          = "NetworkCreated"
+	cudnReadyConditionType          = "NetworkAllocationSucceeded"
 )
 
 var (
@@ -49,13 +50,13 @@ var (
 )
 
 type cudnMetric struct {
-	Timestamp             time.Time `json:"timestamp"`
-	MetricName            string    `json:"metricName"`
-	UUID                  string    `json:"uuid"`
-	JobName               string    `json:"jobName,omitempty"`
-	Name                  string    `json:"cudnName"`
-	Metadata              any       `json:"metadata,omitempty"`
-	NetworkCreatedLatency int       `json:"networkAllocLatency"`
+	Timestamp                         time.Time `json:"timestamp"`
+	MetricName                        string    `json:"metricName"`
+	UUID                              string    `json:"uuid"`
+	JobName                           string    `json:"jobName,omitempty"`
+	Name                              string    `json:"cudnName"`
+	Metadata                          any       `json:"metadata,omitempty"`
+	NetworkAllocationSucceededLatency int       `json:"networkAllocLatency"`
 }
 
 type cudnLatency struct {
@@ -99,33 +100,33 @@ func (c *cudnLatency) handleAdd(obj any) {
 		return
 	}
 
-	// Check if NetworkCreated is already True at creation time
+	// Check if NetworkAllocationSucceeded is already True at creation time
 	if transitionTime, ok := getNetworkAllocTransitionTime(cudn); ok {
 		latency := transitionTime.Sub(t).Milliseconds()
-		log.Debugf("CUDN %s already has NetworkCreated=True, latency: %dms", cudnName, latency)
+		log.Debugf("CUDN %s already has NetworkAllocationSucceeded=True, latency: %dms", cudnName, latency)
 		c.Metrics.LoadOrStore(cudnName, cudnMetric{
-			Name:                  cudnName,
-			Timestamp:             t.UTC(),
-			MetricName:            cudnLatencyMeasurementName,
-			UUID:                  c.Uuid,
-			Metadata:              c.Metadata,
-			JobName:               c.JobConfig.Name,
-			NetworkCreatedLatency: int(latency),
+			Name:                              cudnName,
+			Timestamp:                         t.UTC(),
+			MetricName:                        cudnLatencyMeasurementName,
+			UUID:                              c.Uuid,
+			Metadata:                          c.Metadata,
+			JobName:                           c.JobConfig.Name,
+			NetworkAllocationSucceededLatency: int(latency),
 		})
 		return
 	}
 
 	// Store creation timestamp, latency will be computed on update
 	c.Metrics.LoadOrStore(cudnName, cudnMetric{
-		Name:                  cudnName,
-		Timestamp:             t.UTC(),
-		MetricName:            cudnLatencyMeasurementName,
-		UUID:                  c.Uuid,
-		Metadata:              c.Metadata,
-		JobName:               c.JobConfig.Name,
-		NetworkCreatedLatency: -1, // Not yet ready
+		Name:                              cudnName,
+		Timestamp:                         t.UTC(),
+		MetricName:                        cudnLatencyMeasurementName,
+		UUID:                              c.Uuid,
+		Metadata:                          c.Metadata,
+		JobName:                           c.JobConfig.Name,
+		NetworkAllocationSucceededLatency: -1, // Not yet ready
 	})
-	log.Debugf("CUDN %s created at %v, waiting for NetworkCreated", cudnName, t.UTC())
+	log.Debugf("CUDN %s created at %v, waiting for NetworkAllocationSucceeded", cudnName, t.UTC())
 }
 
 func (c *cudnLatency) handleUpdate(oldObj, newObj any) {
@@ -142,18 +143,18 @@ func (c *cudnLatency) handleUpdate(oldObj, newObj any) {
 		return
 	}
 	m := val.(cudnMetric)
-	if m.NetworkCreatedLatency >= 0 {
+	if m.NetworkAllocationSucceededLatency >= 0 {
 		return // Already recorded
 	}
 
 	latency := transitionTime.Sub(m.Timestamp).Milliseconds()
-	m.NetworkCreatedLatency = int(latency)
+	m.NetworkAllocationSucceededLatency = int(latency)
 	c.Metrics.Store(cudnName, m)
-	log.Debugf("CUDN %s NetworkCreated after %dms", cudnName, latency)
+	log.Debugf("CUDN %s NetworkAllocationSucceeded after %dms", cudnName, latency)
 }
 
 // getNetworkAllocTransitionTime returns the lastTransitionTime of the
-// NetworkCreated=True condition, and true if found.
+// NetworkAllocationSucceeded=True condition, and true if found.
 func getNetworkAllocTransitionTime(cudn *unstructured.Unstructured) (time.Time, bool) {
 	conditions, found, err := unstructured.NestedSlice(cudn.UnstructuredContent(), "status", "conditions")
 	if err != nil || !found {
@@ -172,7 +173,7 @@ func getNetworkAllocTransitionTime(cudn *unstructured.Unstructured) (time.Time, 
 				return t, true
 			}
 			// Fall back to current time if lastTransitionTime is missing
-			log.Warnf("CUDN %s: NetworkCreated=True but missing lastTransitionTime, using current time", cudn.GetName())
+			log.Warnf("CUDN %s: NetworkAllocationSucceeded=True but missing lastTransitionTime, using current time", cudn.GetName())
 			return time.Now().UTC(), true
 		}
 	}
@@ -190,7 +191,11 @@ func (c *cudnLatency) Start(measurementWg *sync.WaitGroup) error {
 	}
 
 	c.stopCh = make(chan struct{})
-	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(c.dynamicClient, 0, "", nil)
+	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(c.dynamicClient, 0, "", func(opts *metav1.ListOptions) {
+		if c.LabelSelector != "" {
+			opts.LabelSelector = c.LabelSelector
+		}
+	})
 	cudnInformer := factory.ForResource(cudnGVRForLatency).Informer()
 	cudnInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.handleAdd,
@@ -218,8 +223,8 @@ func (c *cudnLatency) Stop() error {
 func (c *cudnLatency) normalizeMetrics() float64 {
 	c.Metrics.Range(func(key, value any) bool {
 		m := value.(cudnMetric)
-		if m.NetworkCreatedLatency < 0 {
-			log.Warnf("CUDN %s never reached NetworkCreated=True, excluding from latency metrics", m.Name)
+		if m.NetworkAllocationSucceededLatency < 0 {
+			log.Warnf("CUDN %s never reached NetworkAllocationSucceeded=True, excluding from latency metrics", m.Name)
 			return true
 		}
 		c.NormLatencies = append(c.NormLatencies, m)
@@ -231,7 +236,7 @@ func (c *cudnLatency) normalizeMetrics() float64 {
 func (c *cudnLatency) getLatency(normLatency any) map[string]float64 {
 	m := normLatency.(cudnMetric)
 	return map[string]float64{
-		"NetworkCreatedLatency": float64(m.NetworkCreatedLatency),
+		"NetworkAllocationSucceededLatency": float64(m.NetworkAllocationSucceededLatency),
 	}
 }
 

--- a/pkg/workloads/cudn-churn.go
+++ b/pkg/workloads/cudn-churn.go
@@ -1,0 +1,138 @@
+// Copyright 2025 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workloads
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+)
+
+var cudnGVR = schema.GroupVersionResource{
+	Group:    "k8s.ovn.org",
+	Version:  "v1",
+	Resource: "clusteruserdefinednetworks",
+}
+
+type cudnChurnDeleter struct {
+	clientSet     kubernetes.Interface
+	dynamicClient dynamic.Interface
+	cudnIndices   []int
+	nsPerCudn     int
+}
+
+func newCudnChurnDeleter(clientSet kubernetes.Interface, dynamicClient dynamic.Interface, totalNamespaces, nsPerCudn, churnPercent int) *cudnChurnDeleter {
+	numCudns := totalNamespaces / nsPerCudn
+	numToChurn := int(math.Ceil(float64(churnPercent) * float64(numCudns) / 100.0))
+	churnStartIdx := numCudns - numToChurn
+	cudnIndices := make([]int, numToChurn)
+	for i := range numToChurn {
+		cudnIndices[i] = churnStartIdx + i
+	}
+	return &cudnChurnDeleter{
+		clientSet:     clientSet,
+		dynamicClient: dynamicClient,
+		cudnIndices:   cudnIndices,
+		nsPerCudn:     nsPerCudn,
+	}
+}
+
+func (d *cudnChurnDeleter) deleteAndWait() error {
+	ctx := context.Background()
+	if err := d.deleteNamespaces(ctx); err != nil {
+		return err
+	}
+	if err := d.deleteCudns(ctx); err != nil {
+		return err
+	}
+	return d.waitForNamespaces(ctx)
+}
+
+func (d *cudnChurnDeleter) deleteNamespaces(ctx context.Context) error {
+	log.Info("Deleting namespaces for churned CUDNs (not waiting for completion)")
+	for _, cudnIdx := range d.cudnIndices {
+		for j := 0; j < d.nsPerCudn; j++ {
+			nsName := fmt.Sprintf("cudn-density-%d", cudnIdx*d.nsPerCudn+j)
+			err := d.clientSet.CoreV1().Namespaces().Delete(ctx, nsName, metav1.DeleteOptions{})
+			if err != nil && !errors.IsNotFound(err) {
+				return fmt.Errorf("failed to delete namespace %s: %v", nsName, err)
+			}
+			log.Debugf("Deleted namespace %s", nsName)
+		}
+	}
+	return nil
+}
+
+func (d *cudnChurnDeleter) deleteCudns(ctx context.Context) error {
+	log.Info("Deleting churned CUDNs (waiting for completion)")
+	for _, cudnIdx := range d.cudnIndices {
+		cudnName := fmt.Sprintf("cudn-%d", cudnIdx)
+		err := d.dynamicClient.Resource(cudnGVR).Delete(ctx, cudnName, metav1.DeleteOptions{})
+		if err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete CUDN %s: %v", cudnName, err)
+		}
+		log.Debugf("Deleted CUDN %s", cudnName)
+	}
+
+	pollCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+	return wait.PollUntilContextCancel(pollCtx, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+		for _, cudnIdx := range d.cudnIndices {
+			cudnName := fmt.Sprintf("cudn-%d", cudnIdx)
+			_, err := d.dynamicClient.Resource(cudnGVR).Get(ctx, cudnName, metav1.GetOptions{})
+			if err == nil {
+				log.Debugf("Waiting for CUDN %s to be deleted", cudnName)
+				return false, nil
+			}
+			if !errors.IsNotFound(err) {
+				return false, fmt.Errorf("error checking CUDN %s: %v", cudnName, err)
+			}
+		}
+		log.Info("All churned CUDNs deleted")
+		return true, nil
+	})
+}
+
+func (d *cudnChurnDeleter) waitForNamespaces(ctx context.Context) error {
+	log.Info("Waiting for namespaces to finish terminating")
+	pollCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+	return wait.PollUntilContextCancel(pollCtx, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+		for _, cudnIdx := range d.cudnIndices {
+			for j := 0; j < d.nsPerCudn; j++ {
+				nsName := fmt.Sprintf("cudn-density-%d", cudnIdx*d.nsPerCudn+j)
+				_, err := d.clientSet.CoreV1().Namespaces().Get(ctx, nsName, metav1.GetOptions{})
+				if err == nil {
+					log.Debugf("Waiting for namespace %s to be deleted", nsName)
+					return false, nil
+				}
+				if !errors.IsNotFound(err) {
+					return false, fmt.Errorf("error checking namespace %s: %v", nsName, err)
+				}
+			}
+		}
+		log.Info("All churned namespaces deleted")
+		return true, nil
+	})
+}

--- a/pkg/workloads/cudn-density.go
+++ b/pkg/workloads/cudn-density.go
@@ -15,6 +15,7 @@
 package workloads
 
 import (
+	"math"
 	"os"
 	"time"
 
@@ -23,6 +24,7 @@ import (
 	"github.com/kube-burner/kube-burner/v2/pkg/workloads"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/dynamic"
 
 	"github.com/kube-burner/kube-burner-ocp/pkg/measurements"
 )
@@ -34,8 +36,9 @@ var cudnMeasurementFactoryMap = map[string]kubeburnermeasurements.NewMeasurement
 // NewCudnDensity holds cudn-density workload
 func NewCudnDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 	var churnPercent, churnCycles, iterations, namespacesPerCudn int
+	var cudnChurnCycles, cudnChurnPercent int
 	var l3, pprof bool
-	var churnDelay, churnDuration, podReadyThreshold, pprofInterval, jobPause time.Duration
+	var churnDelay, churnDuration, podReadyThreshold, pprofInterval, jobPause, cudnChurnDelay time.Duration
 	var churnMode string
 	var metricsProfiles []string
 	var rc int
@@ -50,6 +53,19 @@ func NewCudnDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 			if churnMode == string(config.ChurnNamespaces) && (churnDuration > 0 || churnCycles > 0) {
 				log.Fatal("churn-mode=namespaces is not supported for cudn-density: CUDN finalizers block namespace deletion. Use --churn-mode=objects instead")
 			}
+			if cudnChurnCycles > 0 {
+				if cudnChurnPercent < 1 || cudnChurnPercent > 99 {
+					log.Fatalf("cudn-churn-percent must be between 1 and 99, got %d", cudnChurnPercent)
+				}
+				numCudns := iterations / namespacesPerCudn
+				numToChurn := int(math.Ceil(float64(cudnChurnPercent) * float64(numCudns) / 100.0))
+				if numToChurn < 1 {
+					log.Fatalf("cudn-churn-percent=%d with %d CUDNs results in 0 CUDNs to churn", cudnChurnPercent, numCudns)
+				}
+				if numToChurn >= numCudns {
+					log.Fatalf("cudn-churn-percent=%d would churn all %d CUDNs; reduce the percentage", cudnChurnPercent, numCudns)
+				}
+			}
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			setMetrics(cmd, metricsProfiles)
@@ -59,7 +75,10 @@ func NewCudnDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 				log.Info("Layer 2 topology enabled")
 			}
 			if churnDuration > 0 || churnCycles > 0 {
-				log.Info("Churn is enabled")
+				log.Info("Pod churn is enabled")
+			}
+			if cudnChurnCycles > 0 {
+				log.Info("CUDN churn is enabled")
 			}
 
 			AdditionalVars["PPROF"] = pprof
@@ -74,8 +93,85 @@ func NewCudnDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 			AdditionalVars["NAMESPACES_PER_CUDN"] = namespacesPerCudn
 			AdditionalVars["POD_READY_THRESHOLD"] = podReadyThreshold
 			AdditionalVars["ENABLE_LAYER_3"] = l3
+			AdditionalVars["CUDN_CHURN_ENABLED"] = cudnChurnCycles > 0
+			AdditionalVars["CLEANUP_ONLY"] = false
+			AdditionalVars["CUDN_CHURN_RECREATE"] = false
+
 			wh.SetMeasurements(cudnMeasurementFactoryMap)
-			rc = RunWorkload(cmd, wh, cmd.Name()+".yml")
+
+			if cudnChurnCycles == 0 {
+				rc = RunWorkload(cmd, wh, cmd.Name()+".yml")
+			} else {
+				gcEnabled, _ := cmd.Root().PersistentFlags().GetBool("gc")
+				AdditionalVars["GC"] = false
+
+				// Phase 1: Setup + pod churn
+				rc = RunWorkload(cmd, wh, cmd.Name()+".yml")
+				if rc != 0 {
+					log.Error("Phase 1 setup failed, skipping CUDN churn and proceeding to cleanup")
+				}
+
+				// Phase 2: CUDN churn cycles (skipped if Phase 1 failed)
+				if rc == 0 {
+					kubeClientProvider := config.NewKubeClientProvider("", "")
+					clientSet, restConfig := kubeClientProvider.ClientSet(0, 0)
+					dynamicClient, err := dynamic.NewForConfig(restConfig)
+					if err != nil {
+						log.Fatalf("Failed to create dynamic client: %v", err)
+					}
+					deleter := newCudnChurnDeleter(clientSet, dynamicClient, iterations, namespacesPerCudn, cudnChurnPercent)
+					churnStartIdx := deleter.cudnIndices[0]
+					numToChurn := len(deleter.cudnIndices)
+					nsStart := churnStartIdx * namespacesPerCudn
+					nsCount := numToChurn * namespacesPerCudn
+
+					AdditionalVars["CUDN_CHURN_RECREATE"] = true
+					AdditionalVars["CUDN_CHURN_NS_START"] = nsStart
+					AdditionalVars["CUDN_CHURN_NS_COUNT"] = nsCount
+					AdditionalVars["CUDN_CHURN_CUDN_START"] = churnStartIdx
+					AdditionalVars["CUDN_CHURN_CUDN_COUNT"] = numToChurn
+
+					for cycle := 0; cycle < cudnChurnCycles; cycle++ {
+						log.Infof("CUDN churn cycle %d/%d: churning %d CUDNs (indices %d-%d)",
+							cycle+1, cudnChurnCycles, numToChurn, churnStartIdx, churnStartIdx+numToChurn-1)
+
+						if err := deleter.deleteAndWait(); err != nil {
+							log.Errorf("CUDN churn cycle %d: %v", cycle+1, err)
+							rc = 1
+							break
+						}
+
+						wh.SetVariables(AdditionalVars, SetVars)
+						churnRC := wh.Run(cmd.Name() + ".yml")
+						if churnRC != 0 {
+							log.Errorf("CUDN churn cycle %d recreation failed", cycle+1)
+							rc = churnRC
+							break
+						}
+
+						log.Infof("CUDN churn cycle %d/%d completed successfully", cycle+1, cudnChurnCycles)
+						if cycle < cudnChurnCycles-1 {
+							log.Infof("Sleeping %v before next CUDN churn cycle", cudnChurnDelay)
+							time.Sleep(cudnChurnDelay)
+						}
+					}
+					AdditionalVars["CUDN_CHURN_RECREATE"] = false
+				}
+
+				if rc != 0 {
+					log.Error("CUDN churn failed, proceeding to cleanup")
+				}
+
+				// Phase 3: Cleanup
+				if gcEnabled {
+					AdditionalVars["CLEANUP_ONLY"] = true
+					wh.SetVariables(AdditionalVars, SetVars)
+					cleanupRC := wh.Run(cmd.Name() + ".yml")
+					if cleanupRC != 0 && rc == 0 {
+						rc = cleanupRC
+					}
+				}
+			}
 		},
 		PostRun: func(cmd *cobra.Command, args []string) {
 			os.Exit(rc)
@@ -94,6 +190,9 @@ func NewCudnDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().IntVar(&namespacesPerCudn, "namespaces-per-cudn", 5, "Number of namespaces sharing the same CUDN")
 	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 0, "Pod ready timeout threshold")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
+	cmd.Flags().IntVar(&cudnChurnCycles, "cudn-churn-cycles", 0, "Number of CUDN churn cycles (0=disabled). Each cycle deletes and recreates a percentage of CUDNs with their namespaces and workloads")
+	cmd.Flags().IntVar(&cudnChurnPercent, "cudn-churn-percent", 10, "Percentage of CUDNs to churn per cycle (1-99)")
+	cmd.Flags().DurationVar(&cudnChurnDelay, "cudn-churn-delay", 2*time.Minute, "Time to wait between CUDN churn cycles")
 	cmd.MarkFlagRequired("iterations")
 	return cmd
 }

--- a/test/test-ocp.bats
+++ b/test/test-ocp.bats
@@ -143,6 +143,18 @@ teardown_file() {
   verify_object_count clusteruserdefinednetworks 0 "" kube-burner.io/job=cudn-density-create-cudn-l2
 }
 
+@test "cudn-density-l2: pod-churn + cudn-churn" {
+  oc delete clusteruserdefinednetworks --all --ignore-not-found
+  run_cmd ${KUBE_BURNER_OCP} cudn-density --extract
+  run_cmd ${KUBE_BURNER_OCP} cudn-density --iterations=10 --namespaces-per-cudn=5 --gc=true --job-pause=0s \
+    --churn-cycles=1 --churn-percent=50 --churn-delay=5s \
+    --cudn-churn-cycles=1 --cudn-churn-percent=50 --cudn-churn-delay=5s \
+    --uuid=${UUID}
+  # Verify all resources cleaned up (both original and churn-recreated)
+  verify_object_count clusteruserdefinednetworks 0 "" kube-burner.io/job=cudn-density-create-cudn-l2
+  verify_object_count clusteruserdefinednetworks 0 "" kube-burner.io/job=cudn-churn-create-cudns
+}
+
 @test "cluster-health" {
   run_cmd ${KUBE_BURNER_OCP} cluster-health
 }


### PR DESCRIPTION
Add the ability to delete and recreate a percentage of CUDNs along with their dependent namespaces

New flags:` --cudn-churn-cycles, --cudn-churn-percent, --cudn-churn-delay`

The workload runs in three phases when CUDN churn is enabled:

- Phase 1: Setup + pod churn (existing behavior, cleanup deferred)
- Phase 2: CUDN churn cycles (Go deletion + YAML recreation using [kube-burner's new iterationStart](https://github.com/kube-burner/kube-burner/pull/1240) for correct namespace/CUDN indices)

  - Deletes the churned namespaces and CUDNs in the correct order — namespaces first (they get stuck in Terminating), then CUDNs (releases the finalizers so namespaces can finish deleting), then waits until everything is gone.
  - Targets specific resources by name — picks the last N% of CUDNs deterministically (e.g., cudn-9 out of 10 CUDNs at 10%) and their associated namespaces.
  - Why not use kube-burner's built-in churn — pod churn deletes and recreates objects within a single job in one step. CUDN churn requires an ordered sequence across two resource types: delete namespaces first, then delete CUDNs, wait for finalizers to clear between each step, then recreate both in order. The churn framework has no concept of cross-resource dependencies or finalizer-aware ordering.
- Phase 3: Cleanup via standard delete jobs

Pod latency, CUDN latency, and Prometheus metrics are collected end-to-end across all phases with no duplicate indexing.

Also update CUDN condition from NetworkCreated to
NetworkAllocationSucceeded to match current OVN-K API.

