### PR TITLE
[DRAFT] synthetic application workload

### DIFF
--- a/cmd/config/synthetic-app/app-client-deployment.yml
+++ b/cmd/config/synthetic-app/app-client-deployment.yml
@@ -1,0 +1,126 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: app-client
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app-client
+      pattern: app-database
+  template:
+    metadata:
+      labels:
+        app: app-client
+        pattern: app-database
+        role: client
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/worker
+                operator: Exists
+              - key: node-role.kubernetes.io/infra
+                operator: DoesNotExist
+              - key: node-role.kubernetes.io/workload
+                operator: DoesNotExist
+      containers:
+      - name: uperf-client
+        image: {{.uperfImage}}
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "1000m"
+        env:
+        - name: METRICS_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: METRICS_PORT
+          value: "9999"
+        - name: PATTERN_NAME
+          value: "app-database"
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: SERVER_HOST
+          value: "db-svc"
+        - name: SERVER_PORT
+          value: "20000"
+        - name: DB_CONNECTIONS
+          value: "{{.dbConnections}}"
+        - name: TRAFFIC_DURATION
+          value: "{{.trafficDuration}}"
+        - name: REPORT_INTERVAL
+          value: "{{.metricsReportInterval}}"
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -e
+          METRICS_URL="http://${METRICS_HOST}:${METRICS_PORT}/metrics"
+          PROFILE="/tmp/app-database.xml"
+
+          # Create uperf profile for OLTP-style database traffic
+          cat > ${PROFILE} << 'PROFILE_EOF'
+          <?xml version="1.0"?>
+          <profile name="app-database">
+            <group nthreads="${DB_CONNECTIONS}">
+              <transaction iterations="1">
+                <flowop type="connect" options="remotehost=${SERVER_HOST} port=${SERVER_PORT} protocol=tcp tcp_nodelay"/>
+              </transaction>
+              <transaction duration="${TRAFFIC_DURATION}">
+                <flowop type="write" options="size=128"/>
+                <flowop type="read" options="size=1024"/>
+                <flowop type="write" options="size=512"/>
+                <flowop type="read" options="size=64"/>
+              </transaction>
+              <transaction iterations="1">
+                <flowop type="disconnect"/>
+              </transaction>
+            </group>
+          </profile>
+          PROFILE_EOF
+
+          # Substitute environment variables
+          envsubst < ${PROFILE} > /tmp/profile.xml
+
+          echo "Starting uperf client for app-database pattern"
+          echo "Server: ${SERVER_HOST}:${SERVER_PORT}, DB Connections: ${DB_CONNECTIONS}"
+
+          # Run uperf and report metrics periodically
+          while true; do
+            OUTPUT=$(timeout ${REPORT_INTERVAL}s uperf -m /tmp/profile.xml -a 2>&1 || true)
+
+            # Parse metrics
+            OPS_SEC=$(echo "$OUTPUT" | grep -oP 'Txn1\s+\K[\d.]+(?=\s+ops)' | tail -1 || echo "0")
+            BYTES_SEC=$(echo "$OUTPUT" | grep -oP '[\d.]+(?=\s+Mb/s)' | tail -1 || echo "0")
+
+            # Report to metrics store
+            curl -s -X POST "${METRICS_URL}" \
+              -H "Content-Type: application/json" \
+              -d "{
+                \"timestamp\": \"$(date -Iseconds)\",
+                \"namespace\": \"${POD_NAMESPACE}\",
+                \"pattern\": \"${PATTERN_NAME}\",
+                \"client\": \"${POD_NAME}\",
+                \"metrics\": {
+                  \"ops_per_sec\": ${OPS_SEC:-0},
+                  \"throughput_mbps\": ${BYTES_SEC:-0}
+                }
+              }" || echo "Failed to report metrics"
+
+            echo "Reported metrics: ops/sec=${OPS_SEC}, throughput=${BYTES_SEC} Mb/s"
+          done
+        imagePullPolicy: IfNotPresent

--- a/cmd/config/synthetic-app/app-client-deployment.yml
+++ b/cmd/config/synthetic-app/app-client-deployment.yml
@@ -16,6 +16,10 @@ spec:
         pattern: app-database
         role: client
     spec:
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "2"
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -27,6 +31,10 @@ spec:
                 operator: DoesNotExist
               - key: node-role.kubernetes.io/workload
                 operator: DoesNotExist
+      volumes:
+      - name: uperf-profiles
+        configMap:
+          name: uperf-profiles
       containers:
       - name: uperf-client
         image: {{.uperfImage}}
@@ -37,11 +45,13 @@ spec:
           limits:
             memory: "512Mi"
             cpu: "1000m"
+        volumeMounts:
+        - name: uperf-profiles
+          mountPath: /profiles
+          readOnly: true
         env:
         - name: METRICS_HOST
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
+          value: "synthetic-app-metrics-store.synthetic-app-infra.svc"
         - name: METRICS_PORT
           value: "9999"
         - name: PATTERN_NAME
@@ -58,10 +68,6 @@ spec:
           value: "db-svc"
         - name: SERVER_PORT
           value: "20000"
-        - name: DB_CONNECTIONS
-          value: "{{.dbConnections}}"
-        - name: TRAFFIC_DURATION
-          value: "{{.trafficDuration}}"
         - name: REPORT_INTERVAL
           value: "{{.metricsReportInterval}}"
         command:
@@ -70,56 +76,30 @@ spec:
         - |
           set -e
           METRICS_URL="http://${METRICS_HOST}:${METRICS_PORT}/metrics"
-          PROFILE="/tmp/app-database.xml"
+          PROFILE_TEMPLATE="/profiles/app-database.xml"
+          PROFILE="/tmp/profile.xml"
 
-          # Create uperf profile for OLTP-style database traffic
-          cat > ${PROFILE} << 'PROFILE_EOF'
-          <?xml version="1.0"?>
-          <profile name="app-database">
-            <group nthreads="${DB_CONNECTIONS}">
-              <transaction iterations="1">
-                <flowop type="connect" options="remotehost=${SERVER_HOST} port=${SERVER_PORT} protocol=tcp tcp_nodelay"/>
-              </transaction>
-              <transaction duration="${TRAFFIC_DURATION}">
-                <flowop type="write" options="size=128"/>
-                <flowop type="read" options="size=1024"/>
-                <flowop type="write" options="size=512"/>
-                <flowop type="read" options="size=64"/>
-              </transaction>
-              <transaction iterations="1">
-                <flowop type="disconnect"/>
-              </transaction>
-            </group>
-          </profile>
-          PROFILE_EOF
-
-          # Substitute environment variables
-          envsubst < ${PROFILE} > /tmp/profile.xml
+          # Substitute environment variables in profile using sed
+          sed -e "s|\$SERVER_HOST|${SERVER_HOST}|g" \
+              -e "s|\$SERVER_PORT|${SERVER_PORT}|g" \
+              ${PROFILE_TEMPLATE} > ${PROFILE}
 
           echo "Starting uperf client for app-database pattern"
-          echo "Server: ${SERVER_HOST}:${SERVER_PORT}, DB Connections: ${DB_CONNECTIONS}"
+          echo "Server: ${SERVER_HOST}:${SERVER_PORT}"
+          cat ${PROFILE}
 
           # Run uperf and report metrics periodically
           while true; do
-            OUTPUT=$(timeout ${REPORT_INTERVAL}s uperf -m /tmp/profile.xml -a 2>&1 || true)
+            OUTPUT=$(timeout ${REPORT_INTERVAL}s uperf -m ${PROFILE} -a 2>&1 || true)
 
-            # Parse metrics
-            OPS_SEC=$(echo "$OUTPUT" | grep -oP 'Txn1\s+\K[\d.]+(?=\s+ops)' | tail -1 || echo "0")
-            BYTES_SEC=$(echo "$OUTPUT" | grep -oP '[\d.]+(?=\s+Mb/s)' | tail -1 || echo "0")
+            # Parse metrics from uperf output (from "Total" line)
+            # Example: "Total     22.89MB /   7.31(s) =    26.28Mb/s       51322op/s"
+            OPS_SEC=$(echo "$OUTPUT" | grep "^Total" | grep -oP '\d+(?=op/s)' || echo "0")
+            BYTES_SEC=$(echo "$OUTPUT" | grep "^Total" | grep -oP '[\d.]+(?=Mb/s)' || echo "0")
 
-            # Report to metrics store
-            curl -s -X POST "${METRICS_URL}" \
-              -H "Content-Type: application/json" \
-              -d "{
-                \"timestamp\": \"$(date -Iseconds)\",
-                \"namespace\": \"${POD_NAMESPACE}\",
-                \"pattern\": \"${PATTERN_NAME}\",
-                \"client\": \"${POD_NAME}\",
-                \"metrics\": {
-                  \"ops_per_sec\": ${OPS_SEC:-0},
-                  \"throughput_mbps\": ${BYTES_SEC:-0}
-                }
-              }" || echo "Failed to report metrics"
+            # Report to metrics store (single-line JSON for proper parsing)
+            JSON_DATA="{\"timestamp\":\"$(date -Iseconds)\",\"namespace\":\"${POD_NAMESPACE}\",\"pattern\":\"${PATTERN_NAME}\",\"client\":\"${POD_NAME}\",\"metrics\":{\"ops_per_sec\":${OPS_SEC:-0},\"throughput_mbps\":${BYTES_SEC:-0}}}"
+            curl -s -X POST "${METRICS_URL}" -H "Content-Type: application/json" -d "${JSON_DATA}" || echo "Failed to report metrics"
 
             echo "Reported metrics: ops/sec=${OPS_SEC}, throughput=${BYTES_SEC} Mb/s"
           done

--- a/cmd/config/synthetic-app/db-server-deployment.yml
+++ b/cmd/config/synthetic-app/db-server-deployment.yml
@@ -1,0 +1,59 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: db-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: db-server
+      pattern: app-database
+  template:
+    metadata:
+      labels:
+        app: db-server
+        pattern: app-database
+        role: server
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/worker
+                operator: Exists
+              - key: node-role.kubernetes.io/infra
+                operator: DoesNotExist
+              - key: node-role.kubernetes.io/workload
+                operator: DoesNotExist
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  pattern: app-database
+                  role: client
+              topologyKey: kubernetes.io/hostname
+      containers:
+      - name: uperf-server
+        image: {{.uperfImage}}
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+        ports:
+        - containerPort: 20000
+          protocol: TCP
+          name: uperf
+        command:
+        - /bin/sh
+        - -c
+        - |
+          echo "Starting uperf server (db-server) on port 20000"
+          uperf -s -v -P 20000
+        imagePullPolicy: IfNotPresent

