### PR TITLE
Update README to reflect --ignore-health-check flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Available Commands:
 Flags:
       --alerting                  Enable alerting (default true)
       --burst int                 Burst (default 20)
-      --check-health              Check cluster health before job (default true)
+      --ignore-health-check       Run cluster health check, but ignore failures (default false)
       --enable-file-logging       Enable file logging (default true)
       --es-index string           Elastic Search index
       --es-server string          Elastic Search endpoint


### PR DESCRIPTION
## Type of change

- Documentation

## Description

The --check-health flag was replaced with --ignore-health-check in commit 6b26f052 ("Ignore health check results (#345)"), but the README still referenced the old flag with incorrect behavior.

The new flag:
- Always runs cluster health checks (cannot be disabled)
- When set to true, continues execution on health check failures
- Defaults to false (health check failures are fatal)

This updates the documentation to match the current implementation.

Related-to: 6b26f052bf6311ca58760c62ff1ca30fcf0440df


## Related Tickets & Documents

- Related Issue #
- Closes #

