### PR TITLE
Split cudn-density infra and pod deployment into separate execution groups

### DIFF
--- a/cmd/config/cudn-density/cudn-density.yml
+++ b/cmd/config/cudn-density/cudn-density.yml
@@ -130,6 +130,7 @@ jobs:
         churn: false
         group:
           id: 2
+          pauseBeforeGC: {{.JOB_PAUSE}}
 
       - objectTemplate: service.yml
         replicas: 1
@@ -210,21 +211,21 @@ jobs:
       - objectTemplate: deployment-server.yml
         replicas: 1
         group:
-          id: 2
+          id: 3
         inputVars:
           podReplicas: 2
 
       - objectTemplate: deployment-app.yml
         replicas: 1
         group:
-          id: 2
+          id: 3
         inputVars:
           podReplicas: 1
 
       - objectTemplate: deployment-client.yml
         replicas: 1
         group:
-          id: 2
+          id: 3
         inputVars:
           podReplicas: 1
           namespaces_per_cudn: {{.NAMESPACES_PER_CUDN}}

--- a/pkg/workloads/cudn-density.go
+++ b/pkg/workloads/cudn-density.go
@@ -160,7 +160,7 @@ func NewCudnDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().BoolVar(&l3, "layer3", false, "Use Layer3 topology instead of Layer2")
 	cmd.Flags().BoolVar(&pprof, "pprof", false, "Enable pprof collection for ovnkube components")
 	cmd.Flags().DurationVar(&pprofInterval, "pprof-interval", 0, "Interval between pprof collections")
-	cmd.Flags().DurationVar(&jobPause, "job-pause", 1*time.Minute, "Pause after CUDN creation to allow OVN-K network settling before workload deployment")
+	cmd.Flags().DurationVar(&jobPause, "job-pause", 1*time.Minute, "Pause between execution groups (after CUDN creation and after infra objects) to allow OVN-K settling before the next phase")
 	cmd.Flags().IntVar(&churnCycles, "churn-cycles", 0, "Churn cycles to execute")
 	cmd.Flags().DurationVar(&churnDuration, "churn-duration", 0, "Churn duration")
 	cmd.Flags().DurationVar(&churnDelay, "churn-delay", 2*time.Minute, "Time to wait between each churn")


### PR DESCRIPTION
Moves deployments from group 2 to group 3 so infra objects (services, network policies, egressfirewall, quotas) are fully created and settled before pods start binding ports. The existing --job-pause flag now applies to both group transitions.

This can be important at large scales, especially if OVN doesn't incrementally process objects created during infra phase. 