### PR TITLE
Fix MicroShift process metrics: capture missing system components

### DIFF
--- a/cmd/config/metrics-profiles/microshift-metrics.yml
+++ b/cmd/config/metrics-profiles/microshift-metrics.yml
@@ -88,11 +88,11 @@
   metricName: nodeDiskReadBytes
 
 # MicroShift system components from named-process-exporter.
-- query: sum(irate(namedprocess_namegroup_cpu_seconds_total{job="process",groupname=~"ovs-vswitchd|ovsdb-server|microshift|microshift-etcd|crio|ovnkube|coredns|haproxy|lvms|openshift-route"}[2m]) * 100) by (groupname,instance) > 0
+- query: sum(irate(namedprocess_namegroup_cpu_seconds_total{job="process",groupname=~"ovs-vswitchd|ovsdb-server|microshift|microshift-etcd|crio|ovnkube|coredns|haproxy|lvms|openshift-route|service-ca-oper|snapshot-contro|ovn-controller|conmon|kube-rbac-proxy|ovn-northd|ovn-k8s-cni-ove"}[2m]) * 100) by (groupname,instance) > 0
   metricName: namedprocessCPU
 
-- query: sum(namedprocess_namegroup_memory_bytes{job="process",memtype="resident",groupname=~"ovs-vswitchd|ovsdb-server|microshift|microshift-etcd|crio|ovnkube|coredns|haproxy|lvms|openshift-route"}) by (groupname,instance) > 0
+- query: sum(namedprocess_namegroup_memory_bytes{job="process",memtype="resident",groupname=~"ovs-vswitchd|ovsdb-server|microshift|microshift-etcd|crio|ovnkube|coredns|haproxy|lvms|openshift-route|service-ca-oper|snapshot-contro|ovn-controller|conmon|kube-rbac-proxy|ovn-northd|ovn-k8s-cni-ove"}) by (groupname,instance) > 0
   metricName: namedprocessMemoryRSS
 
-- query: sum(namedprocess_namegroup_num_threads{job="process",groupname=~"ovs-vswitchd|ovsdb-server|microshift|microshift-etcd|crio|ovnkube|coredns|haproxy|lvms|openshift-route"}) by (groupname,instance) > 0
+- query: sum(namedprocess_namegroup_num_threads{job="process",groupname=~"ovs-vswitchd|ovsdb-server|microshift|microshift-etcd|crio|ovnkube|coredns|haproxy|lvms|openshift-route|service-ca-oper|snapshot-contro|ovn-controller|conmon|kube-rbac-proxy|ovn-northd|ovn-k8s-cni-ove"}) by (groupname,instance) > 0
   metricName: namedprocessThreads


### PR DESCRIPTION
## What

The `named-process-exporter` queries in the MicroShift metrics profile
(`namedprocessCPU`, `namedprocessMemoryRSS`, `namedprocessThreads`) only
matched a subset of MicroShift's system processes, so several components
were silently missing from the collected metrics.

This adds the remaining components to the `groupname` regex. Names are
truncated to process-exporter's 15-character `comm` value, matching the
existing entries:

| Process | `groupname` (comm) |
| --- | --- |
| service-ca-operator | `service-ca-oper` |
| snapshot-controller | `snapshot-contro` |
| ovn-controller | `ovn-controller` |
| conmon | `conmon` |
| kube-rbac-proxy | `kube-rbac-proxy` |
| ovn-northd | `ovn-northd` |
| ovn-k8s-cni-overlay | `ovn-k8s-cni-ove` |

## Why

Without these entries, CPU, memory (RSS) and thread usage for these
MicroShift / OVN-Kubernetes processes were not captured, leaving gaps in
the MicroShift resource-usage metrics.

## Related Tickets & Documents

- Related Issue: USHIFT-7333

