### PR TITLE
Adding UDN L2 RA to UDN-BGP workload

### DIFF
--- a/cmd/config/udn-bgp/cudn.yml
+++ b/cmd/config/udn-bgp/cudn.yml
@@ -22,9 +22,17 @@ spec:
   {{- $secondOctet := mod $.Iteration 255 }}
   {{- $cudnCidr := print $firstOctet "." $secondOctet ".0.0/16" }}
   network:
+{{- if $.layer2 }}
+    topology: Layer2
+    layer2:
+      role: Primary
+      subnets:
+        - {{$cudnCidr}}
+{{- else }}
     topology: Layer3
     layer3:
       role: Primary
       subnets:
         - cidr: {{$cudnCidr}}
           hostSubnet: 24
+{{- end }}

--- a/cmd/config/udn-bgp/ra.yml
+++ b/cmd/config/udn-bgp/ra.yml
@@ -13,4 +13,6 @@ spec:
             cudn-{{.Iteration}}: ""
   advertisements:
   - "PodNetwork"
+{{- if not $.layer2 }}
   - "EgressIP"
+{{- end }}

--- a/cmd/config/udn-bgp/udn-bgp.yml
+++ b/cmd/config/udn-bgp/udn-bgp.yml
@@ -66,6 +66,7 @@ jobs:
           namespaces_per_cudn: {{.NAMESPACES_PER_CUDN}}
           total_namespaces: {{.JOB_ITERATIONS}}
           enable_vm: {{.ENABLE_VM}}
+          layer2: {{.LAYER2}}
 
   - name: udn-bgp-create-pods
     namespace: udn-bgp
@@ -117,3 +118,4 @@ jobs:
           numAddressOnDummyIface: 20
           exportScenarioMaxTimeout: 10m
           importScenarioMaxTimeout: 10m
+          layer2: {{.LAYER2}}