--- a/cmd/config/synthetic-app/db-server-service.yml
+++ b/cmd/config/synthetic-app/db-server-service.yml
@@ -1,0 +1,15 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: db-svc
+spec:
+  selector:
+    app: db-server
+    pattern: app-database
+  ports:
+  - name: uperf
+    port: 20000
+    targetPort: 20000
+    protocol: TCP
+  type: ClusterIP

--- a/cmd/config/synthetic-app/filler-deployment.yml
+++ b/cmd/config/synthetic-app/filler-deployment.yml
@@ -1,0 +1,39 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: filler-{{.Replica}}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: filler-{{.Replica}}
+      type: filler
+  template:
+    metadata:
+      labels:
+        app: filler-{{.Replica}}
+        type: filler
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/worker
+                operator: Exists
+              - key: node-role.kubernetes.io/infra
+                operator: DoesNotExist
+              - key: node-role.kubernetes.io/workload
+                operator: DoesNotExist
+      containers:
+      - name: pause
+        image: registry.k8s.io/pause:3.9
+        resources:
+          requests:
+            memory: "10Mi"
+            cpu: "5m"
+          limits:
+            memory: "20Mi"
+            cpu: "10m"
+        imagePullPolicy: IfNotPresent

--- a/cmd/config/synthetic-app/filler-service.yml
+++ b/cmd/config/synthetic-app/filler-service.yml
@@ -1,0 +1,15 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: filler-svc-{{.Replica}}
+spec:
+  selector:
+    app: filler-{{.Replica}}
+    type: filler
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+    protocol: TCP
+  type: ClusterIP

--- a/cmd/config/synthetic-app/frontend-client-deployment.yml
+++ b/cmd/config/synthetic-app/frontend-client-deployment.yml
@@ -1,0 +1,130 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: frontend-client
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontend-client
+      pattern: frontend-microservices
+  template:
+    metadata:
+      labels:
+        app: frontend-client
+        pattern: frontend-microservices
+        role: client
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/worker
+                operator: Exists
+              - key: node-role.kubernetes.io/infra
+                operator: DoesNotExist
+              - key: node-role.kubernetes.io/workload
+                operator: DoesNotExist
+      containers:
+      - name: uperf-client
+        image: {{.uperfImage}}
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "1000m"
+        env:
+        - name: METRICS_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: METRICS_PORT
+          value: "9999"
+        - name: PATTERN_NAME
+          value: "frontend-microservices"
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: MS1_HOST
+          value: "microservice-svc-1"
+        - name: MS2_HOST
+          value: "microservice-svc-2"
+        - name: SERVER_PORT
+          value: "20000"
+        - name: THREADS
+          value: "{{.threads}}"
+        - name: TRAFFIC_DURATION
+          value: "{{.trafficDuration}}"
+        - name: REPORT_INTERVAL
+          value: "{{.metricsReportInterval}}"
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -e
+          METRICS_URL="http://${METRICS_HOST}:${METRICS_PORT}/metrics"
+          PROFILE="/tmp/frontend-microservices.xml"
+
+          # Create uperf profile for fan-out to multiple microservices
+          cat > ${PROFILE} << 'PROFILE_EOF'
+          <?xml version="1.0"?>
+          <profile name="frontend-microservices">
+            <group nthreads="${THREADS}">
+              <transaction iterations="1">
+                <flowop type="connect" options="remotehost=${MS1_HOST} port=${SERVER_PORT} protocol=tcp"/>
+                <flowop type="connect" options="conn=1 remotehost=${MS2_HOST} port=${SERVER_PORT} protocol=tcp"/>
+              </transaction>
+              <transaction duration="${TRAFFIC_DURATION}">
+                <flowop type="write" options="size=256"/>
+                <flowop type="write" options="conn=1 size=256"/>
+                <flowop type="read" options="size=1024"/>
+                <flowop type="read" options="conn=1 size=1024"/>
+              </transaction>
+              <transaction iterations="1">
+                <flowop type="disconnect"/>
+                <flowop type="disconnect" options="conn=1"/>
+              </transaction>
+            </group>
+          </profile>
+          PROFILE_EOF
+
+          # Substitute environment variables
+          envsubst < ${PROFILE} > /tmp/profile.xml
+
+          echo "Starting uperf client for frontend-microservices pattern"
+          echo "MS1: ${MS1_HOST}:${SERVER_PORT}, MS2: ${MS2_HOST}:${SERVER_PORT}, Threads: ${THREADS}"
+
+          # Run uperf and report metrics periodically
+          while true; do
+            OUTPUT=$(timeout ${REPORT_INTERVAL}s uperf -m /tmp/profile.xml -a 2>&1 || true)
+
+            # Parse metrics
+            OPS_SEC=$(echo "$OUTPUT" | grep -oP 'Txn1\s+\K[\d.]+(?=\s+ops)' | tail -1 || echo "0")
+            BYTES_SEC=$(echo "$OUTPUT" | grep -oP '[\d.]+(?=\s+Mb/s)' | tail -1 || echo "0")
+
+            # Report to metrics store
+            curl -s -X POST "${METRICS_URL}" \
+              -H "Content-Type: application/json" \
+              -d "{
+                \"timestamp\": \"$(date -Iseconds)\",
+                \"namespace\": \"${POD_NAMESPACE}\",
+                \"pattern\": \"${PATTERN_NAME}\",
+                \"client\": \"${POD_NAME}\",
+                \"metrics\": {
+                  \"ops_per_sec\": ${OPS_SEC:-0},
+                  \"throughput_mbps\": ${BYTES_SEC:-0}
+                }
+              }" || echo "Failed to report metrics"
+
+            echo "Reported metrics: ops/sec=${OPS_SEC}, throughput=${BYTES_SEC} Mb/s"
+          done
+        imagePullPolicy: IfNotPresent

--- a/cmd/config/synthetic-app/frontend-client-deployment.yml
+++ b/cmd/config/synthetic-app/frontend-client-deployment.yml
@@ -16,6 +16,10 @@ spec:
         pattern: frontend-microservices
         role: client
     spec:
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "2"
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -27,6 +31,10 @@ spec:
                 operator: DoesNotExist
               - key: node-role.kubernetes.io/workload
                 operator: DoesNotExist
+      volumes:
+      - name: uperf-profiles
+        configMap:
+          name: uperf-profiles
       containers:
       - name: uperf-client
         image: {{.uperfImage}}
@@ -37,11 +45,13 @@ spec:
           limits:
             memory: "512Mi"
             cpu: "1000m"
+        volumeMounts:
+        - name: uperf-profiles
+          mountPath: /profiles
+          readOnly: true
         env:
         - name: METRICS_HOST
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
+          value: "synthetic-app-metrics-store.synthetic-app-infra.svc"
         - name: METRICS_PORT
           value: "9999"
         - name: PATTERN_NAME
@@ -60,10 +70,6 @@ spec:
           value: "microservice-svc-2"
         - name: SERVER_PORT
           value: "20000"
-        - name: THREADS
-          value: "{{.threads}}"
-        - name: TRAFFIC_DURATION
-          value: "{{.trafficDuration}}"
         - name: REPORT_INTERVAL
           value: "{{.metricsReportInterval}}"
         command:
@@ -72,58 +78,31 @@ spec:
         - |
           set -e
           METRICS_URL="http://${METRICS_HOST}:${METRICS_PORT}/metrics"
-          PROFILE="/tmp/frontend-microservices.xml"
+          PROFILE_TEMPLATE="/profiles/frontend-microservices.xml"
+          PROFILE="/tmp/profile.xml"
 
-          # Create uperf profile for fan-out to multiple microservices
-          cat > ${PROFILE} << 'PROFILE_EOF'
-          <?xml version="1.0"?>
-          <profile name="frontend-microservices">
-            <group nthreads="${THREADS}">
-              <transaction iterations="1">
-                <flowop type="connect" options="remotehost=${MS1_HOST} port=${SERVER_PORT} protocol=tcp"/>
-                <flowop type="connect" options="conn=1 remotehost=${MS2_HOST} port=${SERVER_PORT} protocol=tcp"/>
-              </transaction>
-              <transaction duration="${TRAFFIC_DURATION}">
-                <flowop type="write" options="size=256"/>
-                <flowop type="write" options="conn=1 size=256"/>
-                <flowop type="read" options="size=1024"/>
-                <flowop type="read" options="conn=1 size=1024"/>
-              </transaction>
-              <transaction iterations="1">
-                <flowop type="disconnect"/>
-                <flowop type="disconnect" options="conn=1"/>
-              </transaction>
-            </group>
-          </profile>
-          PROFILE_EOF
-
-          # Substitute environment variables
-          envsubst < ${PROFILE} > /tmp/profile.xml
+          # Substitute environment variables in profile using sed
+          sed -e "s|\$MS1_HOST|${MS1_HOST}|g" \
+              -e "s|\$MS2_HOST|${MS2_HOST}|g" \
+              -e "s|\$SERVER_PORT|${SERVER_PORT}|g" \
+              ${PROFILE_TEMPLATE} > ${PROFILE}
 
           echo "Starting uperf client for frontend-microservices pattern"
-          echo "MS1: ${MS1_HOST}:${SERVER_PORT}, MS2: ${MS2_HOST}:${SERVER_PORT}, Threads: ${THREADS}"
+          echo "MS1: ${MS1_HOST}:${SERVER_PORT}, MS2: ${MS2_HOST}:${SERVER_PORT}"
+          cat ${PROFILE}
 
           # Run uperf and report metrics periodically
           while true; do
-            OUTPUT=$(timeout ${REPORT_INTERVAL}s uperf -m /tmp/profile.xml -a 2>&1 || true)
+            OUTPUT=$(timeout ${REPORT_INTERVAL}s uperf -m ${PROFILE} -a 2>&1 || true)
 
