### PR TITLE
ROX-34347: Add berserker workload

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Usage:
 
 Available Commands:
   anp-density-pods           Runs anp-density-pods workload
+  berserker-load             Runs berserker-load workload
   build-farm                 Runs build-farm workload
   cluster-density-ms         Runs cluster-density-ms workload
   cluster-density-v2         Runs cluster-density-v2 workload
@@ -1571,6 +1572,40 @@ This workload creates jobs in multiple namespaces that are handled by 10 shared 
 
 This workload creates pods in a single namespace that are handled by a single ClusterQueue with pre-defined CPU, memory and pod quotas. Key measurements are Kueue admission wait time and pod ready latency.
 
+
+## Berserker-load workload
+
+The berserker-load workload deploys DaemonSets whose pods are evenly distributed across cluster nodes. Each pod runs multiple containers that produce four types of load: process spawning, file activity, listening network endpoints, and network connections. This makes it useful for stress-testing monitoring and security tooling that observe pod and cluster behavior.
+
+### Architecture
+
+The workload creates namespaced iterations, each containing:
+
+1. **ConfigMaps**: Configuration files that define the berserker workload parameters (endpoint distribution, network connection rates, process/file activity rates). The ConfigMap template is customizable via the `BERSERKER_CONFIGMAP_TEMPLATE` environment variable.
+
+2. **DaemonSets**: Deployed across cluster nodes, each running containers that generate:
+   - **Process and file activity**: Spawns processes and performs file operations at configurable rates
+   - **Endpoint load**: Creates listening network endpoints with a configurable port distribution
+   - **Connection load**: Generates network connections with configurable arrival/departure rates and connection counts
+
+   The container definitions are customizable via the `BERSERKER_CONTAINERS_FILE` environment variable.
+
+3. **Services**: ClusterIP services exposing HTTP (80) and HTTPS (443) ports, backed by the DaemonSet pods. The Service template is customizable via the `BERSERKER_SERVICE_TEMPLATE` environment variable.
+
+### Configuration Flags
+
+- `--job-iterations`: Number of job iterations to create (default: 5)
+- `--job-pause`: Duration to pause after creating resources (default: 0)
+- `--max-wait-timeout`: Maximum time to wait for created objects to be ready (default: 12m)
+- `--pod-ready-threshold`: Pod ready timeout threshold (default: 5m)
+- `--deletion-strategy`: GC deletion mode (default: gvr)
+- `--daemonset-replicas`: Number of berserker DaemonSets to create per namespace (default: 6)
+- `--service-replicas`: Number of services per namespace (default: 6)
+- `--churn-cycles`: Number of churn cycles, 0 = infinite when churn-duration > 0 (default: 0)
+- `--churn-duration`: Churn duration, 0 disables churn (default: 0)
+- `--churn-delay`: Time to wait between each churn (default: 10m)
+- `--churn-percent`: Percentage of job iterations to churn each round (default: 80)
+- `--churn-mode`: Churn mode: namespaces or objects (default: namespaces)
 
 ## Build-Farm workload
 

--- a/cmd/config/berserker-load/berserker-configmap.yml
+++ b/cmd/config/berserker-load/berserker-configmap.yml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{.JobName}}-berserker-config
+data:
+  endpoints.toml: |
+    restart_interval = 10
+    workers = 9
+
+    [workload]
+    type = "endpoints"
+    distribution = "zipf"
+    n_ports = 2000
+    exponent = 1.4
+  network-server.toml: |
+    restart_interval = 10
+    workers = 1
+    per_core = false
+
+    [workload]
+    type = "network"
+    server = true
+    address = "223.42.0.1"
+    target_port = 1337
+    arrival_rate = 10
+    departure_rate = 10
+    connections_static = 100
+    connections_dyn_max = 4000
+    conns_per_addr = 2
+    preempt = false
+  network-client.toml: |
+    restart_interval = 10
+    workers = 1
+    per_core = false
+
+    [workload]
+    type = "network"
+    server = false
+    address = "223.42.0.1"
+    target_port = 1337
+    arrival_rate = 10
+    departure_rate = 10
+    connections_static = 100
+    connections_dyn_max = 4000
+    conns_per_addr = 2
+    preempt = true
+  process-and-file-activity.ber: |
+    machine {
+      path("/tmp/data");
+    }
+
+    processes (workers = 1, duration = 0) {
+      task(stub);
+    } : exp {
+      rate = 1.0;
+    }
+
+    file_activity (workers = 2, duration = 0) {
+      open(random_path("/tmp/data"));
+    } : exp {
+      rate = 100.0;
+    }

