### PR TITLE
Add image preload DaemonSets for build-farm autoscaler compatibility

### DIFF
--- a/cmd/config/build-farm/build-farm-ds-preload.yml
+++ b/cmd/config/build-farm/build-farm-ds-preload.yml
@@ -1,0 +1,34 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: build-farm-preload-{{.preloadName}}
+spec:
+  selector:
+    matchLabels:
+      name: build-farm-preload-{{.preloadName}}
+  template:
+    metadata:
+      labels:
+        name: build-farm-preload-{{.preloadName}}
+    spec:
+      hostNetwork: true
+      tolerations:
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+        effect: NoSchedule
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/worker
+                operator: Exists
+              - key: node-role.kubernetes.io/infra
+                operator: DoesNotExist
+              - key: node-role.kubernetes.io/workload
+                operator: DoesNotExist
+      containers:
+      - name: pause
+        image: {{.preloadImage}}
+        command: [sleep, inf]
+        imagePullPolicy: IfNotPresent

--- a/cmd/config/build-farm/build-farm-preload-rolebinding.yml
+++ b/cmd/config/build-farm/build-farm-preload-rolebinding.yml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: hostnetwork-to-default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:hostnetwork-v2
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: build-farm-preload

--- a/cmd/config/build-farm/build-farm.yml
+++ b/cmd/config/build-farm/build-farm.yml
@@ -25,6 +25,31 @@ metricsEndpoints:
 {{ end }}
 
 jobs:
+  - name: build-farm-preload-images
+    namespace: build-farm-preload
+    jobIterations: 1
+    skipIndexing: true
+    namespacedIterations: false
+    preLoadImages: false
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: "false"
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+    objects:
+      - objectTemplate: build-farm-preload-rolebinding.yml
+        replicas: 1
+      - objectTemplate: build-farm-ds-preload.yml
+        replicas: 1
+        inputVars:
+          preloadName: build-image
+          preloadImage: "{{ .BUILD_IMAGE }}"
+      - objectTemplate: build-farm-ds-preload.yml
+        replicas: 1
+        inputVars:
+          preloadName: metadata-adder
+          preloadImage: "quay.io/kube-burner/build-farm-controller:metadata-adder"
+
   - name: build-farm-controller
     namespace: build-farm-controllers
     jobIterations: 1


### PR DESCRIPTION

## Type of change

- Optimization

## Description

The build-farm runs on autoscaler clusters where nodes may not exist at workload start. Use custom DaemonSets with hostNetwork and a not-ready toleration so images are pulled as soon as new nodes appear, before CNI is ready. A RoleBinding grants the hostnetwork-v2 SCC to the default SA and namespace labels disable PodSecurity restrictions. DaemonSets persist for the workload lifetime to cover late-joining nodes.