-            # Parse metrics
-            OPS_SEC=$(echo "$OUTPUT" | grep -oP 'Txn1\s+\K[\d.]+(?=\s+ops)' | tail -1 || echo "0")
-            BYTES_SEC=$(echo "$OUTPUT" | grep -oP '[\d.]+(?=\s+Mb/s)' | tail -1 || echo "0")
+            # Parse metrics from uperf output (from "Total" line)
+            # Example: "Total     22.89MB /   7.31(s) =    26.28Mb/s       51322op/s"
+            OPS_SEC=$(echo "$OUTPUT" | grep "^Total" | grep -oP '\d+(?=op/s)' || echo "0")
+            BYTES_SEC=$(echo "$OUTPUT" | grep "^Total" | grep -oP '[\d.]+(?=Mb/s)' || echo "0")
 
-            # Report to metrics store
-            curl -s -X POST "${METRICS_URL}" \
-              -H "Content-Type: application/json" \
-              -d "{
-                \"timestamp\": \"$(date -Iseconds)\",
-                \"namespace\": \"${POD_NAMESPACE}\",
-                \"pattern\": \"${PATTERN_NAME}\",
-                \"client\": \"${POD_NAME}\",
-                \"metrics\": {
-                  \"ops_per_sec\": ${OPS_SEC:-0},
-                  \"throughput_mbps\": ${BYTES_SEC:-0}
-                }
-              }" || echo "Failed to report metrics"
+            # Report to metrics store (single-line JSON for proper parsing)
+            JSON_DATA="{\"timestamp\":\"$(date -Iseconds)\",\"namespace\":\"${POD_NAMESPACE}\",\"pattern\":\"${PATTERN_NAME}\",\"client\":\"${POD_NAME}\",\"metrics\":{\"ops_per_sec\":${OPS_SEC:-0},\"throughput_mbps\":${BYTES_SEC:-0}}}"
+            curl -s -X POST "${METRICS_URL}" -H "Content-Type: application/json" -d "${JSON_DATA}" || echo "Failed to report metrics"
 
             echo "Reported metrics: ops/sec=${OPS_SEC}, throughput=${BYTES_SEC} Mb/s"
           done

--- a/cmd/config/synthetic-app/frontend-server-deployment.yml
+++ b/cmd/config/synthetic-app/frontend-server-deployment.yml
@@ -1,0 +1,59 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: frontend-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontend-server
+      pattern: users-frontend
+  template:
+    metadata:
+      labels:
+        app: frontend-server
+        pattern: users-frontend
+        role: server
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/worker
+                operator: Exists
+              - key: node-role.kubernetes.io/infra
+                operator: DoesNotExist
+              - key: node-role.kubernetes.io/workload
+                operator: DoesNotExist
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  pattern: users-frontend
+                  role: client
+              topologyKey: kubernetes.io/hostname
+      containers:
+      - name: uperf-server
+        image: {{.uperfImage}}
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+        ports:
+        - containerPort: 20000
+          protocol: TCP
+          name: uperf
+        command:
+        - /bin/sh
+        - -c
+        - |
+          echo "Starting uperf server on port 20000"
+          uperf -s -v -P 20000
+        imagePullPolicy: IfNotPresent

--- a/cmd/config/synthetic-app/frontend-server-service.yml
+++ b/cmd/config/synthetic-app/frontend-server-service.yml
@@ -1,0 +1,15 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: frontend-svc
+spec:
+  selector:
+    app: frontend-server
+    pattern: users-frontend
+  ports:
+  - name: uperf
+    port: 20000
+    targetPort: 20000
+    protocol: TCP
+  type: ClusterIP

--- a/cmd/config/synthetic-app/metrics-store-daemonset.yml
+++ b/cmd/config/synthetic-app/metrics-store-daemonset.yml
@@ -1,9 +1,10 @@
 ---
 apiVersion: apps/v1
-kind: DaemonSet
+kind: Deployment
 metadata:
   name: synthetic-app-metrics-store
 spec:
+  replicas: {{.replicas}}
   selector:
     matchLabels:
       app: synthetic-app-metrics-store
@@ -12,8 +13,6 @@ spec:
       labels:
         app: synthetic-app-metrics-store
     spec:
-      tolerations:
-      - operator: Exists
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -21,9 +20,25 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/worker
                 operator: Exists
+              - key: node-role.kubernetes.io/infra
+                operator: DoesNotExist
+              - key: node-role.kubernetes.io/workload
+                operator: DoesNotExist
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: synthetic-app-metrics-store
+              topologyKey: kubernetes.io/hostname
+      volumes:
+      - name: script
+        configMap:
+          name: metrics-store-script
       containers:
       - name: metrics-store
-        image: quay.io/cloud-bulldozer/nginx:latest
+        image: registry.access.redhat.com/ubi9/python-39:latest
         resources:
           requests:
             memory: "64Mi"
@@ -33,135 +48,32 @@ spec:
             cpu: "200m"
         ports:
         - containerPort: 9999
-          hostPort: 9999
           name: metrics
           protocol: TCP
+        volumeMounts:
+        - name: script
+          mountPath: /app
+          readOnly: true
         env:
-        - name: NODE_NAME
+        - name: POD_NAME
           valueFrom:
             fieldRef:
-              fieldPath: spec.nodeName
+              fieldPath: metadata.name
+        - name: PORT
+          value: "9999"
         command:
-        - /bin/sh
-        - -c
-        - |
-          set -e
-
-          # Create a simple metrics store using shell and netcat
-          METRICS_FILE="/tmp/metrics.json"
-          AGGREGATED_FILE="/tmp/aggregated.json"
-
-          # Initialize metrics files
-          echo '{"metrics": []}' > ${METRICS_FILE}
-          echo '{"summary": {}, "by_pattern": {}, "by_namespace": {}}' > ${AGGREGATED_FILE}
-
-          # Create CGI-style script to handle HTTP requests
-          cat > /tmp/metrics-handler.sh << 'HANDLER_EOF'
-          #!/bin/sh
-          read -r REQUEST_LINE
-          METHOD=$(echo "$REQUEST_LINE" | cut -d' ' -f1)
-          PATH=$(echo "$REQUEST_LINE" | cut -d' ' -f2)
-
-          # Read headers
-          CONTENT_LENGTH=0
-          while read -r header; do
-            header=$(echo "$header" | tr -d '\r')
-            [ -z "$header" ] && break
-            case "$header" in
-              Content-Length:*) CONTENT_LENGTH=$(echo "$header" | cut -d' ' -f2) ;;
-            esac
-          done
-
-          METRICS_FILE="/tmp/metrics.json"
-          AGGREGATED_FILE="/tmp/aggregated.json"
-
-          case "$METHOD $PATH" in
-            "POST /metrics")
-              # Read POST body
-              if [ "$CONTENT_LENGTH" -gt 0 ]; then
-                BODY=$(head -c "$CONTENT_LENGTH")
-                TIMESTAMP=$(date -Iseconds)
-
-                # Append metric to file (simple append, will aggregate on GET)
-                echo "$BODY" >> /tmp/metrics_raw.log
-
-                echo "HTTP/1.1 200 OK"
-                echo "Content-Type: application/json"
-                echo ""
-                echo '{"status": "ok", "received": true}'
-              else
-                echo "HTTP/1.1 400 Bad Request"
-                echo "Content-Type: application/json"
-                echo ""
-                echo '{"error": "no body"}'
-              fi
-              ;;
-            "GET /metrics")
-              # Return all collected metrics
-              echo "HTTP/1.1 200 OK"
-              echo "Content-Type: application/json"
-              echo ""
-              if [ -f /tmp/metrics_raw.log ]; then
-                # Aggregate metrics by pattern and namespace
-                echo '{"node": "'$NODE_NAME'", "metrics": ['
-                FIRST=true
-                while read -r line; do
-                  if [ "$FIRST" = true ]; then
-                    FIRST=false
-                  else
-                    echo ","
-                  fi
-                  echo "$line"
-                done < /tmp/metrics_raw.log
-                echo ']}'
-              else
-                echo '{"node": "'$NODE_NAME'", "metrics": []}'
-              fi
-              ;;
-            "GET /health")
-              echo "HTTP/1.1 200 OK"
-              echo "Content-Type: application/json"
-              echo ""
-              echo '{"status": "healthy", "node": "'$NODE_NAME'"}'
-              ;;
-            "DELETE /metrics")
-              # Clear metrics (for reset between runs)
-              rm -f /tmp/metrics_raw.log
-              echo "HTTP/1.1 200 OK"
-              echo "Content-Type: application/json"
-              echo ""
-              echo '{"status": "cleared"}'
-              ;;
-            *)
-              echo "HTTP/1.1 404 Not Found"
-              echo "Content-Type: application/json"
-              echo ""
-              echo '{"error": "not found", "path": "'$PATH'"}'
-              ;;
-          esac
-          HANDLER_EOF
-
-          chmod +x /tmp/metrics-handler.sh
-
-          echo "Starting metrics store on port 9999 (node: ${NODE_NAME})"
-
-          # Use busybox nc to serve HTTP requests
-          while true; do
-            nc -l -p 9999 -e /tmp/metrics-handler.sh 2>/dev/null || {
-              # If nc doesn't support -e, fall back to socat-style approach
-              while true; do
-                { echo -e "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nMetrics store ready"; } | nc -l -p 9999 -q 1 2>/dev/null || sleep 1
-              done
-            }
-          done
+        - python3
+        - /app/server.py
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          tcpSocket:
-            port: 9999
-          initialDelaySeconds: 10
-          periodSeconds: 30
-        readinessProbe:
-          tcpSocket:
+          httpGet:
+            path: /health
             port: 9999
           initialDelaySeconds: 5
           periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 9999
+          initialDelaySeconds: 3
+          periodSeconds: 5

