### PR TITLE
Adding idle jobs to the rds-core workload.

### DIFF
--- a/cmd/config/rds-core/rds-core.yml
+++ b/cmd/config/rds-core/rds-core.yml
@@ -37,6 +37,21 @@ metricsEndpoints:
 {{ end }}
 
 jobs:
+{{ if .PHASED }}
+  # Idle for baseline metrics collection
+  - name: rds-idle-pre
+    namespace: rds-idle
+    jobIterations: 1
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    namespacedIterations: false
+    jobPause: {{.IDLE_DURATION}}
+    skipIndexing: true
+    objects:
+      - objectTemplate: configmap.yml
+        replicas: 1
+{{ end }}
+
   - name: bgp-setup
     namespace: metallb-system
     jobIterations: 1
@@ -62,6 +77,10 @@ jobs:
     podWait: false
     waitWhenFinished: true
     preLoadImages: true
+{{ if .PHASED }}
+    cleanup: false
+    gc: false
+{{ end }}
     churnConfig:
       cycles: {{.CHURN_CYCLES}}
       duration: {{.CHURN_DURATION}}
@@ -127,4 +146,19 @@ jobs:
           dpdk_cores: {{.DPDK_CORES}}
           dpdk_hugepages: {{.DPDK_HUGEPAGES}}
           perf_profile: {{.PERF_PROFILE}}
+
+{{ if .PHASED }}
+  # Post-churn idle for metrics collection
+  - name: rds-idle-post
+    namespace: rds-idle
+    jobIterations: 1
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    namespacedIterations: false
+    jobPause: {{.IDLE_DURATION}}
+    skipIndexing: true
+    objects:
+      - objectTemplate: configmap.yml
+        replicas: 1
+{{ end }}
 

