### PR TITLE
Add BGP support for cudn-density

### DIFF
--- a/cmd/config/cudn-density/README.md
+++ b/cmd/config/cudn-density/README.md
@@ -337,6 +337,7 @@ kube-burner-ocp cudn-density \
 | `--incremental-pattern` | `linear` | Incremental load pattern: `linear` or `exponential` |
 | `--incremental-exp-base` | `2.0` | Base for exponential incremental pattern (must be > 1.0) |
 | `--gateway-check` | `false` | Enable [default gateway reachability check](#with-gateway-check) from each namespace (validates north-south connectivity under CUDN scale) |
+| `--bgp` | `false` | Enable for each CUDN. CUDN will be exported outside the cluster when BGP is enabled. When --gateway-check=true, cluster default gateway sees the POD IP Address instead of NODE IP Address in the traffic. User has to setup external FRR on the default gateway node before running the kube-burner |
 | `--metrics-profile` | `metrics.yml` | Comma-separated list of [metrics profiles](#metrics-profiles) to use |
 | `--gc` | `true` | Garbage collect created resources on completion. See [Cleanup](#cleanup) |
 

--- a/cmd/config/cudn-density/cudn-density.yml
+++ b/cmd/config/cudn-density/cudn-density.yml
@@ -127,6 +127,9 @@ jobs:
       {{ if .BGP }}
       - objectTemplate: ra.yml
         replicas: 1
+        group:
+          id: 0
+        repeatEveryNIterations: {{.NAMESPACES_PER_CUDN}}
       {{ end }}
 
       - objectTemplate: configmap.yml

--- a/cmd/config/cudn-density/cudn-density.yml
+++ b/cmd/config/cudn-density/cudn-density.yml
@@ -124,6 +124,10 @@ jobs:
             - key: .conditions[] | select(.type=="NetworkAllocationSucceeded") | .status
               value: "True"
       {{ end }}
+      {{ if .BGP }}
+      - objectTemplate: ra.yml
+        replicas: 1
+      {{ end }}
 
       - objectTemplate: configmap.yml
         replicas: 1
@@ -259,6 +263,11 @@ jobs:
     burst: {{.BURST}}
     skipIndexing: true
     objects:
+      {{ if .BGP }}
+      - kind: RouteAdvertisements
+        apiVersion: k8s.ovn.org/v1
+        labelSelector: {kube-burner.io/job: cudn-density}
+      {{ end }}
       - kind: ClusterUserDefinedNetwork
         apiVersion: k8s.ovn.org/v1
         labelSelector: {kube-burner.io/job: cudn-density}

--- a/cmd/config/cudn-density/cudn-density.yml
+++ b/cmd/config/cudn-density/cudn-density.yml
@@ -127,6 +127,7 @@ jobs:
       {{ if .BGP }}
       - objectTemplate: ra.yml
         replicas: 1
+        churn: false
         group:
           id: 0
         repeatEveryNIterations: {{.NAMESPACES_PER_CUDN}}

--- a/cmd/config/cudn-density/cudn-l2.yml
+++ b/cmd/config/cudn-density/cudn-l2.yml
@@ -1,3 +1,14 @@
+# CUDN CIDR allocation uses RFC1918 range 10.132.0.0 - 10.255.255.255, avoiding:
+#   - AWS VPC (10.0.0.0/16), OCP pod network (10.128.0.0/14)
+#   - OVN-K internals (100.64.0.0/16 join, 100.88.0.0/16 transit)
+#
+# Adjust CIDR prefix and perBlock to match your cluster size and CUDN count:
+#
+#   CIDR prefix | perBlock | Max nodes | Max CUDNs
+#   /16         | 1        | 1024      | 124
+#   /17         | 2        | 512       | 248
+#   /18         | 4        | 256       | 496
+#   /19         | 8        | 128       | 992
 apiVersion: k8s.ovn.org/v1
 kind: ClusterUserDefinedNetwork
 metadata:
@@ -18,9 +29,10 @@ spec:
     - key: kubernetes.io/metadata.name
       operator: In
       values: {{$nsNames}}
-  {{- $firstOctet := add (div $.Iteration 256) 40 }}
-  {{- $secondOctet := mod $.Iteration 256 }}
-  {{- $cudnCidr := print $firstOctet "." $secondOctet ".0.0/16" }}
+  {{- $perBlock := 8 }}
+  {{- $secondOctet := add 132 (div $.Iteration $perBlock) }}
+  {{- $thirdOctet := mul (mod $.Iteration $perBlock) 32 }}
+  {{- $cudnCidr := printf "10.%d.%d.0/19" $secondOctet $thirdOctet }}
   network:
     topology: Layer2
     layer2:

--- a/cmd/config/cudn-density/cudn-l2.yml
+++ b/cmd/config/cudn-density/cudn-l2.yml
@@ -18,8 +18,11 @@ spec:
     - key: kubernetes.io/metadata.name
       operator: In
       values: {{$nsNames}}
+  {{- $firstOctet := add (div $.Iteration 256) 40 }}
+  {{- $secondOctet := mod $.Iteration 256 }}
+  {{- $cudnCidr := print $firstOctet "." $secondOctet ".0.0/16" }}
   network:
     topology: Layer2
     layer2:
       role: Primary
-      subnets: ["10.132.0.0/16"]
+      subnets: [{{$cudnCidr}}]

--- a/cmd/config/cudn-density/cudn-l3.yml
+++ b/cmd/config/cudn-density/cudn-l3.yml
@@ -1,3 +1,14 @@
+# CUDN CIDR allocation uses RFC1918 range 10.132.0.0 - 10.255.255.255, avoiding:
+#   - AWS VPC (10.0.0.0/16), OCP pod network (10.128.0.0/14)
+#   - OVN-K internals (100.64.0.0/16 join, 100.88.0.0/16 transit)
+#
+# Adjust CIDR prefix, perBlock, and hostSubnet to match your cluster size and CUDN count:
+#
+#   CIDR prefix | perBlock | hostSubnet | Max nodes | Pods/node | Max CUDNs
+#   /16         | 1        | /26        | 1024      | 62        | 124
+#   /17         | 2        | /26        | 512       | 62        | 248
+#   /18         | 4        | /26        | 256       | 62        | 496
+#   /19         | 8        | /26        | 128       | 62        | 992
 apiVersion: k8s.ovn.org/v1
 kind: ClusterUserDefinedNetwork
 metadata:
@@ -18,13 +29,14 @@ spec:
     - key: kubernetes.io/metadata.name
       operator: In
       values: {{$nsNames}}
-  {{- $firstOctet := add (div $.Iteration 256) 40 }}
-  {{- $secondOctet := mod $.Iteration 256 }}
-  {{- $cudnCidr := print $firstOctet "." $secondOctet ".0.0/16" }}
+  {{- $perBlock := 8 }}
+  {{- $secondOctet := add 132 (div $.Iteration $perBlock) }}
+  {{- $thirdOctet := mul (mod $.Iteration $perBlock) 32 }}
+  {{- $cudnCidr := printf "10.%d.%d.0/19" $secondOctet $thirdOctet }}
   network:
     topology: Layer3
     layer3:
       role: Primary
       subnets:
         - cidr: {{$cudnCidr}}
-          hostSubnet: 24
+          hostSubnet: 26

--- a/cmd/config/cudn-density/ra.yml
+++ b/cmd/config/cudn-density/ra.yml
@@ -1,0 +1,15 @@
+apiVersion: k8s.ovn.org/v1
+kind: RouteAdvertisements
+metadata:
+  name: ra-{{.Iteration}}
+spec:
+  nodeSelector: {}
+  frrConfigurationSelector: {}
+  networkSelectors:
+    - networkSelectionType: ClusterUserDefinedNetworks
+      clusterUserDefinedNetworkSelector:
+        networkSelector:
+          matchLabels:
+            cudn-{{.Iteration}}: ""
+  advertisements:
+  - "PodNetwork"

--- a/pkg/workloads/cudn-density.go
+++ b/pkg/workloads/cudn-density.go
@@ -74,7 +74,7 @@ func getDefaultGatewayIP() string {
 func NewCudnDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 	var churnPercent, churnCycles, iterations, namespacesPerCudn, incrementalStepSize int
 	var incrementalExpBase float64
-	var l3, pprof, gatewayCheck bool
+	var l3, pprof, gatewayCheck, bgp bool
 	var churnDelay, churnDuration, podReadyThreshold, pprofInterval, jobPause, incrementalStepDelay time.Duration
 	var churnMode, incrementalPattern string
 	var metricsProfiles []string
@@ -146,6 +146,7 @@ func NewCudnDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 			AdditionalVars["INCREMENTAL_PATTERN"] = incrementalPattern
 			AdditionalVars["INCREMENTAL_EXP_BASE"] = incrementalExpBase
 			AdditionalVars["GATEWAY_CHECK"] = gatewayCheck
+			AdditionalVars["BGP"] = bgp
 			if gatewayCheck {
 				gatewayIP := getDefaultGatewayIP()
 				AdditionalVars["GATEWAY_IP"] = gatewayIP
@@ -158,6 +159,7 @@ func NewCudnDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&l3, "layer3", false, "Use Layer3 topology instead of Layer2")
+	cmd.Flags().BoolVar(&bgp, "bgp", false, "Enable BGP route advertisement for each CUDN (requires external FRR on the default gatewaynode)")
 	cmd.Flags().BoolVar(&pprof, "pprof", false, "Enable pprof collection for ovnkube components")
 	cmd.Flags().DurationVar(&pprofInterval, "pprof-interval", 0, "Interval between pprof collections")
 	cmd.Flags().DurationVar(&jobPause, "job-pause", 1*time.Minute, "Pause after CUDN creation to allow OVN-K network settling before workload deployment")


### PR DESCRIPTION
Enable BGP for each CUDN. CUDN will be exported outside the cluster when BGP is enabled.
User has to setup external FRR on the default gateway node before running the kube-burner

When --gateway-check=true, cluster default gateway sees the POD IP Address instead of NODE IP Address in the traffic.

We can't have overlapping CIDRs for CUDN with BGP till we use a dedicated VRF for each CUDN both on worker node and external node