--- a/cmd/config/synthetic-app/metrics-store-daemonset.yml
+++ b/cmd/config/synthetic-app/metrics-store-daemonset.yml
@@ -1,0 +1,167 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: synthetic-app-metrics-store
+spec:
+  selector:
+    matchLabels:
+      app: synthetic-app-metrics-store
+  template:
+    metadata:
+      labels:
+        app: synthetic-app-metrics-store
+    spec:
+      tolerations:
+      - operator: Exists
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/worker
+                operator: Exists
+      containers:
+      - name: metrics-store
+        image: quay.io/cloud-bulldozer/nginx:latest
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "50m"
+          limits:
+            memory: "256Mi"
+            cpu: "200m"
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+          name: metrics
+          protocol: TCP
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -e
+
+          # Create a simple metrics store using shell and netcat
+          METRICS_FILE="/tmp/metrics.json"
+          AGGREGATED_FILE="/tmp/aggregated.json"
+
+          # Initialize metrics files
+          echo '{"metrics": []}' > ${METRICS_FILE}
+          echo '{"summary": {}, "by_pattern": {}, "by_namespace": {}}' > ${AGGREGATED_FILE}
+
+          # Create CGI-style script to handle HTTP requests
+          cat > /tmp/metrics-handler.sh << 'HANDLER_EOF'
+          #!/bin/sh
+          read -r REQUEST_LINE
+          METHOD=$(echo "$REQUEST_LINE" | cut -d' ' -f1)
+          PATH=$(echo "$REQUEST_LINE" | cut -d' ' -f2)
+
+          # Read headers
+          CONTENT_LENGTH=0
+          while read -r header; do
+            header=$(echo "$header" | tr -d '\r')
+            [ -z "$header" ] && break
+            case "$header" in
+              Content-Length:*) CONTENT_LENGTH=$(echo "$header" | cut -d' ' -f2) ;;
+            esac
+          done
+
+          METRICS_FILE="/tmp/metrics.json"
+          AGGREGATED_FILE="/tmp/aggregated.json"
+
+          case "$METHOD $PATH" in
+            "POST /metrics")
+              # Read POST body
+              if [ "$CONTENT_LENGTH" -gt 0 ]; then
+                BODY=$(head -c "$CONTENT_LENGTH")
+                TIMESTAMP=$(date -Iseconds)
+
+                # Append metric to file (simple append, will aggregate on GET)
+                echo "$BODY" >> /tmp/metrics_raw.log
+
+                echo "HTTP/1.1 200 OK"
+                echo "Content-Type: application/json"
+                echo ""
+                echo '{"status": "ok", "received": true}'
+              else
+                echo "HTTP/1.1 400 Bad Request"
+                echo "Content-Type: application/json"
+                echo ""
+                echo '{"error": "no body"}'
+              fi
+              ;;
+            "GET /metrics")
+              # Return all collected metrics
+              echo "HTTP/1.1 200 OK"
+              echo "Content-Type: application/json"
+              echo ""
+              if [ -f /tmp/metrics_raw.log ]; then
+                # Aggregate metrics by pattern and namespace
+                echo '{"node": "'$NODE_NAME'", "metrics": ['
+                FIRST=true
+                while read -r line; do
+                  if [ "$FIRST" = true ]; then
+                    FIRST=false
+                  else
+                    echo ","
+                  fi
+                  echo "$line"
+                done < /tmp/metrics_raw.log
+                echo ']}'
+              else
+                echo '{"node": "'$NODE_NAME'", "metrics": []}'
+              fi
+              ;;
+            "GET /health")
+              echo "HTTP/1.1 200 OK"
+              echo "Content-Type: application/json"
+              echo ""
+              echo '{"status": "healthy", "node": "'$NODE_NAME'"}'
+              ;;
+            "DELETE /metrics")
+              # Clear metrics (for reset between runs)
+              rm -f /tmp/metrics_raw.log
+              echo "HTTP/1.1 200 OK"
+              echo "Content-Type: application/json"
+              echo ""
+              echo '{"status": "cleared"}'
+              ;;
+            *)
+              echo "HTTP/1.1 404 Not Found"
+              echo "Content-Type: application/json"
+              echo ""
+              echo '{"error": "not found", "path": "'$PATH'"}'
+              ;;
+          esac
+          HANDLER_EOF
+
+          chmod +x /tmp/metrics-handler.sh
+
+          echo "Starting metrics store on port 9999 (node: ${NODE_NAME})"
+
+          # Use busybox nc to serve HTTP requests
+          while true; do
+            nc -l -p 9999 -e /tmp/metrics-handler.sh 2>/dev/null || {
+              # If nc doesn't support -e, fall back to socat-style approach
+              while true; do
+                { echo -e "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nMetrics store ready"; } | nc -l -p 9999 -q 1 2>/dev/null || sleep 1
+              done
+            }
+          done
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          tcpSocket:
+            port: 9999
+          initialDelaySeconds: 10
+          periodSeconds: 30
+        readinessProbe:
+          tcpSocket:
+            port: 9999
+          initialDelaySeconds: 5
+          periodSeconds: 10

--- a/cmd/config/synthetic-app/metrics-store-network-policy.yml
+++ b/cmd/config/synthetic-app/metrics-store-network-policy.yml
@@ -1,0 +1,19 @@
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-from-synthetic-app
+spec:
+  podSelector:
+    matchLabels:
+      app: synthetic-app-metrics-store
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kube-burner.io/job: synthetic-app
+    ports:
+    - protocol: TCP
+      port: 9999

--- a/cmd/config/synthetic-app/metrics-store-script-configmap.yml
+++ b/cmd/config/synthetic-app/metrics-store-script-configmap.yml
@@ -1,0 +1,144 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metrics-store-script
+data:
+  server.py: |
+    import json
+    import os
+    import threading
+    from http.server import HTTPServer, BaseHTTPRequestHandler
+    from datetime import datetime
+    from collections import defaultdict
+
+    METRICS_FILE = "/tmp/metrics_raw.log"
+    POD_NAME = os.environ.get("POD_NAME", "unknown")
+    PORT = int(os.environ.get("PORT", "9999"))
+
+    def make_default_entry():
+        return dict(count=0, ops_sum=0, throughput_sum=0, last_update="")
+
+    aggregated = defaultdict(make_default_entry)
+    lock = threading.Lock()
+
+    class MetricsHandler(BaseHTTPRequestHandler):
+        def log_message(self, format, *args):
+            print("[" + datetime.now().isoformat() + "] " + str(args[0]))
+
+        def do_GET(self):
+            if self.path == "/health" or self.path == "/healthz":
+                self._send_json(200, dict(status="healthy", pod=POD_NAME))
+            elif self.path == "/prometheus":
+                self._send_prometheus()
+            elif self.path.startswith("/metrics"):
+                self._send_metrics_json()
+            else:
+                self._send_json(200, dict(status="ok"))
+
+        def _send_metrics_json(self):
+            metrics = []
+            try:
+                with open(METRICS_FILE, "r") as f:
+                    for line in f:
+                        line = line.strip()
+                        if line:
+                            try:
+                                metrics.append(json.loads(line))
+                            except json.JSONDecodeError:
+                                pass
+            except FileNotFoundError:
+                pass
+            self._send_json(200, dict(pod=POD_NAME, metrics=metrics))
+
+        def _send_prometheus(self):
+            lines = []
+            lines.append("# HELP synthetic_app_ops_per_sec Operations per second from uperf")
+            lines.append("# TYPE synthetic_app_ops_per_sec gauge")
+            lines.append("# HELP synthetic_app_throughput_mbps Throughput in Mbps from uperf")
+            lines.append("# TYPE synthetic_app_throughput_mbps gauge")
+            lines.append("# HELP synthetic_app_sample_count Number of samples received")
+            lines.append("# TYPE synthetic_app_sample_count counter")
+
+            with lock:
+                for key, data in aggregated.items():
+                    ns, pattern = key
+                    labels = 'namespace="' + ns + '",pattern="' + pattern + '",pod="' + POD_NAME + '"'
+                    if data["count"] > 0:
+                        avg_ops = data["ops_sum"] / data["count"]
+                        avg_throughput = data["throughput_sum"] / data["count"]
+                        lines.append("synthetic_app_ops_per_sec" + chr(123) + labels + chr(125) + " " + str(round(avg_ops, 2)))
+                        lines.append("synthetic_app_throughput_mbps" + chr(123) + labels + chr(125) + " " + str(round(avg_throughput, 2)))
+                        lines.append("synthetic_app_sample_count" + chr(123) + labels + chr(125) + " " + str(data["count"]))
+
+            response = "\n".join(lines) + "\n"
+            self._send_text(response)
+
+        def do_POST(self):
+            if self.path == "/metrics" or self.path.startswith("/metrics"):
+                content_length = int(self.headers.get("Content-Length", 0))
+                if content_length > 0:
+                    body = self.rfile.read(content_length).decode("utf-8")
+                    with open(METRICS_FILE, "a") as f:
+                        f.write(body + "\n")
+
+                    try:
+                        data = json.loads(body)
+                        ns = data.get("namespace", "unknown")
+                        pattern = data.get("pattern", "unknown")
+                        metrics = data.get("metrics", dict())
+                        ops = float(metrics.get("ops_per_sec", 0))
+                        throughput = float(metrics.get("throughput_mbps", 0))
+
+                        with lock:
+                            key = (ns, pattern)
+                            aggregated[key]["count"] += 1
+                            aggregated[key]["ops_sum"] += ops
+                            aggregated[key]["throughput_sum"] += throughput
+                            aggregated[key]["last_update"] = data.get("timestamp", "")
+                    except (json.JSONDecodeError, ValueError, KeyError):
+                        pass
+
+                    self._send_json(200, dict(status="ok", received=True))
+                else:
+                    self._send_json(400, dict(error="no body"))
+            else:
+                self._send_json(404, dict(error="not found"))
+
+        def do_DELETE(self):
+            if self.path == "/metrics":
+                try:
+                    os.remove(METRICS_FILE)
+                except FileNotFoundError:
+                    pass
+                with lock:
+                    aggregated.clear()
+                self._send_json(200, dict(status="cleared"))
+            else:
+                self._send_json(404, dict(error="not found"))
+
+        def _send_json(self, code, data):
+            response = json.dumps(data).encode("utf-8")
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", len(response))
+            self.send_header("Connection", "close")
+            self.end_headers()
+            self.wfile.write(response)
+
+        def _send_text(self, text):
+            response = text.encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.send_header("Content-Length", len(response))
+            self.send_header("Connection", "close")
+            self.end_headers()
+            self.wfile.write(response)
+
+    if __name__ == "__main__":
+        print("Starting metrics store on port " + str(PORT) + " (pod: " + POD_NAME + ")")
+        print("  POST /metrics - receive metrics from uperf clients")
+        print("  GET /metrics - return all metrics as JSON")
+        print("  GET /prometheus - return metrics in Prometheus format")
+        server = HTTPServer(("0.0.0.0", PORT), MetricsHandler)
+        server.serve_forever()

