### PR TITLE
Reduce datapoints from podStatusCount metric

### DIFF
--- a/cmd/config/metrics-profiles/kueue-metrics.yml
+++ b/cmd/config/metrics-profiles/kueue-metrics.yml
@@ -3,7 +3,7 @@
 - query: count(kube_job_info{namespace=~"kueue-scale-.+"})
   metricName: totalJobs
 
-- query: sum(kube_pod_status_phase{namespace=~"kueue-scale-.+"}) by (phase)
+- query: sum(kube_pod_status_phase{namespace=~"kueue-scale-.+"}) by (phase) > 0
   metricName: podStatusCount
 
 # Pod CPU & memory

--- a/cmd/config/metrics-profiles/metrics-aggregated.yml
+++ b/cmd/config/metrics-profiles/metrics-aggregated.yml
@@ -85,7 +85,7 @@
 - query: sum(kube_namespace_status_phase) by (phase) > 0
   metricName: namespaceCount
 
-- query: sum(kube_pod_status_phase{}) by (phase)
+- query: sum(kube_pod_status_phase{}) by (phase) > 0
   metricName: podStatusCount
 
 - query: count(kube_secret_info{})

--- a/cmd/config/metrics-profiles/metrics-egressip.yml
+++ b/cmd/config/metrics-profiles/metrics-egressip.yml
@@ -100,7 +100,7 @@
 - query: sum(kube_namespace_status_phase) by (phase) > 0
   metricName: namespaceCount
 
-- query: sum(kube_pod_status_phase{}) by (phase)
+- query: sum(kube_pod_status_phase{}) by (phase) > 0
   metricName: podStatusCount
 
 - query: count(kube_secret_info{})

--- a/cmd/config/metrics-profiles/metrics.yml
+++ b/cmd/config/metrics-profiles/metrics.yml
@@ -112,7 +112,7 @@
 - query: sum(kube_namespace_status_phase) by (phase) > 0
   metricName: namespaceCount
 
-- query: sum(kube_pod_status_phase{}) by (phase)
+- query: sum(kube_pod_status_phase{}) by (phase) > 0
   metricName: podStatusCount
 
 - query: count(kube_secret_info{})


### PR DESCRIPTION
## Type of change

- Optimization

## Description

When pods are not in a phase the metric has value 0, skipping those datapoints can help to reduce the number of documents generated significantly 

## Related Tickets & Documents

- Related Issue #
- Closes #

