### PR TITLE
Restore CPU profiling and standardize pprof duration to 60s

### DIFF
--- a/cmd/config/cluster-density-v2/cluster-density-v2.yml
+++ b/cmd/config/cluster-density-v2/cluster-density-v2.yml
@@ -20,10 +20,18 @@ global:
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-node}
         url: http://localhost:29103/debug/pprof/heap
+      - name: ovnkube-controller-cpu
+        namespace: "openshift-ovn-kubernetes"
+        labelSelector: {app: ovnkube-node}
+        url: http://localhost:29103/debug/pprof/profile?seconds=60
       - name: ovnk-control-plane-heap
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-control-plane}
         url: http://localhost:29108/debug/pprof/heap
+      - name: ovnk-control-plane-cpu
+        namespace: "openshift-ovn-kubernetes"
+        labelSelector: {app: ovnkube-control-plane}
+        url: http://localhost:29108/debug/pprof/profile?seconds=60
 {{ end }}
 {{ if .SVC_LATENCY }}
     - name: serviceLatency

--- a/cmd/config/cudn-density/cudn-density.yml
+++ b/cmd/config/cudn-density/cudn-density.yml
@@ -15,7 +15,7 @@ global:
       - name: ovnkube-controller-cpu
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-node}
-        url: http://localhost:29103/debug/pprof/profile?seconds=30
+        url: http://localhost:29103/debug/pprof/profile?seconds=60
       - name: ovnk-control-plane-heap
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-control-plane}
@@ -23,7 +23,7 @@ global:
       - name: ovnk-control-plane-cpu
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-control-plane}
-        url: http://localhost:29108/debug/pprof/profile?seconds=30
+        url: http://localhost:29108/debug/pprof/profile?seconds=60
 {{ end }}
 metricsEndpoints:
 {{ if .ES_SERVER }}

--- a/cmd/config/node-density-cni/node-density-cni.yml
+++ b/cmd/config/node-density-cni/node-density-cni.yml
@@ -20,10 +20,18 @@ global:
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-node}
         url: http://localhost:29103/debug/pprof/heap
+      - name: ovnkube-controller-cpu
+        namespace: "openshift-ovn-kubernetes"
+        labelSelector: {app: ovnkube-node}
+        url: http://localhost:29103/debug/pprof/profile?seconds=60
       - name: ovnk-control-plane-heap
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-control-plane}
         url: http://localhost:29108/debug/pprof/heap
+      - name: ovnk-control-plane-cpu
+        namespace: "openshift-ovn-kubernetes"
+        labelSelector: {app: ovnkube-control-plane}
+        url: http://localhost:29108/debug/pprof/profile?seconds=60
 {{ end }}
 {{ if .SVC_LATENCY }}
     - name: serviceLatency

--- a/cmd/config/node-density-heavy/node-density-heavy.yml
+++ b/cmd/config/node-density-heavy/node-density-heavy.yml
@@ -20,10 +20,18 @@ global:
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-node}
         url: http://localhost:29103/debug/pprof/heap
+      - name: ovnkube-controller-cpu
+        namespace: "openshift-ovn-kubernetes"
+        labelSelector: {app: ovnkube-node}
+        url: http://localhost:29103/debug/pprof/profile?seconds=60
       - name: ovnk-control-plane-heap
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-control-plane}
         url: http://localhost:29108/debug/pprof/heap
+      - name: ovnk-control-plane-cpu
+        namespace: "openshift-ovn-kubernetes"
+        labelSelector: {app: ovnkube-control-plane}
+        url: http://localhost:29108/debug/pprof/profile?seconds=60
 {{ end }}
 {{ if .SVC_LATENCY }}
     - name: serviceLatency

--- a/cmd/config/node-density/node-density.yml
+++ b/cmd/config/node-density/node-density.yml
@@ -20,10 +20,18 @@ global:
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-node}
         url: http://localhost:29103/debug/pprof/heap
+      - name: ovnkube-controller-cpu
+        namespace: "openshift-ovn-kubernetes"
+        labelSelector: {app: ovnkube-node}
+        url: http://localhost:29103/debug/pprof/profile?seconds=60
       - name: ovnk-control-plane-heap
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-control-plane}
         url: http://localhost:29108/debug/pprof/heap
+      - name: ovnk-control-plane-cpu
+        namespace: "openshift-ovn-kubernetes"
+        labelSelector: {app: ovnkube-control-plane}
+        url: http://localhost:29108/debug/pprof/profile?seconds=60
 {{ end }}
 metricsEndpoints:
 {{ if .ES_SERVER }}

--- a/cmd/config/udn-density-pods/udn-density-pods.yml
+++ b/cmd/config/udn-density-pods/udn-density-pods.yml
@@ -23,7 +23,7 @@ global:
       - name: ovnkube-controller-cpu
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-node}
-        url: http://localhost:29103/debug/pprof/profile?seconds=30
+        url: http://localhost:29103/debug/pprof/profile?seconds=60
       - name: ovnk-control-plane-heap
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-control-plane}
@@ -31,7 +31,7 @@ global:
       - name: ovnk-control-plane-cpu
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-control-plane}
-        url: http://localhost:29108/debug/pprof/profile?seconds=30
+        url: http://localhost:29108/debug/pprof/profile?seconds=60
 {{ end }}
 metricsEndpoints:
 {{ if .ES_SERVER }}

--- a/cmd/config/virt-udn-density/virt-udn-density.yml
+++ b/cmd/config/virt-udn-density/virt-udn-density.yml
@@ -23,7 +23,7 @@ global:
       - name: ovnkube-controller-cpu
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-node}
-        url: http://localhost:29103/debug/pprof/profile?seconds=30
+        url: http://localhost:29103/debug/pprof/profile?seconds=60
       - name: ovnk-control-plane-heap
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-control-plane}
@@ -31,7 +31,7 @@ global:
       - name: ovnk-control-plane-cpu
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-control-plane}
-        url: http://localhost:29108/debug/pprof/profile?seconds=30
+        url: http://localhost:29108/debug/pprof/profile?seconds=60
 {{ end }}
 metricsEndpoints:
 {{ if .ES_SERVER }}


### PR DESCRIPTION
## Summary
- Add CPU pprof endpoints (`profile?seconds=60`) for `ovnkube-controller` and `ovnk-control-plane` alongside existing heap profiling in cluster-density-v2, node-density, node-density-cni, and node-density-heavy workloads
- Standardize CPU profiling duration from 30s to 60s in udn-density-pods, virt-udn-density, and cudn-density workloads