--- a/cmd/config/synthetic-app/metrics-store-service.yml
+++ b/cmd/config/synthetic-app/metrics-store-service.yml
@@ -1,0 +1,14 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: synthetic-app-metrics-store
+spec:
+  selector:
+    app: synthetic-app-metrics-store
+  ports:
+  - name: metrics
+    port: 9999
+    targetPort: 9999
+    protocol: TCP
+  type: ClusterIP

--- a/cmd/config/synthetic-app/metrics-store-servicemonitor.yml
+++ b/cmd/config/synthetic-app/metrics-store-servicemonitor.yml
@@ -1,0 +1,19 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: synthetic-app-metrics-store
+  labels:
+    app: synthetic-app-metrics-store
+spec:
+  endpoints:
+  - interval: 15s
+    path: /prometheus
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - synthetic-app-infra
+  selector:
+    matchLabels:
+      app: synthetic-app-metrics-store

--- a/cmd/config/synthetic-app/metrics-synthetic-app.yml
+++ b/cmd/config/synthetic-app/metrics-synthetic-app.yml
@@ -1,0 +1,24 @@
+# Synthetic App uperf metrics
+
+- query: synthetic_app_ops_per_sec
+  metricName: syntheticAppOpsPerSec
+
+- query: synthetic_app_throughput_mbps
+  metricName: syntheticAppThroughputMbps
+
+- query: synthetic_app_sample_count
+  metricName: syntheticAppSampleCount
+
+# Aggregate by pattern
+- query: avg(synthetic_app_ops_per_sec) by (pattern)
+  metricName: syntheticAppOpsPerSecByPattern
+
+- query: avg(synthetic_app_throughput_mbps) by (pattern)
+  metricName: syntheticAppThroughputByPattern
+
+# Aggregate by namespace
+- query: avg(synthetic_app_ops_per_sec) by (namespace)
+  metricName: syntheticAppOpsPerSecByNamespace
+
+- query: avg(synthetic_app_throughput_mbps) by (namespace)
+  metricName: syntheticAppThroughputByNamespace

--- a/cmd/config/synthetic-app/microservice-server-deployment.yml
+++ b/cmd/config/synthetic-app/microservice-server-deployment.yml
@@ -1,0 +1,59 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: microservice-server-{{.Replica}}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: microservice-server-{{.Replica}}
+      pattern: frontend-microservices
+  template:
+    metadata:
+      labels:
+        app: microservice-server-{{.Replica}}
+        pattern: frontend-microservices
+        role: server
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/worker
+                operator: Exists
+              - key: node-role.kubernetes.io/infra
+                operator: DoesNotExist
+              - key: node-role.kubernetes.io/workload
+                operator: DoesNotExist
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  pattern: frontend-microservices
+                  role: client
+              topologyKey: kubernetes.io/hostname
+      containers:
+      - name: uperf-server
+        image: {{.uperfImage}}
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+        ports:
+        - containerPort: 20000
+          protocol: TCP
+          name: uperf
+        command:
+        - /bin/sh
+        - -c
+        - |
+          echo "Starting uperf server (microservice-{{.Replica}}) on port 20000"
+          uperf -s -v -P 20000
+        imagePullPolicy: IfNotPresent

--- a/cmd/config/synthetic-app/microservice-server-service.yml
+++ b/cmd/config/synthetic-app/microservice-server-service.yml
@@ -1,0 +1,15 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: microservice-svc-{{.Replica}}
+spec:
+  selector:
+    app: microservice-server-{{.Replica}}
+    pattern: frontend-microservices
+  ports:
+  - name: uperf
+    port: 20000
+    targetPort: 20000
+    protocol: TCP
+  type: ClusterIP

--- a/cmd/config/synthetic-app/network-policy-allow-metrics.yml
+++ b/cmd/config/synthetic-app/network-policy-allow-metrics.yml
@@ -1,0 +1,19 @@
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-egress-to-metrics-store
+spec:
+  podSelector:
+    matchLabels:
+      role: client
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: synthetic-app-infra
+    ports:
+    - protocol: TCP
+      port: 9999

--- a/cmd/config/synthetic-app/network-policy-allow-traffic.yml
+++ b/cmd/config/synthetic-app/network-policy-allow-traffic.yml
@@ -1,0 +1,41 @@
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-synthetic-app-traffic
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: {{.Namespace}}
+    - podSelector: {}
+    ports:
+    - protocol: TCP
+      port: 20000
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: {{.Namespace}}
+    - podSelector: {}
+    ports:
+    - protocol: TCP
+      port: 20000
+  - to:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 9999
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53

--- a/cmd/config/synthetic-app/network-policy-allow-traffic.yml
+++ b/cmd/config/synthetic-app/network-policy-allow-traffic.yml
@@ -12,7 +12,7 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          kubernetes.io/metadata.name: {{.Namespace}}
+          kubernetes.io/metadata.name: {{.namespace}}-{{.Iteration}}
     - podSelector: {}
     ports:
     - protocol: TCP
@@ -21,7 +21,7 @@ spec:
   - to:
     - namespaceSelector:
         matchLabels:
-          kubernetes.io/metadata.name: {{.Namespace}}
+          kubernetes.io/metadata.name: {{.namespace}}-{{.Iteration}}
     - podSelector: {}
     ports:
     - protocol: TCP

--- a/cmd/config/synthetic-app/network-policy-deny-all.yml
+++ b/cmd/config/synthetic-app/network-policy-deny-all.yml
@@ -1,0 +1,10 @@
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: deny-all
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/cmd/config/synthetic-app/network-policy-filler.yml
+++ b/cmd/config/synthetic-app/network-policy-filler.yml
@@ -1,0 +1,55 @@
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: filler-netpol-{{.Replica}}
+spec:
+  podSelector:
+    matchLabels:
+      netpol-target: filler-{{.Replica}}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          netpol-peer: filler-{{.Replica}}
+    - podSelector:
+        matchLabels:
+          netpol-source: filler-{{.Replica}}
+    ports:
+    - protocol: TCP
+      port: 80
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 8080
+  - from:
+    - ipBlock:
+        cidr: 10.{{mod .Replica 256}}.0.0/16
+        except:
+        - 10.{{mod .Replica 256}}.1.0/24
+    ports:
+    - protocol: TCP
+      port: 80
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          netpol-peer: filler-{{.Replica}}
+    - podSelector:
+        matchLabels:
+          netpol-target: filler-{{.Replica}}
+    ports:
+    - protocol: TCP
+      port: 80
+    - protocol: TCP
+      port: 443
+  - to:
+    - ipBlock:
+        cidr: 10.{{mod .Replica 256}}.0.0/16
+    ports:
+    - protocol: TCP
+      port: 80
+      endPort: 8080

--- a/cmd/config/synthetic-app/synthetic-app.yml
+++ b/cmd/config/synthetic-app/synthetic-app.yml
@@ -1,0 +1,180 @@
+---
+global:
+  gc: {{.GC}}
+  gcMetrics: {{.GC_METRICS}}
+  measurements:
+    - name: podLatency
+      thresholds:
+        - conditionType: Ready
+          metric: P99
+          threshold: {{.POD_READY_THRESHOLD}}
+
+metricsEndpoints:
+{{ if .ES_SERVER }}
+  - metrics: [{{.METRICS}}]
+    alerts: [{{.ALERTS}}]
+    indexer:
+      esServers: ["{{.ES_SERVER}}"]
+      insecureSkipVerify: true
+      defaultIndex: {{.ES_INDEX}}
+      type: opensearch
+{{ end }}
+{{ if .LOCAL_INDEXING }}
+  - metrics: [{{.METRICS}}]
+    alerts: [{{.ALERTS}}]
+    indexer:
+      type: local
+      metricsDirectory: collected-metrics-{{.UUID}}
+{{ end }}
+
+jobs:
+  # Phase 1: Create metrics infrastructure (run once)
+  - name: synthetic-app-metrics-store
+    namespace: synthetic-app-metrics
+    jobIterations: 1
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    namespacedIterations: false
+    podWait: true
+    waitWhenFinished: true
+    cleanup: false
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+    objects:
+      - objectTemplate: metrics-store-daemonset.yml
+        replicas: 1
+
+      - objectTemplate: metrics-store-service.yml
+        replicas: 1
+
+  # Phase 2: Create uperf profile ConfigMaps (shared across namespaces)
+  - name: synthetic-app-profiles
+    namespace: synthetic-app-profiles
+    jobIterations: 1
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    namespacedIterations: false
+    podWait: false
+    waitWhenFinished: true
+    cleanup: false
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+    objects:
+      - objectTemplate: uperf-profiles-configmap.yml
+        replicas: 1
+
+  # Phase 3: Create synthetic applications (one per namespace)
+  - name: synthetic-app
+    namespace: synthetic-app
+    jobIterations: {{.JOB_ITERATIONS}}
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    namespacedIterations: true
+    podWait: true
+    waitWhenFinished: true
+    preLoadImages: true
+    jobPause: 10s
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+    objects:
+      # Pattern 1: Users -> Frontend (many-to-one)
+      - objectTemplate: frontend-server-deployment.yml
+        replicas: 1
+        inputVars:
+          uperfImage: {{.UPERF_IMAGE}}
+
+      - objectTemplate: frontend-server-service.yml
+        replicas: 1
+
+      - objectTemplate: user-client-deployment.yml
+        replicas: 1
+        inputVars:
+          uperfImage: {{.UPERF_IMAGE}}
+          users: {{.USERS_PER_FRONTEND}}
+          trafficDuration: {{.TRAFFIC_DURATION}}
+          metricsReportInterval: {{.METRICS_REPORT_INTERVAL}}
+
+      # Pattern 2: Frontend -> Microservices (one-to-many, fan-out)
+      - objectTemplate: microservice-server-deployment.yml
+        replicas: 2
+        inputVars:
+          uperfImage: {{.UPERF_IMAGE}}
+
+      - objectTemplate: microservice-server-service.yml
+        replicas: 2
+
+      - objectTemplate: frontend-client-deployment.yml
+        replicas: 1
+        inputVars:
+          uperfImage: {{.UPERF_IMAGE}}
+          threads: {{.FRONTEND_THREADS}}
+          trafficDuration: {{.TRAFFIC_DURATION}}
+          metricsReportInterval: {{.METRICS_REPORT_INTERVAL}}
+
+      # Pattern 3: App -> Database (OLTP-style)
+      - objectTemplate: db-server-deployment.yml
+        replicas: 1
+        inputVars:
+          uperfImage: {{.UPERF_IMAGE}}
+
+      - objectTemplate: db-server-service.yml
+        replicas: 1
+
+      - objectTemplate: app-client-deployment.yml
+        replicas: 1
+        inputVars:
+          uperfImage: {{.UPERF_IMAGE}}
+          dbConnections: {{.DB_CONNECTIONS}}
+          trafficDuration: {{.TRAFFIC_DURATION}}
+          metricsReportInterval: {{.METRICS_REPORT_INTERVAL}}
+
+      # Filler deployments (control plane load)
+      - objectTemplate: filler-deployment.yml
+        replicas: {{.FILLER_DEPLOYMENTS}}
+
+      # Filler services
+      - objectTemplate: filler-service.yml
+        replicas: {{.FILLER_SERVICES}}
+
+      # Network policies (control plane load)
+      - objectTemplate: network-policy-deny-all.yml
+        replicas: 1
+
+      - objectTemplate: network-policy-allow-traffic.yml
+        replicas: 1
+
+      - objectTemplate: network-policy-filler.yml
+        replicas: {{.NETWORK_POLICIES}}
+
+{{ if .CHURN }}
+  # Phase 4: Control plane churn (optional - creates additional resources while traffic runs)
+  - name: synthetic-app-churn
+    namespace: synthetic-app-churn
+    jobIterations: 1
+    qps: 2
+    burst: 5
+    namespacedIterations: true
+    podWait: false
+    waitWhenFinished: false
+    cleanup: false
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+    objects:
+      - objectTemplate: filler-deployment.yml
+        replicas: {{.CHURN_DEPLOYMENTS}}
+
+      - objectTemplate: network-policy-filler.yml
+        replicas: {{.CHURN_NETWORK_POLICIES}}
+{{ end }}