--- a/cmd/config/berserker-load/berserker-daemonset.yml
+++ b/cmd/config/berserker-load/berserker-daemonset.yml
@@ -1,0 +1,36 @@
+{{- $ip1 := randInt 1 223 -}}
+{{- $ip2 := randInt 1 254 -}}
+{{- $ip3 := randInt 1 254 -}}
+{{- $ip4 := randInt 1 254 -}}
+{{- $ip := printf "%d.%d.%d.%d/16" $ip1 $ip2 $ip3 $ip4 -}}
+{{- $berserkerAddress := printf "%d.%d.%d.%d" $ip1 $ip2 $ip3 $ip4 }}
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: berserker-{{.Replica}}
+spec:
+  selector:
+    matchLabels:
+      app: berserker-{{.Replica}}
+  template:
+    metadata:
+      labels:
+        app: berserker-{{.Replica}}
+    spec:
+      serviceAccountName: berserker
+      terminationGracePeriodSeconds: 0
+      containers:
+{{ ReadFile ((env "BERSERKER_CONTAINERS_FILE") | default "berserker-default-containers.yml") | replace "__IP_BASE__" $ip | replace "__BERSERKER_ADDRESS__" $berserkerAddress | indent 6 }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{.JobName}}-berserker-config
+      tolerations:
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900

--- a/cmd/config/berserker-load/berserker-default-containers.yml
+++ b/cmd/config/berserker-load/berserker-default-containers.yml
@@ -1,0 +1,74 @@
+- name: process-and-file-activity
+  image: "quay.io/stackrox-io/berserker:1.0-92-gec43ada756"
+  command:
+  - berserker
+  args:
+  - -f
+  - /etc/berserker/process-and-file-activity.ber
+  resources:
+    requests:
+      memory: "200Mi"
+      cpu: "30m"
+    limits:
+      memory: "200Mi"
+      cpu: "30m"
+  volumeMounts:
+  - name: config
+    mountPath: "/etc/berserker/process-and-file-activity.ber"
+    subPath: process-and-file-activity.ber
+    readOnly: true
+  imagePullPolicy: IfNotPresent
+  env:
+  - name: RUST_LOG
+    value: "error"
+- name: endpoint-load
+  image: "quay.io/stackrox-io/berserker:1.0-92-gec43ada756"
+  resources:
+    requests:
+      memory: "100Mi"
+      cpu: "25m"
+    limits:
+      memory: "180Mi"
+      cpu: "25m"
+  volumeMounts:
+  - name: config
+    mountPath: "/etc/berserker/workload.toml"
+    subPath: endpoints.toml
+    readOnly: true
+  imagePullPolicy: IfNotPresent
+  ports:
+  - containerPort: 8080
+    protocol: TCP
+  - containerPort: 8443
+    protocol: TCP
+  env:
+  - name: RUST_LOG
+    value: "error"
+- name: connection-load
+  image: "quay.io/stackrox-io/berserker:network-1.0-92-gec43ada756"
+  resources:
+    requests:
+      memory: "100Mi"
+      cpu: "25m"
+    limits:
+      memory: "180Mi"
+      cpu: "25m"
+  volumeMounts:
+  - name: config
+    mountPath: "/etc/berserker/network-server.toml"
+    subPath: network-server.toml
+    readOnly: true
+  - name: config
+    mountPath: "/etc/berserker/network-client.toml"
+    subPath: network-client.toml
+    readOnly: true
+  imagePullPolicy: IfNotPresent
+  env:
+  - name: RUST_LOG
+    value: "error"
+  - name: IP_BASE
+    value: "__IP_BASE__"
+  - name: BERSERKER__WORKLOAD__ADDRESS
+    value: "__BERSERKER_ADDRESS__"
+  securityContext:
+    privileged: true

