### PR TITLE
Use Always image pull policy in build-farm preload ds

### DIFF
--- a/cmd/config/build-farm/build-farm-ds-preload.yml
+++ b/cmd/config/build-farm/build-farm-ds-preload.yml
@@ -31,4 +31,4 @@ spec:
       - name: pause
         image: {{.preloadImage}}
         command: [sleep, inf]
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always


### PR DESCRIPTION
## Type of change

- Bug fix

## Description

The preload DaemonSets require worker nodes matching specific affinity rules. In case no such nodes exist, pods never schedule and the test times out waiting for readiness.


