### PR TITLE
cudn-density: Add local namespace server curl to client pods

### DIFF
--- a/cmd/config/cudn-density/README.md
+++ b/cmd/config/cudn-density/README.md
@@ -133,11 +133,11 @@ CUDN-0 group (namespaces 0-4):
 
   Continuous traffic (every 10s):             Readiness probes (every 1s):
   ─────────────────────────                   ────────────────────────────
-  client in ns-0 → curls ns-1, ns-2, ns-3, ns-4    probes ns-1
-  client in ns-1 → curls ns-2, ns-3, ns-4          probes ns-2
-  client in ns-2 → curls ns-3, ns-4                probes ns-3
-  client in ns-3 → curls ns-4                      probes ns-4
-  client in ns-4 → sleeps (last in group)           probes ns-0 (wraps)
+  client in ns-0 → curls ns-0(local), ns-1, ns-2, ns-3, ns-4    probes ns-1
+  client in ns-1 → curls ns-1(local), ns-2, ns-3, ns-4          probes ns-2
+  client in ns-2 → curls ns-2(local), ns-3, ns-4                probes ns-3
+  client in ns-3 → curls ns-3(local), ns-4                      probes ns-4
+  client in ns-4 → curls ns-4(local)                             probes ns-0 (wraps)
 ```
 
 **Key design choices:**

--- a/cmd/config/cudn-density/README.md
+++ b/cmd/config/cudn-density/README.md
@@ -126,7 +126,7 @@ The workload deploys a 3-tier structure (client, app, server) but only the **cli
 
 ### Cross-Namespace Traffic Pattern
 
-Each client generates continuous HTTP traffic to peer namespaces within its CUDN group:
+Each client generates continuous HTTP traffic to namespaces within its CUDN group, including the client's namespace:
 
 ```
 CUDN-0 group (namespaces 0-4):

--- a/cmd/config/cudn-density/deployment-client.yml
+++ b/cmd/config/cudn-density/deployment-client.yml
@@ -48,6 +48,7 @@ spec:
           - "-c"
           - |
             while true; do
+              curl --fail -sS http://cudn-svc.cudn-density-{{ $.Iteration }}.svc.cluster.local:8080 -o /dev/null 2>/dev/null && echo "OK->ns-{{ $.Iteration }}(local)" || echo "FAIL->ns-{{ $.Iteration }}(local)";
               {{- range $offset := until (int $lastPosition) }}
                 {{- $peerOffset := add $offset 1 }}
                 {{- if lt (add $position $peerOffset) $.namespaces_per_cudn }}
@@ -58,7 +59,14 @@ spec:
               sleep 10
             done
         {{ else }}
-        command: ["sleep", "inf"]
+        command:
+          - "/bin/sh"
+          - "-c"
+          - |
+            while true; do
+              curl --fail -sS http://cudn-svc.cudn-density-{{ $.Iteration }}.svc.cluster.local:8080 -o /dev/null 2>/dev/null && echo "OK->ns-{{ $.Iteration }}(local)" || echo "FAIL->ns-{{ $.Iteration }}(local)";
+              sleep 10
+            done
         {{ end }}
         resources:
           requests:


### PR DESCRIPTION
Client pods now also curl the server in their own namespace in addition to peer namespaces within the CUDN group. The last-in-group client (previously sleep inf) now curls its local server every 10 seconds.