--- a/pkg/workloads/udn-bgp.go
+++ b/pkg/workloads/udn-bgp.go
@@ -55,7 +55,7 @@ func validateFrrExternalIP(frrExternalIP string) error {
 // NewUdnBgp holds udn-bgp workload
 func NewUdnBgp(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 	var iterations, namespacePerCudn int
-	var enableVm bool
+	var enableVm, layer2 bool
 	var frrExternalIP string
 	var metricsProfiles []string
 	var rc int
@@ -73,6 +73,7 @@ func NewUdnBgp(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 			AdditionalVars["JOB_ITERATIONS"] = iterations
 			AdditionalVars["NAMESPACES_PER_CUDN"] = namespacePerCudn
 			AdditionalVars["ENABLE_VM"] = enableVm
+			AdditionalVars["LAYER2"] = layer2
 			wh.SetMeasurements(additionalMeasurementFactoryMap)
 			rc = RunWorkload(cmd, wh, cmd.Name()+".yml")
 		},
@@ -82,6 +83,7 @@ func NewUdnBgp(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 	}
 	cmd.Flags().IntVar(&iterations, "iterations", 10, fmt.Sprintf("%v iterations", variant))
 	cmd.Flags().BoolVar(&enableVm, "vm", false, "Deploy a VM for the test instead of a pod")
+	cmd.Flags().BoolVar(&layer2, "layer2", false, "Use Layer2 topology for CUDNs instead of Layer3")
 	cmd.Flags().IntVar(&namespacePerCudn, "namespaces-per-cudn", 1, "Number of namespaces sharing the same cluster udn")
 	cmd.Flags().StringVar(&frrExternalIP, "frr-external-ip", "", "IP address of the external FRR router (required)")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->

- New feature

## Description

The udn-bgp workload is already able to test layer 3 routes. With layer 3, the CUDN routes visible on the bastion host, where FRR is also deployed in this test, look like:

```
ip r
default via 10.6.60.254 dev eno3 proto dhcp src 10.6.60.98 metric 105 
10.6.60.0/24 dev eno3 proto kernel scope link src 10.6.60.98 metric 105 
20.0.2.0/24 dev dummy1 proto kernel scope link src 20.0.2.1 
40.0.0.0/24 nhid 137877 via 198.18.0.9 dev eno1 proto bgp metric 20 
40.0.1.0/24 nhid 137881 via 198.18.0.10 dev eno1 proto bgp metric 20 
40.0.2.0/24 nhid 137873 via 198.18.0.6 dev eno1 proto bgp metric 20 
40.0.3.0/24 nhid 137875 via 198.18.0.7 dev eno1 proto bgp metric 20 
40.0.4.0/24 nhid 137883 via 198.18.0.11 dev eno1 proto bgp metric 20 
40.0.5.0/24 nhid 137871 via 198.18.0.5 dev eno1 proto bgp metric 20 
40.0.6.0/24 nhid 137880 via 198.18.0.8 dev eno1 proto bgp metric 20
``` 

With layer 2, CUDN routes visible on the bastion are however:

```
bin/amd64/kube-burner-ocp udn-bgp --log-level=debug --gc=false --iterations=1 --namespaces-per-cudn=1 --frr-external-ip=198.18.0.1 --layer2

(...)

time="2026-06-19 14:12:53" level=info msg="Initializing measurements for job: udn-bgp-route-advertisements" file="factory.go:104"
time="2026-06-19 14:12:53" level=info msg="Registered measurement: raLatency" file="factory.go:139"
time="2026-06-19 14:12:53" level=info msg="Creating Router Advertisement latency watcher for udn-bgp-route-advertisements" file="routeadvertisement-latency_linux.go:639"
time="2026-06-19 14:12:53" level=info msg="Triggering job: udn-bgp-route-advertisements" file="job.go:138"
time="2026-06-19 14:12:53" level=debug msg="Creating object replicas from iteration 0" file="create.go:328"
time="2026-06-19 14:12:53" level=debug msg="Created RouteAdvertisements/ra-0" file="create.go:698"
time="2026-06-19 14:12:53" level=info msg="Waiting up to 4h0m0s for actions to be completed" file="create.go:608"
time="2026-06-19 14:12:53" level=info msg="Actions completed" file="waiters.go:82"
time="2026-06-19 14:12:53" level=info msg="Verifying created objects" file="utils.go:161"
time="2026-06-19 14:12:53" level=debug msg="routeadvertisements found: 1 Expected: 1" file="utils.go:219"
time="2026-06-19 14:12:53" level=info msg="Job udn-bgp-route-advertisements took 0s" file="job.go:233"
time="2026-06-19 14:12:53" level=info msg="Stopping measurement: raLatency" file="factory.go:168"
time="2026-06-19 14:12:53" level=debug msg="RA ra-0 discovered at: 2026-06-19 14:12:53.771248999 +0000 UTC created at: 2026-06-19 14:12:53 +0000 UTC" file="routeadvertisement-latency_linux.go:317"
time="2026-06-19 14:13:02" level=debug msg="Netlink route: 40.0.0.0/16 received for udn: cudn-0 at: 2026-06-19 14:13:02.520757312 +0000 UTC" file="routeadvertisement-latency_linux.go:493"
time="2026-06-19 14:13:02" level=debug msg="Ping success to pod 40.0.0.4 for the Netlink route: 40.0.0.0/16 received for udn: cudn-0 at: 2026-06-19 14:13:02.525164225 +0000 UTC" file="routeadvertisement-latency_linux.go:502"
time="2026-06-19 14:13:02" level=debug msg="Netlink route: 40.0.0.0/16 received for udn: cudn-0 at: 2026-06-19 14:13:02.621225804 +0000 UTC" file="routeadvertisement-latency_linux.go:493"
time="2026-06-19 14:13:02" level=debug msg="Ping success to pod 40.0.0.4 for the Netlink route: 40.0.0.0/16 received for udn: cudn-0 at: 2026-06-19 14:13:02.624777516 +0000 UTC" file="routeadvertisement-latency_linux.go:502"
time="2026-06-19 14:13:02" level=debug msg="Netlink route: 40.0.0.0/16 received for udn: cudn-0 at: 2026-06-19 14:13:02.721728223 +0000 UTC" file="routeadvertisement-latency_linux.go:493"
time="2026-06-19 14:13:02" level=debug msg="Ping success to pod 40.0.0.4 for the Netlink route: 40.0.0.0/16 received for udn: cudn-0 at: 2026-06-19 14:13:02.72445276 +0000 UTC" file="routeadvertisement-latency_linux.go:502"
time="2026-06-19 14:13:02" level=debug msg="Netlink route: 40.0.0.0/16 received for udn: cudn-0 at: 2026-06-19 14:13:02.822322576 +0000 UTC" file="routeadvertisement-latency_linux.go:493"
time="2026-06-19 14:13:02" level=debug msg="Ping success to pod 40.0.0.4 for the Netlink route: 40.0.0.0/16 received for udn: cudn-0 at: 2026-06-19 14:13:02.823918414 +0000 UTC" file="routeadvertisement-latency_linux.go:502"
time="2026-06-19 14:13:03" level=debug msg="Netlink route: 40.0.0.0/16 received for udn: cudn-0 at: 2026-06-19 14:13:03.022852973 +0000 UTC" file="routeadvertisement-latency_linux.go:493"
time="2026-06-19 14:13:03" level=debug msg="Ping success to pod 40.0.0.4 for the Netlink route: 40.0.0.0/16 received for udn: cudn-0 at: 2026-06-19 14:13:03.025564204 +0000 UTC" file="routeadvertisement-latency_linux.go:502"
time="2026-06-19 14:13:03" level=debug msg="Netlink route: 40.0.0.0/16 received for udn: cudn-0 at: 2026-06-19 14:13:03.117028339 +0000 UTC" file="routeadvertisement-latency_linux.go:493"
time="2026-06-19 14:13:03" level=debug msg="Ping success to pod 40.0.0.4 for the Netlink route: 40.0.0.0/16 received for udn: cudn-0 at: 2026-06-19 14:13:03.118480163 +0000 UTC" file="routeadvertisement-latency_linux.go:502"

```
```
ip r
default via 10.6.60.254 dev eno3 proto dhcp src 10.6.60.98 metric 105
10.6.60.0/24 dev eno3 proto kernel scope link src 10.6.60.98 metric 105
20.0.2.0/24 dev dummy1 proto kernel scope link src 20.0.2.1
40.0.0.0/16 nhid 138563 proto bgp metric 20
	nexthop via 198.18.0.5 dev eno1 weight 1
	nexthop via 198.18.0.6 dev eno1 weight 1
	nexthop via 198.18.0.7 dev eno1 weight 1
	nexthop via 198.18.0.9 dev eno1 weight 1
	nexthop via 198.18.0.8 dev eno1 weight 1
	nexthop via 198.18.0.10 dev eno1 weight 1
	nexthop via 198.18.0.11 dev eno1 weight 1
198.18.0.0/16 dev eno1 proto kernel scope link src 198.18.0.1 metric 104
```

This adds the ability to the same udn-bgp workload to also test layer 2 route import and export. 

## Related Tickets & Documents

PERFSCALE-4930
