### PR TITLE
Cancel in progress

### DIFF
--- a/.github/workflows/test-ocp.yml
+++ b/.github/workflows/test-ocp.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   ocp-e2e-ci:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
     concurrency:
       group: ocp-e2e-ci
       cancel-in-progress: false

--- a/.github/workflows/test-ocp.yml
+++ b/.github/workflows/test-ocp.yml
@@ -14,7 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     concurrency:
       group: ocp-e2e-ci
+      cancel-in-progress: false
     steps:
+
+    - name: Cancel previous runs from same PR
+      if: github.event.pull_request.number
+      uses: styfle/cancel-workflow-action@0.12.1
+      with:
+        workflow_id: ci-tests.yml
+        access_token: ${{ github.token }}
+        all_but_latest: true
 
     - name: Check out code
       uses: actions/checkout@v4


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to improve CI run management for pull requests. The main change is the addition of a step to automatically cancel previous workflow runs from the same pull request, ensuring that only the latest run is active and reducing unnecessary resource usage.

**Workflow management improvements:**

* Added a step using `styfle/cancel-workflow-action@0.12.1` to automatically cancel previous runs of the `ci-tests.yml` workflow for the same pull request, keeping only the latest run active.
* Set `cancel-in-progress: false` in the `concurrency` group to allow multiple runs to proceed unless explicitly cancelled by the new step.