--- a/cmd/config/synthetic-app/synthetic-app.yml
+++ b/cmd/config/synthetic-app/synthetic-app.yml
@@ -28,9 +28,9 @@ metricsEndpoints:
 {{ end }}
 
 jobs:
-  # Phase 1: Create metrics infrastructure (run once)
-  - name: synthetic-app-metrics-store
-    namespace: synthetic-app-metrics
+  # Phase 1: Create metrics infrastructure (separate namespace)
+  - name: synthetic-app-infra
+    namespace: synthetic-app-infra
     jobIterations: 1
     qps: {{.QPS}}
     burst: {{.BURST}}
@@ -44,32 +44,24 @@ jobs:
       pod-security.kubernetes.io/audit: privileged
       pod-security.kubernetes.io/warn: privileged
     objects:
+      - objectTemplate: metrics-store-script-configmap.yml
+        replicas: 1
+
       - objectTemplate: metrics-store-daemonset.yml
         replicas: 1
+        inputVars:
+          replicas: 5
 
       - objectTemplate: metrics-store-service.yml
         replicas: 1
 
-  # Phase 2: Create uperf profile ConfigMaps (shared across namespaces)
-  - name: synthetic-app-profiles
-    namespace: synthetic-app-profiles
-    jobIterations: 1
-    qps: {{.QPS}}
-    burst: {{.BURST}}
-    namespacedIterations: false
-    podWait: false
-    waitWhenFinished: true
-    cleanup: false
-    namespaceLabels:
-      security.openshift.io/scc.podSecurityLabelSync: false
-      pod-security.kubernetes.io/enforce: privileged
-      pod-security.kubernetes.io/audit: privileged
-      pod-security.kubernetes.io/warn: privileged
-    objects:
-      - objectTemplate: uperf-profiles-configmap.yml
+      - objectTemplate: metrics-store-network-policy.yml
         replicas: 1
 
-  # Phase 3: Create synthetic applications (one per namespace)
+      - objectTemplate: metrics-store-servicemonitor.yml
+        replicas: 1
+
+  # Phase 2: Create synthetic applications (one per namespace)
   - name: synthetic-app
     namespace: synthetic-app
     jobIterations: {{.JOB_ITERATIONS}}
@@ -78,14 +70,23 @@ jobs:
     namespacedIterations: true
     podWait: true
     waitWhenFinished: true
-    preLoadImages: true
-    jobPause: 10s
+    preLoadImages: false
+    jobPause: 2m
     namespaceLabels:
       security.openshift.io/scc.podSecurityLabelSync: false
       pod-security.kubernetes.io/enforce: privileged
       pod-security.kubernetes.io/audit: privileged
       pod-security.kubernetes.io/warn: privileged
     objects:
+      # uperf profiles ConfigMap (created in each namespace)
+      - objectTemplate: uperf-profiles-configmap.yml
+        replicas: 1
+        inputVars:
+          users: {{.USERS_PER_FRONTEND}}
+          threads: {{.FRONTEND_THREADS}}
+          dbConnections: {{.DB_CONNECTIONS}}
+          trafficDuration: {{.TRAFFIC_DURATION}}
+
       # Pattern 1: Users -> Frontend (many-to-one)
       - objectTemplate: frontend-server-deployment.yml
         replicas: 1
@@ -150,31 +151,12 @@ jobs:
         replicas: 1
 
       - objectTemplate: network-policy-allow-traffic.yml
+        inputVars:
+          namespace: synthetic-app
+        replicas: 1
+
+      - objectTemplate: network-policy-allow-metrics.yml
         replicas: 1
 
       - objectTemplate: network-policy-filler.yml
         replicas: {{.NETWORK_POLICIES}}
-
-{{ if .CHURN }}
-  # Phase 4: Control plane churn (optional - creates additional resources while traffic runs)
-  - name: synthetic-app-churn
-    namespace: synthetic-app-churn
-    jobIterations: 1
-    qps: 2
-    burst: 5
-    namespacedIterations: true
-    podWait: false
-    waitWhenFinished: false
-    cleanup: false
-    namespaceLabels:
-      security.openshift.io/scc.podSecurityLabelSync: false
-      pod-security.kubernetes.io/enforce: privileged
-      pod-security.kubernetes.io/audit: privileged
-      pod-security.kubernetes.io/warn: privileged
-    objects:
-      - objectTemplate: filler-deployment.yml
-        replicas: {{.CHURN_DEPLOYMENTS}}
-
-      - objectTemplate: network-policy-filler.yml
-        replicas: {{.CHURN_NETWORK_POLICIES}}
-{{ end }}

--- a/cmd/config/synthetic-app/uperf-profiles-configmap.yml
+++ b/cmd/config/synthetic-app/uperf-profiles-configmap.yml
@@ -7,11 +7,11 @@ data:
   users-frontend.xml: |
     <?xml version="1.0"?>
     <profile name="users-frontend">
-      <group nthreads="100">
+      <group nthreads="{{.users}}">
         <transaction iterations="1">
           <flowop type="connect" options="remotehost=$SERVER_HOST port=$SERVER_PORT protocol=tcp tcp_nodelay"/>
         </transaction>
-        <transaction duration="300s">
+        <transaction duration="{{.trafficDuration}}">
           <flowop type="write" options="size=512"/>
           <flowop type="read" options="size=2048"/>
           <flowop type="think" options="duration=50ms"/>
@@ -25,12 +25,12 @@ data:
   frontend-microservices.xml: |
     <?xml version="1.0"?>
     <profile name="frontend-microservices">
-      <group nthreads="50">
+      <group nthreads="{{.threads}}">
         <transaction iterations="1">
           <flowop type="connect" options="remotehost=$MS1_HOST port=$SERVER_PORT protocol=tcp"/>
           <flowop type="connect" options="conn=1 remotehost=$MS2_HOST port=$SERVER_PORT protocol=tcp"/>
         </transaction>
-        <transaction duration="300s">
+        <transaction duration="{{.trafficDuration}}">
           <flowop type="write" options="size=256"/>
           <flowop type="write" options="conn=1 size=256"/>
           <flowop type="read" options="size=1024"/>
@@ -46,11 +46,11 @@ data:
   app-database.xml: |
     <?xml version="1.0"?>
     <profile name="app-database">
-      <group nthreads="200">
+      <group nthreads="{{.dbConnections}}">
         <transaction iterations="1">
           <flowop type="connect" options="remotehost=$SERVER_HOST port=$SERVER_PORT protocol=tcp tcp_nodelay"/>
         </transaction>
-        <transaction duration="300s">
+        <transaction duration="{{.trafficDuration}}">
           <flowop type="write" options="size=128"/>
           <flowop type="read" options="size=1024"/>
           <flowop type="write" options="size=512"/>

