### PR TITLE
Parametrize DPDK worker label in rds-core workload

### DIFF
--- a/cmd/config/rds-core/deployment-dpdk.yml
+++ b/cmd/config/rds-core/deployment-dpdk.yml
@@ -56,7 +56,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: node-role.kubernetes.io/worker-dpdk
+              - key: node-role.kubernetes.io/{{.worker_label}}
                 operator: Exists
       # Add not-ready/unreachable tolerations for 15 minutes so that node
       # failure doesn't trigger pod deletion.

--- a/cmd/config/rds-core/rds-core.yml
+++ b/cmd/config/rds-core/rds-core.yml
@@ -146,6 +146,7 @@ jobs:
           dpdk_cores: {{.DPDK_CORES}}
           dpdk_hugepages: {{.DPDK_HUGEPAGES}}
           perf_profile: {{.PERF_PROFILE}}
+          worker_label: {{.DPDK_WORKER_LABEL}}
 
 {{ if .PHASED }}
   # Post-churn idle for metrics collection

--- a/pkg/workloads/rds-core.go
+++ b/pkg/workloads/rds-core.go
@@ -30,7 +30,7 @@ func NewRDSCore(wh *workloads.WorkloadHelper) *cobra.Command {
 	var iterations, churnPercent, churnCycles, dpdkCores int
 	var svcLatency bool
 	var churnDelay, churnDuration, podReadyThreshold, idleDuration time.Duration
-	var deletionStrategy, perfProfile, dpdkHugepages, sriovDpdkDevicepool, sriovNetDevicepool, churnMode string
+	var deletionStrategy, perfProfile, dpdkHugepages, sriovDpdkDevicepool, sriovNetDevicepool, churnMode, workerLabel string
 	var metricsProfiles []string
 	var phased bool
 	var rc int
@@ -61,6 +61,7 @@ func NewRDSCore(wh *workloads.WorkloadHelper) *cobra.Command {
 			AdditionalVars["IDLE_DURATION"] = idleDuration
 			AdditionalVars["INGRESS_DOMAIN"] = ingressDomain
 			AdditionalVars["PHASED"] = phased
+			AdditionalVars["DPDK_WORKER_LABEL"] = workerLabel
 			rc = RunWorkload(cmd, wh, cmd.Name()+".yml")
 		},
 		PostRun: func(cmd *cobra.Command, args []string) {
@@ -77,6 +78,7 @@ func NewRDSCore(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().StringVar(&dpdkHugepages, "dpdk-hugepages", "16Gi", "Number of hugepages per DPDK pod. Must be a multiple of 1Gi")
 	cmd.Flags().StringVar(&sriovDpdkDevicepool, "dpdk-devicepool", "intelnics2", "SRIOV Device pool name for DPDK VFs in the cluster")
 	cmd.Flags().StringVar(&sriovNetDevicepool, "net-devicepool", "intelnics2", "SRIOV Device pool name for Kernel VFs in the cluster")
+	cmd.Flags().StringVar(&workerLabel, "worker-label", "worker-dpdk", "Node label value for DPDK worker node affinity")
 	cmd.Flags().IntVar(&iterations, "iterations", 0, "Number of iterations/namespaces")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
 	cmd.Flags().StringVar(&perfProfile, "perf-profile", "default", "Performance profile implemented in the cluster")


### PR DESCRIPTION
## Type of change

- Refactor

## Description

Small refactor in the `rds-core` workload to pass DPDK worker label with `--worker-label` argument, defaults to `worker-dpdk` (the current value).