--- a/cmd/config/berserker-load/berserker-load.yml
+++ b/cmd/config/berserker-load/berserker-load.yml
@@ -1,0 +1,72 @@
+---
+global:
+  gc: {{.GC}}
+  gcMetrics: {{.GC_METRICS}}
+  deletionStrategy: {{.DELETION_STRATEGY}}
+  measurements:
+    - name: podLatency
+{{ if ne .POD_READY_THRESHOLD 0 }}
+      thresholds:
+        - conditionType: Ready
+          metric: P99
+          threshold: {{.POD_READY_THRESHOLD}}
+{{ end }}
+metricsEndpoints:
+{{ if .ES_SERVER }}
+  - metrics: [{{.METRICS}}]
+    alerts: [{{.ALERTS}}]
+    indexer:
+      esServers: ["{{.ES_SERVER}}"]
+      insecureSkipVerify: true
+      defaultIndex: {{.ES_INDEX}}
+      type: opensearch
+{{ end }}
+{{ if .LOCAL_INDEXING }}
+  - metrics: [{{.METRICS}}]
+    alerts: [{{.ALERTS}}]
+    indexer:
+      type: local
+      metricsDirectory: collected-metrics-{{.UUID}}
+{{ end }}
+jobs:
+  - name: berserker-load
+    namespace: berserker
+    jobIterations: {{.JOB_ITERATIONS}}
+    jobPause: {{.JOB_PAUSE}}
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    namespacedIterations: true
+    podWait: true
+    waitWhenFinished: false
+    preLoadImages: true
+    preLoadPeriod: 30s
+    churnConfig:
+      cycles: {{.CHURN_CYCLES}}
+      duration: {{.CHURN_DURATION}}
+      delay: {{.CHURN_DELAY}}
+      percent: {{.CHURN_PERCENT}}
+      mode: {{.CHURN_MODE}}
+    maxWaitTimeout: {{.MAX_WAIT_TIMEOUT}}
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+    objects:
+
+      - objectTemplate: berserker-sa.yml
+        replicas: 1
+        runOnce: true
+
+      - objectTemplate: berserker-scc-rolebinding.yml
+        replicas: 1
+        runOnce: true
+
+      - objectTemplate: {{ (env "BERSERKER_CONFIGMAP_TEMPLATE") | default "berserker-configmap.yml" }}
+        replicas: 1
+
+      - objectTemplate: berserker-daemonset.yml
+        replicas: {{.DAEMONSET_REPLICAS}}
+
+      - objectTemplate: {{ (env "BERSERKER_SERVICE_TEMPLATE") | default "service.yml" }}
+        replicas: {{.SERVICE_REPLICAS}}

--- a/cmd/config/berserker-load/berserker-sa.yml
+++ b/cmd/config/berserker-load/berserker-sa.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: berserker

--- a/cmd/config/berserker-load/berserker-scc-rolebinding.yml
+++ b/cmd/config/berserker-load/berserker-scc-rolebinding.yml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: berserker-privileged-scc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: berserker

--- a/cmd/config/berserker-load/service.yml
+++ b/cmd/config/berserker-load/service.yml
@@ -1,0 +1,18 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: berserker-{{.Replica}}
+spec:
+  selector:
+    app: berserker-{{.Replica}}
+  ports:
+  - name: http
+    protocol: TCP
+    port: 80
+    targetPort: 8080
+  - name: https
+    protocol: TCP
+    port: 443
+    targetPort: 8443
+  type: ClusterIP

--- a/cmd/ocp.go
+++ b/cmd/ocp.go
@@ -191,6 +191,7 @@ func openShiftCmd() *cobra.Command {
 		ocpWorkloads.NewANPDensityPods(&wh, "anp-density-pods"),
 		ocpWorkloads.NewBuildFarm(&wh),
 		ocpWorkloads.NewEtcdDensity(&wh),
+		ocpWorkloads.NewBerserkerLoad(&wh),
 	)
 	util.SetupCmd(ocpCmd)
 	return ocpCmd