--- a/cmd/config/synthetic-app/uperf-profiles-configmap.yml
+++ b/cmd/config/synthetic-app/uperf-profiles-configmap.yml
@@ -1,0 +1,63 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: uperf-profiles
+data:
+  users-frontend.xml: |
+    <?xml version="1.0"?>
+    <profile name="users-frontend">
+      <group nthreads="100">
+        <transaction iterations="1">
+          <flowop type="connect" options="remotehost=$SERVER_HOST port=$SERVER_PORT protocol=tcp tcp_nodelay"/>
+        </transaction>
+        <transaction duration="300s">
+          <flowop type="write" options="size=512"/>
+          <flowop type="read" options="size=2048"/>
+          <flowop type="think" options="duration=50ms"/>
+        </transaction>
+        <transaction iterations="1">
+          <flowop type="disconnect"/>
+        </transaction>
+      </group>
+    </profile>
+
+  frontend-microservices.xml: |
+    <?xml version="1.0"?>
+    <profile name="frontend-microservices">
+      <group nthreads="50">
+        <transaction iterations="1">
+          <flowop type="connect" options="remotehost=$MS1_HOST port=$SERVER_PORT protocol=tcp"/>
+          <flowop type="connect" options="conn=1 remotehost=$MS2_HOST port=$SERVER_PORT protocol=tcp"/>
+        </transaction>
+        <transaction duration="300s">
+          <flowop type="write" options="size=256"/>
+          <flowop type="write" options="conn=1 size=256"/>
+          <flowop type="read" options="size=1024"/>
+          <flowop type="read" options="conn=1 size=1024"/>
+        </transaction>
+        <transaction iterations="1">
+          <flowop type="disconnect"/>
+          <flowop type="disconnect" options="conn=1"/>
+        </transaction>
+      </group>
+    </profile>
+
+  app-database.xml: |
+    <?xml version="1.0"?>
+    <profile name="app-database">
+      <group nthreads="200">
+        <transaction iterations="1">
+          <flowop type="connect" options="remotehost=$SERVER_HOST port=$SERVER_PORT protocol=tcp tcp_nodelay"/>
+        </transaction>
+        <transaction duration="300s">
+          <flowop type="write" options="size=128"/>
+          <flowop type="read" options="size=1024"/>
+          <flowop type="write" options="size=512"/>
+          <flowop type="read" options="size=64"/>
+        </transaction>
+        <transaction iterations="1">
+          <flowop type="disconnect"/>
+        </transaction>
+      </group>
+    </profile>

--- a/cmd/config/synthetic-app/user-client-deployment.yml
+++ b/cmd/config/synthetic-app/user-client-deployment.yml
@@ -1,0 +1,128 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: user-client
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: user-client
+      pattern: users-frontend
+  template:
+    metadata:
+      labels:
+        app: user-client
+        pattern: users-frontend
+        role: client
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/worker
+                operator: Exists
+              - key: node-role.kubernetes.io/infra
+                operator: DoesNotExist
+              - key: node-role.kubernetes.io/workload
+                operator: DoesNotExist
+      containers:
+      - name: uperf-client
+        image: {{.uperfImage}}
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "1000m"
+        env:
+        - name: METRICS_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: METRICS_PORT
+          value: "9999"
+        - name: PATTERN_NAME
+          value: "users-frontend"
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: SERVER_HOST
+          value: "frontend-svc"
+        - name: SERVER_PORT
+          value: "20000"
+        - name: USERS
+          value: "{{.users}}"
+        - name: TRAFFIC_DURATION
+          value: "{{.trafficDuration}}"
+        - name: REPORT_INTERVAL
+          value: "{{.metricsReportInterval}}"
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -e
+          METRICS_URL="http://${METRICS_HOST}:${METRICS_PORT}/metrics"
+          PROFILE="/tmp/users-frontend.xml"
+
+          # Create uperf profile
+          cat > ${PROFILE} << 'PROFILE_EOF'
+          <?xml version="1.0"?>
+          <profile name="users-frontend">
+            <group nthreads="${USERS}">
+              <transaction iterations="1">
+                <flowop type="connect" options="remotehost=${SERVER_HOST} port=${SERVER_PORT} protocol=tcp tcp_nodelay"/>
+              </transaction>
+              <transaction duration="${TRAFFIC_DURATION}">
+                <flowop type="write" options="size=512"/>
+                <flowop type="read" options="size=2048"/>
+                <flowop type="think" options="duration=50ms"/>
+              </transaction>
+              <transaction iterations="1">
+                <flowop type="disconnect"/>
+              </transaction>
+            </group>
+          </profile>
+          PROFILE_EOF
+
+          # Substitute environment variables
+          envsubst < ${PROFILE} > /tmp/profile.xml
+
+          echo "Starting uperf client for users-frontend pattern"
+          echo "Server: ${SERVER_HOST}:${SERVER_PORT}, Users: ${USERS}, Duration: ${TRAFFIC_DURATION}"
+
+          # Run uperf and report metrics periodically
+          while true; do
+            START_TIME=$(date +%s)
+
+            # Run uperf for the report interval
+            OUTPUT=$(timeout ${REPORT_INTERVAL}s uperf -m /tmp/profile.xml -a 2>&1 || true)
+
+            # Parse metrics from uperf output
+            OPS_SEC=$(echo "$OUTPUT" | grep -oP 'Txn1\s+\K[\d.]+(?=\s+ops)' | tail -1 || echo "0")
+            BYTES_SEC=$(echo "$OUTPUT" | grep -oP '[\d.]+(?=\s+Mb/s)' | tail -1 || echo "0")
+
+            # Report to metrics store
+            curl -s -X POST "${METRICS_URL}" \
+              -H "Content-Type: application/json" \
+              -d "{
+                \"timestamp\": \"$(date -Iseconds)\",
+                \"namespace\": \"${POD_NAMESPACE}\",
+                \"pattern\": \"${PATTERN_NAME}\",
+                \"client\": \"${POD_NAME}\",
+                \"metrics\": {
+                  \"ops_per_sec\": ${OPS_SEC:-0},
+                  \"throughput_mbps\": ${BYTES_SEC:-0}
+                }
+              }" || echo "Failed to report metrics"
+
+            echo "Reported metrics: ops/sec=${OPS_SEC}, throughput=${BYTES_SEC} Mb/s"
+          done
+        imagePullPolicy: IfNotPresent

--- a/cmd/config/synthetic-app/user-client-deployment.yml
+++ b/cmd/config/synthetic-app/user-client-deployment.yml
@@ -16,6 +16,10 @@ spec:
         pattern: users-frontend
         role: client
     spec:
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "2"
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -27,6 +31,10 @@ spec:
                 operator: DoesNotExist
               - key: node-role.kubernetes.io/workload
                 operator: DoesNotExist
+      volumes:
+      - name: uperf-profiles
+        configMap:
+          name: uperf-profiles
       containers:
       - name: uperf-client
         image: {{.uperfImage}}
@@ -37,11 +45,13 @@ spec:
           limits:
             memory: "512Mi"
             cpu: "1000m"
+        volumeMounts:
+        - name: uperf-profiles
+          mountPath: /profiles
+          readOnly: true
         env:
         - name: METRICS_HOST
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
+          value: "synthetic-app-metrics-store.synthetic-app-infra.svc"
         - name: METRICS_PORT
           value: "9999"
         - name: PATTERN_NAME
@@ -58,10 +68,6 @@ spec:
           value: "frontend-svc"
         - name: SERVER_PORT
           value: "20000"
-        - name: USERS
-          value: "{{.users}}"
-        - name: TRAFFIC_DURATION
-          value: "{{.trafficDuration}}"
         - name: REPORT_INTERVAL
           value: "{{.metricsReportInterval}}"
         command:
@@ -70,58 +76,31 @@ spec:
         - |
           set -e
           METRICS_URL="http://${METRICS_HOST}:${METRICS_PORT}/metrics"
-          PROFILE="/tmp/users-frontend.xml"
+          PROFILE_TEMPLATE="/profiles/users-frontend.xml"
+          PROFILE="/tmp/profile.xml"
 
-          # Create uperf profile
-          cat > ${PROFILE} << 'PROFILE_EOF'
-          <?xml version="1.0"?>
-          <profile name="users-frontend">
-            <group nthreads="${USERS}">
-              <transaction iterations="1">
-                <flowop type="connect" options="remotehost=${SERVER_HOST} port=${SERVER_PORT} protocol=tcp tcp_nodelay"/>
-              </transaction>
-              <transaction duration="${TRAFFIC_DURATION}">
-                <flowop type="write" options="size=512"/>
-                <flowop type="read" options="size=2048"/>
-                <flowop type="think" options="duration=50ms"/>
-              </transaction>
-              <transaction iterations="1">
-                <flowop type="disconnect"/>
-              </transaction>
-            </group>
-          </profile>
-          PROFILE_EOF
-
-          # Substitute environment variables
-          envsubst < ${PROFILE} > /tmp/profile.xml
+          # Substitute environment variables in profile using sed
+          sed -e "s|\$SERVER_HOST|${SERVER_HOST}|g" \
+              -e "s|\$SERVER_PORT|${SERVER_PORT}|g" \
+              ${PROFILE_TEMPLATE} > ${PROFILE}
 
           echo "Starting uperf client for users-frontend pattern"
-          echo "Server: ${SERVER_HOST}:${SERVER_PORT}, Users: ${USERS}, Duration: ${TRAFFIC_DURATION}"
+          echo "Server: ${SERVER_HOST}:${SERVER_PORT}"
+          cat ${PROFILE}
 
           # Run uperf and report metrics periodically
           while true; do
-            START_TIME=$(date +%s)
-
             # Run uperf for the report interval
-            OUTPUT=$(timeout ${REPORT_INTERVAL}s uperf -m /tmp/profile.xml -a 2>&1 || true)
+            OUTPUT=$(timeout ${REPORT_INTERVAL}s uperf -m ${PROFILE} -a 2>&1 || true)
 
-            # Parse metrics from uperf output
-            OPS_SEC=$(echo "$OUTPUT" | grep -oP 'Txn1\s+\K[\d.]+(?=\s+ops)' | tail -1 || echo "0")
-            BYTES_SEC=$(echo "$OUTPUT" | grep -oP '[\d.]+(?=\s+Mb/s)' | tail -1 || echo "0")
+            # Parse metrics from uperf output (from "Total" line)
+            # Example: "Total     22.89MB /   7.31(s) =    26.28Mb/s       51322op/s"
+            OPS_SEC=$(echo "$OUTPUT" | grep "^Total" | grep -oP '\d+(?=op/s)' || echo "0")
+            BYTES_SEC=$(echo "$OUTPUT" | grep "^Total" | grep -oP '[\d.]+(?=Mb/s)' || echo "0")
 