--- a/pkg/workloads/rds-core.go
+++ b/pkg/workloads/rds-core.go
@@ -29,9 +29,10 @@ import (
 func NewRDSCore(wh *workloads.WorkloadHelper) *cobra.Command {
 	var iterations, churnPercent, churnCycles, dpdkCores int
 	var svcLatency bool
-	var churnDelay, churnDuration, podReadyThreshold time.Duration
+	var churnDelay, churnDuration, podReadyThreshold, idleDuration time.Duration
 	var deletionStrategy, perfProfile, dpdkHugepages, sriovDpdkDevicepool, sriovNetDevicepool, churnMode string
 	var metricsProfiles []string
+	var phased bool
 	var rc int
 	cmd := &cobra.Command{
 		Use:          "rds-core",
@@ -57,7 +58,9 @@ func NewRDSCore(wh *workloads.WorkloadHelper) *cobra.Command {
 			AdditionalVars["PERF_PROFILE"] = perfProfile
 			AdditionalVars["POD_READY_THRESHOLD"] = podReadyThreshold
 			AdditionalVars["SVC_LATENCY"] = svcLatency
+			AdditionalVars["IDLE_DURATION"] = idleDuration
 			AdditionalVars["INGRESS_DOMAIN"] = ingressDomain
+			AdditionalVars["PHASED"] = phased
 			rc = RunWorkload(cmd, wh, cmd.Name()+".yml")
 		},
 		PostRun: func(cmd *cobra.Command, args []string) {
@@ -78,6 +81,8 @@ func NewRDSCore(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
 	cmd.Flags().StringVar(&perfProfile, "perf-profile", "default", "Performance profile implemented in the cluster")
 	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 0, "Pod ready timeout threshold")
+	cmd.Flags().DurationVar(&idleDuration, "idle-duration", 3*time.Minute, "Duration of idle periods for baseline and post-churn metrics collection")
+	cmd.Flags().BoolVar(&phased, "phased", false, "Use phased config with idle periods for baseline and post-churn metrics collection")
 	cmd.Flags().BoolVar(&svcLatency, "service-latency", false, "Enable service latency measurement")
 	return cmd
 }


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->

- New feature

## Description

Adding "idle" jobs pre (rds-pre-idle) and post (rds-post-idle) in addition to the main rds job in the rds-core workload.
The goal with this change is to be able to report resource usage before and after the main load is applied to the cluster. These idle jobs also do not collect any metrics (skipIndexing: true).

With the addition of `--phased` and `--idle-duration` flags to kube-burner-ocp:

`kube-burner-ocp rds-core --phased --log-level=info --qps=20 --burst=20 --idle-duration=5m --perf-profile=customcnf --gc-metrics=false --gc=true --churn-cycles 1 --churn-percent 0 --dpdk-devicepool dpdkvfs --net-devicepool servervfs --alerting=true --iterations=121 --es-server=${ES_SERVER} --es-index=${ES_INDEX} --local-indexing 
`
The user can turn the idle jobs on/off in the main rds-core.yaml file and also set the length for the idle jobs. Note that `--idle-duration` only makes sense when `--phased` is used:

```
(...)
time="2026-05-27 07:48:46" level=info msg="Initializing measurements for job: rds-idle-pre" file="factory.go:104"
time="2026-05-27 07:48:46" level=info msg="Registered measurement: podLatency" file="factory.go:139"
time="2026-05-27 07:48:46" level=info msg="Creating /v1, Resource=pods latency watcher for rds-idle-pre using selector [kube-burner.io/runid=bb1e7c6d-b050-4405-ac83-e9a914360a4a]" file="base_measurement.go:81"
time="2026-05-27 07:48:46" level=info msg="Triggering job: rds-idle-pre" file="job.go:139"
time="2026-05-27 07:48:46" level=info msg="Waiting up to 4h0m0s for actions to be completed" file="create.go:270"
time="2026-05-27 07:48:46" level=info msg="Actions in namespace rds-idle completed" file="waiters.go:77"
time="2026-05-27 07:48:46" level=info msg="Verifying created objects" file="utils.go:161"
time="2026-05-27 07:48:46" level=info msg="Pausing for 5m0s before finishing job" file="job.go:225"
time="2026-05-27 07:53:46" level=info msg="Job rds-idle-pre took 0s" file="job.go:234"
(...)
time="2026-05-27 07:53:47" level=info msg="Triggering job: rds" file="job.go:139"
time="2026-05-27 07:53:47" level=info msg="Churning enabled" file="job.go:142"
time="2026-05-27 07:53:47" level=info msg="Churn cycles: 1" file="job.go:143"
time="2026-05-27 07:53:47" level=info msg="Churn duration: 0s" file="job.go:144"
time="2026-05-27 07:53:47" level=info msg="Churn percent: 0" file="job.go:145"
time="2026-05-27 07:53:47" level=info msg="Churn delay: 2m0s" file="job.go:146"
time="2026-05-27 07:53:47" level=info msg="Churn delete delay: 0s" file="job.go:147"
time="2026-05-27 07:53:47" level=info msg="Churn type: namespaces" file="job.go:148"
time="2026-05-27 07:55:03" level=info msg="12/121 iterations completed" file="create.go:142"
time="2026-05-27 07:56:20" level=info msg="24/121 iterations completed" file="create.go:142"
time="2026-05-27 07:57:37" level=info msg="36/121 iterations completed" file="create.go:142"
time="2026-05-27 07:58:53" level=info msg="48/121 iterations completed" file="create.go:142"
time="2026-05-27 08:00:10" level=info msg="60/121 iterations completed" file="create.go:142"
time="2026-05-27 08:01:27" level=info msg="72/121 iterations completed" file="create.go:142"
time="2026-05-27 08:02:44" level=info msg="84/121 iterations completed" file="create.go:142"
time="2026-05-27 08:04:01" level=info msg="96/121 iterations completed" file="create.go:142"
time="2026-05-27 08:05:17" level=info msg="108/121 iterations completed" file="create.go:142"
time="2026-05-27 08:06:34" level=info msg="120/121 iterations completed" file="create.go:142"
time="2026-05-27 08:06:41" level=info msg="Waiting up to 4h0m0s for actions to be completed" file="create.go:270"
(...)
time="2026-05-27 08:10:07" level=info msg="Job rds took 16m20s" file="job.go:234"
(...)
time="2026-05-27 08:10:17" level=info msg="Triggering job: rds-idle-post" file="job.go:139"
time="2026-05-27 08:10:17" level=info msg="Waiting up to 4h0m0s for actions to be completed" file="create.go:270"
time="2026-05-27 08:10:17" level=info msg="Actions in namespace rds-idle completed" file="waiters.go:77"
time="2026-05-27 08:10:17" level=info msg="Verifying created objects" file="utils.go:161"
time="2026-05-27 08:10:17" level=info msg="Pausing for 5m0s before finishing job" file="job.go:225"
time="2026-05-27 08:15:17" level=info msg="Job rds-idle-post took 10s" file="job.go:234"
(...)
```

## Related Tickets & Documents

Not attached to a particular open issue at this point, but it is a long-standing request from the combined workload (rds-core + dataplane) effort to better distinguish between platform vs platform+workload resource usage.

CC. @afcollins , @sraviteja-maker 