--- a/pkg/workloads/berserker-load.go
+++ b/pkg/workloads/berserker-load.go
@@ -1,0 +1,83 @@
+// Copyright 2026 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workloads
+
+import (
+	"os"
+	"time"
+
+	"github.com/kube-burner/kube-burner/v2/pkg/config"
+	"github.com/kube-burner/kube-burner/v2/pkg/workloads"
+	"github.com/spf13/cobra"
+)
+
+// NewBerserkerLoad holds berserker-load workload
+func NewBerserkerLoad(wh *workloads.WorkloadHelper) *cobra.Command {
+	var rc int
+	var metricsProfiles []string
+	var jobIterations int
+	var daemonsetReplicas int
+	var serviceReplicas int
+	var churnCycles, churnPercent int
+	var churnDuration, churnDelay, jobPause, maxWaitTimeout, podReadyThreshold time.Duration
+	var deletionStrategy, churnMode string
+
+	cmd := &cobra.Command{
+		Use:          "berserker-load",
+		Short:        "Runs berserker-load workload",
+		SilenceUsage: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			AdditionalVars["JOB_ITERATIONS"] = jobIterations
+			AdditionalVars["JOB_PAUSE"] = jobPause
+			AdditionalVars["CHURN_CYCLES"] = churnCycles
+			AdditionalVars["CHURN_DURATION"] = churnDuration
+			AdditionalVars["CHURN_DELAY"] = churnDelay
+			AdditionalVars["CHURN_PERCENT"] = churnPercent
+			AdditionalVars["CHURN_MODE"] = churnMode
+			AdditionalVars["DELETION_STRATEGY"] = deletionStrategy
+			AdditionalVars["MAX_WAIT_TIMEOUT"] = maxWaitTimeout
+			AdditionalVars["POD_READY_THRESHOLD"] = podReadyThreshold
+
+			AdditionalVars["DAEMONSET_REPLICAS"] = daemonsetReplicas
+			AdditionalVars["SERVICE_REPLICAS"] = serviceReplicas
+
+			setMetrics(cmd, metricsProfiles)
+			rc = RunWorkload(cmd, wh, cmd.Name()+".yml")
+		},
+		PostRun: func(cmd *cobra.Command, args []string) {
+			os.Exit(rc)
+		},
+	}
+
+	cmd.Flags().IntVar(&jobIterations, "job-iterations", 5, "Number of job iterations to create")
+	cmd.Flags().DurationVar(&jobPause, "job-pause", 0, "Duration to pause after creating resources")
+	cmd.Flags().DurationVar(&maxWaitTimeout, "max-wait-timeout", 12*time.Minute, "Maximum time to wait for created objects to be ready")
+	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 5*time.Minute, "Pod ready timeout threshold")
+	cmd.Flags().StringVar(&deletionStrategy, "deletion-strategy", config.GVRDeletionStrategy, "GC deletion mode")
+
+	cmd.Flags().IntVar(&churnCycles, "churn-cycles", 0, "Number of churn cycles (0 = infinite when churn-duration > 0)")
+	cmd.Flags().DurationVar(&churnDuration, "churn-duration", 0, "Churn duration (0 disables churn)")
+	cmd.Flags().DurationVar(&churnDelay, "churn-delay", 10*time.Minute, "Time to wait between each churn")
+	cmd.Flags().IntVar(&churnPercent, "churn-percent", 80, "Percentage of job iterations to churn each round")
+	cmd.Flags().StringVar(&churnMode, "churn-mode", string(config.ChurnNamespaces), "Churn mode: namespaces or objects")
+
+	cmd.Flags().IntVar(&daemonsetReplicas, "daemonset-replicas", 6, "Number of berserker DaemonSets to create")
+	cmd.Flags().IntVar(&serviceReplicas, "service-replicas", 6, "Number of services")
+
+	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"},
+		"Comma separated list of metrics profiles to use")
+
+	return cmd
+}


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->

- New feature

## Description

<!--- Describe your changes in detail -->

Berserker is a tool created by the RHACS team to generate load for the purposes of performance and scale testing. It is capable of generating process, network listening endpoint, network connection, and file activity load. It has been used by RHACS in long running cluster tests. In those tests kube-burner creates berserker daemonsets. In this PR berserker is introduced as a built in load to kube-burner-ocp.

## Testing

The kube-burner binary built here has also been used to create load with berserker.

Berserker is used for the long running cluster. There is a PR at https://github.com/stackrox/actions/pull/95 to make the long running cluster use the configuration files in this PR. Long running clusters have been successfully created using the stackrox/actions PR.

There is another PR at https://github.com/openshift/release/pull/77737, which uses the built in berserker load, for a performance and scale test in OpenshiftCI. That PR is still in draft form and needs to be cleaned up, but it is able to test if the the changes here are working properly. It has confirmed that the built in berserker load can be used in the performance and scale tests. https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/77737/rehearse-77737-pull-ci-stackrox-stackrox-master-perf-scale-berserker-scale-test/2082185120797691904

## Related Tickets & Documents

- Related Issue #
- Closes #