-            # Report to metrics store
-            curl -s -X POST "${METRICS_URL}" \
-              -H "Content-Type: application/json" \
-              -d "{
-                \"timestamp\": \"$(date -Iseconds)\",
-                \"namespace\": \"${POD_NAMESPACE}\",
-                \"pattern\": \"${PATTERN_NAME}\",
-                \"client\": \"${POD_NAME}\",
-                \"metrics\": {
-                  \"ops_per_sec\": ${OPS_SEC:-0},
-                  \"throughput_mbps\": ${BYTES_SEC:-0}
-                }
-              }" || echo "Failed to report metrics"
+            # Report to metrics store (single-line JSON for proper parsing)
+            JSON_DATA="{\"timestamp\":\"$(date -Iseconds)\",\"namespace\":\"${POD_NAMESPACE}\",\"pattern\":\"${PATTERN_NAME}\",\"client\":\"${POD_NAME}\",\"metrics\":{\"ops_per_sec\":${OPS_SEC:-0},\"throughput_mbps\":${BYTES_SEC:-0}}}"
+            curl -s -X POST "${METRICS_URL}" -H "Content-Type: application/json" -d "${JSON_DATA}" || echo "Failed to report metrics"
 
             echo "Reported metrics: ops/sec=${OPS_SEC}, throughput=${BYTES_SEC} Mb/s"
           done

--- a/cmd/ocp.go
+++ b/cmd/ocp.go
@@ -135,6 +135,7 @@ func openShiftCmd() *cobra.Command {
 		ocpWorkloads.NewUdnBgp(&wh, "udn-bgp"),
 		ocpWorkloads.NewEVPN(&wh, "evpn"),
 		ocpWorkloads.NewNetworkPolicy(&wh, "network-policy"),
+		ocpWorkloads.NewSyntheticApp(&wh),
 		ocpWorkloads.NewOLMv1(&wh, "olm"),
 		ocpWorkloads.NewNodeDensity(&wh, "node-density"),
 		ocpWorkloads.NewNodeDensity(&wh, "node-density-heavy"),

--- a/pkg/workloads/synthetic-app.go
+++ b/pkg/workloads/synthetic-app.go
@@ -1,0 +1,118 @@
+// Copyright 2024 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workloads
+
+import (
+	"os"
+	"time"
+
+	"github.com/kube-burner/kube-burner/v2/pkg/workloads"
+	"github.com/spf13/cobra"
+)
+
+// NewSyntheticApp creates the synthetic-app workload command
+// This workload simulates realistic multi-tier applications to stress OVN/OVS
+// control plane and data plane simultaneously for network performance analysis
+func NewSyntheticApp(wh *workloads.WorkloadHelper) *cobra.Command {
+	var iterations int
+	var fillerDeployments, fillerServices, networkPolicies int
+	var usersPerFrontend, frontendThreads, dbConnections int
+	var trafficDuration time.Duration
+	var metricsReportInterval time.Duration
+	var churn bool
+	var churnDeployments, churnNetworkPolicies int
+	var podReadyThreshold time.Duration
+	var metricsProfiles []string
+	var uperfImage, metricsStoreImage string
+	var rc int
+
+	cmd := &cobra.Command{
+		Use:   "synthetic-app",
+		Short: "Runs synthetic-app workload to simulate multi-tier applications for OVN/OVS performance analysis",
+		Long: `The synthetic-app workload simulates realistic multi-tier customer applications to stress
+both OVN/OVS control plane and data plane simultaneously. It runs three independent uperf
+traffic patterns:
+
+  1. Users → Frontend: Many concurrent connections simulating user load
+  2. Frontend → Microservices: Fan-out pattern to multiple backend services
+  3. App → Database: OLTP-style request/response traffic
+
+Each namespace contains:
+  - Traffic pattern client/server deployments
+  - Filler deployments to create realistic resource density
+  - Services and NetworkPolicies to stress OVN NBDB/SBDB
+
+Metrics are collected via a DaemonSet metrics-store that receives periodic pushes
+from uperf clients and aggregates them for kube-burner indexing.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			setMetrics(cmd, metricsProfiles)
+
+			AdditionalVars["JOB_ITERATIONS"] = iterations
+			AdditionalVars["FILLER_DEPLOYMENTS"] = fillerDeployments
+			AdditionalVars["FILLER_SERVICES"] = fillerServices
+			AdditionalVars["NETWORK_POLICIES"] = networkPolicies
+			AdditionalVars["USERS_PER_FRONTEND"] = usersPerFrontend
+			AdditionalVars["FRONTEND_THREADS"] = frontendThreads
+			AdditionalVars["DB_CONNECTIONS"] = dbConnections
+			AdditionalVars["TRAFFIC_DURATION"] = trafficDuration.String()
+			AdditionalVars["METRICS_REPORT_INTERVAL"] = int(metricsReportInterval.Seconds())
+			AdditionalVars["CHURN"] = churn
+			AdditionalVars["CHURN_DEPLOYMENTS"] = churnDeployments
+			AdditionalVars["CHURN_NETWORK_POLICIES"] = churnNetworkPolicies
+			AdditionalVars["POD_READY_THRESHOLD"] = podReadyThreshold
+			AdditionalVars["UPERF_IMAGE"] = uperfImage
+			AdditionalVars["METRICS_STORE_IMAGE"] = metricsStoreImage
+
+			rc = RunWorkload(cmd, wh, "synthetic-app.yml")
+		},
+		PostRun: func(cmd *cobra.Command, args []string) {
+			os.Exit(rc)
+		},
+	}
+
+	// Namespace/iteration configuration
+	cmd.Flags().IntVar(&iterations, "iterations", 1, "Number of synthetic app namespaces to create")
+
+	// Resource density configuration (filler resources for control plane load)
+	cmd.Flags().IntVar(&fillerDeployments, "filler-deployments", 63, "Number of filler deployments per namespace (adds to 70 total with traffic patterns)")
+	cmd.Flags().IntVar(&fillerServices, "filler-services", 45, "Number of filler services per namespace (adds to 50 total)")
+	cmd.Flags().IntVar(&networkPolicies, "network-policies", 200, "Number of network policies per namespace")
+
+	// Traffic pattern configuration
+	cmd.Flags().IntVar(&usersPerFrontend, "users-per-frontend", 100, "Number of concurrent user connections to frontend (Pattern 1 threads)")
+	cmd.Flags().IntVar(&frontendThreads, "frontend-threads", 50, "Number of frontend handler threads for microservice fan-out (Pattern 2)")
+	cmd.Flags().IntVar(&dbConnections, "db-connections", 200, "Number of database connection pool size (Pattern 3 threads)")
+	cmd.Flags().DurationVar(&trafficDuration, "traffic-duration", 5*time.Minute, "Duration to run uperf traffic patterns")
+	cmd.Flags().DurationVar(&metricsReportInterval, "metrics-report-interval", 30*time.Second, "Interval for uperf clients to report metrics to metrics-store")
+
+	// Churn configuration (control plane stress)
+	cmd.Flags().BoolVar(&churn, "churn", false, "Enable control plane churn during traffic (create additional resources)")
+	cmd.Flags().IntVar(&churnDeployments, "churn-deployments", 20, "Number of deployments to create during churn")
+	cmd.Flags().IntVar(&churnNetworkPolicies, "churn-network-policies", 50, "Number of network policies to create during churn")
+
+	// Pod configuration
+	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 2*time.Minute, "Pod ready timeout threshold")
+
+	// Image configuration
+	cmd.Flags().StringVar(&uperfImage, "uperf-image", "quay.io/cloud-bulldozer/uperf:latest", "uperf container image")
+	cmd.Flags().StringVar(&metricsStoreImage, "metrics-store-image", "quay.io/cloud-bulldozer/synthetic-app-metrics-store:latest", "Metrics store container image")
+
+	// Metrics configuration
+	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
+
+	cmd.MarkFlagRequired("iterations")
+
+	return cmd
+}

--- a/pkg/workloads/synthetic-app.go
+++ b/pkg/workloads/synthetic-app.go
@@ -86,9 +86,9 @@ from uperf clients and aggregates them for kube-burner indexing.`,
 	cmd.Flags().IntVar(&iterations, "iterations", 1, "Number of synthetic app namespaces to create")
 
 	// Resource density configuration (filler resources for control plane load)
-	cmd.Flags().IntVar(&fillerDeployments, "filler-deployments", 63, "Number of filler deployments per namespace (adds to 70 total with traffic patterns)")
-	cmd.Flags().IntVar(&fillerServices, "filler-services", 45, "Number of filler services per namespace (adds to 50 total)")
-	cmd.Flags().IntVar(&networkPolicies, "network-policies", 200, "Number of network policies per namespace")
+	cmd.Flags().IntVar(&fillerDeployments, "filler-deployments", 1, "Number of filler deployments per namespace (adds to 70 total with traffic patterns)")
+	cmd.Flags().IntVar(&fillerServices, "filler-services", 1, "Number of filler services per namespace (adds to 50 total)")
+	cmd.Flags().IntVar(&networkPolicies, "network-policies", 5, "Number of network policies per namespace")
 
 	// Traffic pattern configuration
 	cmd.Flags().IntVar(&usersPerFrontend, "users-per-frontend", 100, "Number of concurrent user connections to frontend (Pattern 1 threads)")


### PR DESCRIPTION
  Add synthetic-app workload for OVN/OVS performance analysis

  This workload simulates realistic multi-tier customer applications to
  stress both OVN/OVS control plane and data plane simultaneously,
  enabling reproduction of customer-reported latency issues.

  Features:
  - Three independent uperf traffic patterns running concurrently:
    - Users → Frontend (many-to-one with think time)
    - Frontend → Microservices (fan-out to multiple services)
    - App → Database (OLTP-style request/response)
  - Configurable resource density per namespace:
    - 70 deployments (7 traffic + 63 fillers)
    - 50 services (5 traffic + 45 fillers)
    - 200 network policies (configurable)
  - Metrics collection via DaemonSet with node-local hostPort
  - Optional control plane churn during traffic generation
  - Per-pattern metrics reporting to correlate with OVN/OVS events

  Usage:
    kube-burner-ocp synthetic-app --iterations=5 --traffic-duration=10m

## Type of change

<!-- Choose a type of change -->

- Refactor
- New feature
- Bug fix
- Optimization
- Documentation
- CI

## Description

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #
- Closes #

