### PR TITLE
Datasource now is a template var

### DIFF
--- a/dashboards/virt-dashboards/Virt-capacity-benchmark.json
+++ b/dashboards/virt-dashboards/Virt-capacity-benchmark.json
@@ -1,14 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_ELASTICSEARCH",
-      "label": "elasticsearch",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "elasticsearch",
-      "pluginName": "Elasticsearch"
-    }
-  ],
   "__elements": {},
   "__requires": [
     {
@@ -90,7 +80,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "# **🚀 kube-burner-ocp virt capacity benchmark dashboard**\n\nThis dashboard provides deep insights into the results of the virt-capacity-benchmark execution using kube-burner-ocp. For a deep dive into workload parameters and metric definitions, refer to the [official kube-burner-ocp documentation](https://kube-burner.github.io/kube-burner-ocp/latest/#virt-capacity-benchmark).\n\n### ⚙️ How to configure your view\n\nUse the dropdown selectors at the top of the dashboard to filter the results:\n\n- **Run UUID 🔽:** Select the unique identifier for your benchmark execution to filter all visualizations for that specific test run.\n- **Latency Percentile 📊:** Toggle between median (50th) for typical performance or tail latencies (90th/95th/99th) to identify worst-case bottlenecks in your infrastructure.\n\n📌 **NOTE:**\n- All latency metrics in this dashboard are reported in seconds.\n- Since the OS image is provisioned through persistent storage instead of being pulled directly into the `virt-launcher` pod’s local directory, this scenario results in the creation and binding of DataVolumes and PVCs.",
+        "content": "# **\ud83d\ude80 kube-burner-ocp virt capacity benchmark dashboard**\n\nThis dashboard provides deep insights into the results of the virt-capacity-benchmark execution using kube-burner-ocp. For a deep dive into workload parameters and metric definitions, refer to the [official kube-burner-ocp documentation](https://kube-burner.github.io/kube-burner-ocp/latest/#virt-capacity-benchmark).\n\n### \u2699\ufe0f How to configure your view\n\nUse the dropdown selectors at the top of the dashboard to filter the results:\n\n- **Run UUID \ud83d\udd3d:** Select the unique identifier for your benchmark execution to filter all visualizations for that specific test run.\n- **Latency Percentile \ud83d\udcca:** Toggle between median (50th) for typical performance or tail latencies (90th/95th/99th) to identify worst-case bottlenecks in your infrastructure.\n\n\ud83d\udccc **NOTE:**\n- All latency metrics in this dashboard are reported in seconds.\n- Since the OS image is provisioned through persistent storage instead of being pulled directly into the `virt-launcher` pod\u2019s local directory, this scenario results in the creation and binding of DataVolumes and PVCs.",
         "mode": "markdown"
       },
       "pluginVersion": "12.1.0",
@@ -6290,6 +6280,20 @@
   "tags": [],
   "templating": {
     "list": [
+      {
+        "current": {},
+        "description": "Elasticsearch datasource used by all panels",
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_ELASTICSEARCH",
+        "options": [],
+        "query": "elasticsearch",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
       {
         "allowCustomValue": false,
         "current": {},

--- a/dashboards/virt-dashboards/Virt-clone-multi.json
+++ b/dashboards/virt-dashboards/Virt-clone-multi.json
@@ -1,14 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_ELASTICSEARCH",
-      "label": "elasticsearch",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "elasticsearch",
-      "pluginName": "Elasticsearch"
-    }
-  ],
   "__elements": {},
   "__requires": [
     {
@@ -90,7 +80,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "# **🚀 kube-burner-ocp virt clone multi benchmark dashboard**\n\nThis dashboard provides deep insights into the results of the virt-clone-multi benchmark execution using kube-burner-ocp. For a deep dive into workload parameters and metric definitions, refer to the [official kube-burner-ocp documentation](https://kube-burner.github.io/kube-burner-ocp/latest/#virt-clone-multi).\n\n### ⚙️ How to configure your view\n\nUse the dropdown selectors at the top of the dashboard to filter the results:\n\n- **Run UUID 🔽:** Select the unique identifier for your benchmark execution to filter all visualizations for that specific test run.\n- **Latency Percentile 📊:** Toggle between median (50th) for typical performance or tail latencies (90th/95th/99th) to identify worst-case bottlenecks in your infrastructure.\n\n📌 **NOTE:**\n- All latency metrics in this dashboard are reported in seconds.\n- Since the OS image is provisioned through persistent storage instead of being pulled directly into the `virt-launcher` pod’s local directory, this scenario results in the creation and binding of DataVolumes and PVCs.",
+        "content": "# **\ud83d\ude80 kube-burner-ocp virt clone multi benchmark dashboard**\n\nThis dashboard provides deep insights into the results of the virt-clone-multi benchmark execution using kube-burner-ocp. For a deep dive into workload parameters and metric definitions, refer to the [official kube-burner-ocp documentation](https://kube-burner.github.io/kube-burner-ocp/latest/#virt-clone-multi).\n\n### \u2699\ufe0f How to configure your view\n\nUse the dropdown selectors at the top of the dashboard to filter the results:\n\n- **Run UUID \ud83d\udd3d:** Select the unique identifier for your benchmark execution to filter all visualizations for that specific test run.\n- **Latency Percentile \ud83d\udcca:** Toggle between median (50th) for typical performance or tail latencies (90th/95th/99th) to identify worst-case bottlenecks in your infrastructure.\n\n\ud83d\udccc **NOTE:**\n- All latency metrics in this dashboard are reported in seconds.\n- Since the OS image is provisioned through persistent storage instead of being pulled directly into the `virt-launcher` pod\u2019s local directory, this scenario results in the creation and binding of DataVolumes and PVCs.",
         "mode": "markdown"
       },
       "pluginVersion": "12.1.0",
@@ -6169,6 +6159,20 @@
   "tags": [],
   "templating": {
     "list": [
+      {
+        "current": {},
+        "description": "Elasticsearch datasource used by all panels",
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_ELASTICSEARCH",
+        "options": [],
+        "query": "elasticsearch",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
       {
         "allowCustomValue": false,
         "current": {},

--- a/dashboards/virt-dashboards/Virt-clone.json
+++ b/dashboards/virt-dashboards/Virt-clone.json
@@ -1,14 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_ELASTICSEARCH",
-      "label": "elasticsearch",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "elasticsearch",
-      "pluginName": "Elasticsearch"
-    }
-  ],
   "__elements": {},
   "__requires": [
     {
@@ -90,7 +80,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "# **🚀 kube-burner-ocp virt clone benchmark dashboard**\n\nThis dashboard provides deep insights into the results of the virt-clone benchmark execution using kube-burner-ocp. For a deep dive into workload parameters and metric definitions, refer to the [official kube-burner-ocp documentation](https://kube-burner.github.io/kube-burner-ocp/latest/#virt-clone).\n\n### ⚙️ How to configure your view\n\nUse the dropdown selectors at the top of the dashboard to filter the results:\n\n- **Run UUID 🔽:** Select the unique identifier for your benchmark execution to filter all visualizations for that specific test run.\n- **Latency Percentile 📊:** Toggle between median (50th) for typical performance or tail latencies (90th/95th/99th) to identify worst-case bottlenecks in your infrastructure.\n\n📌 **NOTE:**\n- All latency metrics in this dashboard are reported in seconds.\n- Since the OS image is provisioned through persistent storage instead of being pulled directly into the `virt-launcher` pod’s local directory, this scenario results in the creation and binding of DataVolumes and PVCs.",
+        "content": "# **\ud83d\ude80 kube-burner-ocp virt clone benchmark dashboard**\n\nThis dashboard provides deep insights into the results of the virt-clone benchmark execution using kube-burner-ocp. For a deep dive into workload parameters and metric definitions, refer to the [official kube-burner-ocp documentation](https://kube-burner.github.io/kube-burner-ocp/latest/#virt-clone).\n\n### \u2699\ufe0f How to configure your view\n\nUse the dropdown selectors at the top of the dashboard to filter the results:\n\n- **Run UUID \ud83d\udd3d:** Select the unique identifier for your benchmark execution to filter all visualizations for that specific test run.\n- **Latency Percentile \ud83d\udcca:** Toggle between median (50th) for typical performance or tail latencies (90th/95th/99th) to identify worst-case bottlenecks in your infrastructure.\n\n\ud83d\udccc **NOTE:**\n- All latency metrics in this dashboard are reported in seconds.\n- Since the OS image is provisioned through persistent storage instead of being pulled directly into the `virt-launcher` pod\u2019s local directory, this scenario results in the creation and binding of DataVolumes and PVCs.",
         "mode": "markdown"
       },
       "pluginVersion": "12.1.0",
@@ -4829,6 +4819,20 @@
   "tags": [],
   "templating": {
     "list": [
+      {
+        "current": {},
+        "description": "Elasticsearch datasource used by all panels",
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_ELASTICSEARCH",
+        "options": [],
+        "query": "elasticsearch",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
       {
         "allowCustomValue": false,
         "current": {},

--- a/dashboards/virt-dashboards/Virt-density.json
+++ b/dashboards/virt-dashboards/Virt-density.json
@@ -1,14 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_ELASTICSEARCH",
-      "label": "elasticsearch",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "elasticsearch",
-      "pluginName": "Elasticsearch"
-    }
-  ],
   "__elements": {},
   "__requires": [
     {
@@ -84,7 +74,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "# **🚀 kube-burner-ocp virt density benchmark dashboard**\n\nThis dashboard provides deep insights into the results of the virt-density benchmark execution using kube-burner-ocp. For a deep dive into workload parameters and metric definitions, refer to the [official kube-burner-ocp documentation](https://kube-burner.github.io/kube-burner-ocp/latest/#virt-density).\n\n### ⚙️ How to configure your view\n\nUse the dropdown selectors at the top of the dashboard to filter the results:\n\n- **Run UUID 🔽:** Select the unique identifier for your benchmark execution to filter all visualizations for that specific test run.\n- **Latency Percentile 📊:** Toggle between median (50th) for typical performance or tail latencies (90th/95th/99th) to identify worst-case bottlenecks in your infrastructure.\n\n📌 **NOTE:**\n- All latency metrics in this dashboard are reported in seconds.\n- Since the OS image is pulled directly into the `virt-launcher` pod’s local directory (typically on the node’s root disk), no DataVolumes or PVCs are created or bound for this scenario.",
+        "content": "# **\ud83d\ude80 kube-burner-ocp virt density benchmark dashboard**\n\nThis dashboard provides deep insights into the results of the virt-density benchmark execution using kube-burner-ocp. For a deep dive into workload parameters and metric definitions, refer to the [official kube-burner-ocp documentation](https://kube-burner.github.io/kube-burner-ocp/latest/#virt-density).\n\n### \u2699\ufe0f How to configure your view\n\nUse the dropdown selectors at the top of the dashboard to filter the results:\n\n- **Run UUID \ud83d\udd3d:** Select the unique identifier for your benchmark execution to filter all visualizations for that specific test run.\n- **Latency Percentile \ud83d\udcca:** Toggle between median (50th) for typical performance or tail latencies (90th/95th/99th) to identify worst-case bottlenecks in your infrastructure.\n\n\ud83d\udccc **NOTE:**\n- All latency metrics in this dashboard are reported in seconds.\n- Since the OS image is pulled directly into the `virt-launcher` pod\u2019s local directory (typically on the node\u2019s root disk), no DataVolumes or PVCs are created or bound for this scenario.",
         "mode": "markdown"
       },
       "pluginVersion": "12.1.0",
@@ -2236,6 +2226,20 @@
   "tags": [],
   "templating": {
     "list": [
+      {
+        "current": {},
+        "description": "Elasticsearch datasource used by all panels",
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_ELASTICSEARCH",
+        "options": [],
+        "query": "elasticsearch",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
       {
         "allowCustomValue": false,
         "current": {},

--- a/dashboards/virt-dashboards/Virt-ephemeral-restart.json
+++ b/dashboards/virt-dashboards/Virt-ephemeral-restart.json
@@ -1,14 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_ELASTICSEARCH",
-      "label": "elasticsearch",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "elasticsearch",
-      "pluginName": "Elasticsearch"
-    }
-  ],
   "__elements": {},
   "__requires": [
     {
@@ -90,7 +80,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "# **🚀 kube-burner-ocp virt ephemeral restart benchmark dashboard**\n\nThis dashboard provides deep insights into the results of the virt-ephemeral-restart benchmark execution using kube-burner-ocp. For a deep dive into workload parameters and metric definitions, refer to the [official kube-burner-ocp documentation](https://kube-burner.github.io/kube-burner-ocp/latest/#virt-ephemeral-restart).\n\n### ⚙️ How to configure your view\n\nUse the dropdown selectors at the top of the dashboard to filter the results:\n\n- **Run UUID 🔽:** Select the unique identifier for your benchmark execution to filter all visualizations for that specific test run.\n- **Latency Percentile 📊:** Toggle between median (50th) for typical performance or tail latencies (90th/95th/99th) to identify worst-case bottlenecks in your infrastructure.\n\n📌 **NOTE:**\n- All latency metrics in this dashboard are reported in seconds.\n- Since the OS image is pulled directly into the `virt-launcher` pod’s local directory (typically on the node’s root disk), no DataVolumes or PVCs are created or bound for this scenario.",
+        "content": "# **\ud83d\ude80 kube-burner-ocp virt ephemeral restart benchmark dashboard**\n\nThis dashboard provides deep insights into the results of the virt-ephemeral-restart benchmark execution using kube-burner-ocp. For a deep dive into workload parameters and metric definitions, refer to the [official kube-burner-ocp documentation](https://kube-burner.github.io/kube-burner-ocp/latest/#virt-ephemeral-restart).\n\n### \u2699\ufe0f How to configure your view\n\nUse the dropdown selectors at the top of the dashboard to filter the results:\n\n- **Run UUID \ud83d\udd3d:** Select the unique identifier for your benchmark execution to filter all visualizations for that specific test run.\n- **Latency Percentile \ud83d\udcca:** Toggle between median (50th) for typical performance or tail latencies (90th/95th/99th) to identify worst-case bottlenecks in your infrastructure.\n\n\ud83d\udccc **NOTE:**\n- All latency metrics in this dashboard are reported in seconds.\n- Since the OS image is pulled directly into the `virt-launcher` pod\u2019s local directory (typically on the node\u2019s root disk), no DataVolumes or PVCs are created or bound for this scenario.",
         "mode": "markdown"
       },
       "pluginVersion": "12.1.0",
@@ -5738,6 +5728,20 @@
   "tags": [],
   "templating": {
     "list": [
+      {
+        "current": {},
+        "description": "Elasticsearch datasource used by all panels",
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_ELASTICSEARCH",
+        "options": [],
+        "query": "elasticsearch",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
       {
         "allowCustomValue": false,
         "current": {},

--- a/dashboards/virt-dashboards/Virt-migration.json
+++ b/dashboards/virt-dashboards/Virt-migration.json
@@ -1,14 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_ELASTICSEARCH",
-      "label": "elasticsearch",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "elasticsearch",
-      "pluginName": "Elasticsearch"
-    }
-  ],
   "__elements": {},
   "__requires": [
     {
@@ -90,7 +80,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "# **🚀 kube-burner-ocp virt migration benchmark dashboard**\n\nThis dashboard provides deep insights into the results of the virt-migration benchmark execution using kube-burner-ocp. For a deep dive into workload parameters and metric definitions, refer to the [official kube-burner-ocp documentation](https://kube-burner.github.io/kube-burner-ocp/latest/#virt-migration).\n\n### ⚙️ How to configure your view\n\nUse the dropdown selectors at the top of the dashboard to filter the results:\n\n- **Run UUID 🔽:** Select the unique identifier for your benchmark execution to filter all visualizations for that specific test run.\n- **Latency Percentile 📊:** Toggle between median (50th) for typical performance or tail latencies (90th/95th/99th) to identify worst-case bottlenecks in your infrastructure.\n\n📌 **NOTE:**\n- All latency metrics in this dashboard are reported in seconds.\n- Since the OS image is provisioned through persistent storage instead of being pulled directly into the `virt-launcher` pod’s local directory, this scenario results in the creation and binding of DataVolumes and PVCs.",
+        "content": "# **\ud83d\ude80 kube-burner-ocp virt migration benchmark dashboard**\n\nThis dashboard provides deep insights into the results of the virt-migration benchmark execution using kube-burner-ocp. For a deep dive into workload parameters and metric definitions, refer to the [official kube-burner-ocp documentation](https://kube-burner.github.io/kube-burner-ocp/latest/#virt-migration).\n\n### \u2699\ufe0f How to configure your view\n\nUse the dropdown selectors at the top of the dashboard to filter the results:\n\n- **Run UUID \ud83d\udd3d:** Select the unique identifier for your benchmark execution to filter all visualizations for that specific test run.\n- **Latency Percentile \ud83d\udcca:** Toggle between median (50th) for typical performance or tail latencies (90th/95th/99th) to identify worst-case bottlenecks in your infrastructure.\n\n\ud83d\udccc **NOTE:**\n- All latency metrics in this dashboard are reported in seconds.\n- Since the OS image is provisioned through persistent storage instead of being pulled directly into the `virt-launcher` pod\u2019s local directory, this scenario results in the creation and binding of DataVolumes and PVCs.",
         "mode": "markdown"
       },
       "pluginVersion": "12.1.0",
@@ -6607,6 +6597,20 @@
   "tags": [],
   "templating": {
     "list": [
+      {
+        "current": {},
+        "description": "Elasticsearch datasource used by all panels",
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_ELASTICSEARCH",
+        "options": [],
+        "query": "elasticsearch",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
       {
         "allowCustomValue": false,
         "current": {},

--- a/dashboards/virt-dashboards/Virt-parallel.json
+++ b/dashboards/virt-dashboards/Virt-parallel.json
@@ -1,14 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_ELASTICSEARCH",
-      "label": "elasticsearch",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "elasticsearch",
-      "pluginName": "Elasticsearch"
-    }
-  ],
   "__elements": {},
   "__requires": [
     {
@@ -90,7 +80,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "# **🚀 kube-burner-ocp virt parallel benchmark dashboard**\n\nThis dashboard provides deep insights into the results of the virt-parallel execution using kube-burner-ocp. For a deep dive into workload parameters and metric definitions, refer to the [official kube-burner-ocp documentation](https://kube-burner.github.io/kube-burner-ocp/latest/#virt-parallel).\n\n### ⚙️ How to configure your view\n\nUse the dropdown selectors at the top of the dashboard to filter the results:\n\n- **Run UUID 🔽:** Select the unique identifier for your benchmark execution to filter all visualizations for that specific test run.\n- **Latency Percentile 📊:** Toggle between median (50th) for typical performance or tail latencies (90th/95th/99th) to identify worst-case bottlenecks in your infrastructure.\n\n📌 **NOTE:**\n- All latency metrics in this dashboard are reported in seconds.\n- Since the OS image is provisioned through persistent storage instead of being pulled directly into the `virt-launcher` pod’s local directory, this scenario results in the creation and binding of DataVolumes and PVCs.",
+        "content": "# **\ud83d\ude80 kube-burner-ocp virt parallel benchmark dashboard**\n\nThis dashboard provides deep insights into the results of the virt-parallel execution using kube-burner-ocp. For a deep dive into workload parameters and metric definitions, refer to the [official kube-burner-ocp documentation](https://kube-burner.github.io/kube-burner-ocp/latest/#virt-parallel).\n\n### \u2699\ufe0f How to configure your view\n\nUse the dropdown selectors at the top of the dashboard to filter the results:\n\n- **Run UUID \ud83d\udd3d:** Select the unique identifier for your benchmark execution to filter all visualizations for that specific test run.\n- **Latency Percentile \ud83d\udcca:** Toggle between median (50th) for typical performance or tail latencies (90th/95th/99th) to identify worst-case bottlenecks in your infrastructure.\n\n\ud83d\udccc **NOTE:**\n- All latency metrics in this dashboard are reported in seconds.\n- Since the OS image is provisioned through persistent storage instead of being pulled directly into the `virt-launcher` pod\u2019s local directory, this scenario results in the creation and binding of DataVolumes and PVCs.",
         "mode": "markdown"
       },
       "pluginVersion": "12.1.0",
@@ -6320,6 +6310,20 @@
   "tags": [],
   "templating": {
     "list": [
+      {
+        "current": {},
+        "description": "Elasticsearch datasource used by all panels",
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_ELASTICSEARCH",
+        "options": [],
+        "query": "elasticsearch",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
       {
         "allowCustomValue": false,
         "current": {},

--- a/dashboards/virt-dashboards/Virt-udn-density.json
+++ b/dashboards/virt-dashboards/Virt-udn-density.json
@@ -1,14 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_ELASTICSEARCH",
-      "label": "elasticsearch",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "elasticsearch",
-      "pluginName": "Elasticsearch"
-    }
-  ],
   "__elements": {},
   "__requires": [
     {
@@ -84,7 +74,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "# **🚀 kube-burner-ocp virt density UDN benchmark dashboard**\n\nThis dashboard provides deep insights into the results of the virt-udn-density benchmark execution using kube-burner-ocp. For a deep dive into workload parameters and metric definitions, refer to the [official kube-burner-ocp documentation](https://kube-burner.github.io/kube-burner-ocp/latest/#virt-density-udn).\n\n### ⚙️ How to configure your view\n\nUse the dropdown selectors at the top of the dashboard to filter the results:\n\n- **Run UUID 🔽:** Select the unique identifier for your benchmark execution to filter all visualizations for that specific test run.\n- **Latency Percentile 📊:** Toggle between median (50th) for typical performance or tail latencies (90th/95th/99th) to identify worst-case bottlenecks in your infrastructure.\n\n📌 **NOTE:**\n- All latency metrics in this dashboard are reported in seconds.\n- Since the OS image is pulled directly into the `virt-launcher` pod’s local directory (typically on the node’s root disk), no DataVolumes or PVCs are created or bound for this scenario.",
+        "content": "# **\ud83d\ude80 kube-burner-ocp virt density UDN benchmark dashboard**\n\nThis dashboard provides deep insights into the results of the virt-udn-density benchmark execution using kube-burner-ocp. For a deep dive into workload parameters and metric definitions, refer to the [official kube-burner-ocp documentation](https://kube-burner.github.io/kube-burner-ocp/latest/#virt-density-udn).\n\n### \u2699\ufe0f How to configure your view\n\nUse the dropdown selectors at the top of the dashboard to filter the results:\n\n- **Run UUID \ud83d\udd3d:** Select the unique identifier for your benchmark execution to filter all visualizations for that specific test run.\n- **Latency Percentile \ud83d\udcca:** Toggle between median (50th) for typical performance or tail latencies (90th/95th/99th) to identify worst-case bottlenecks in your infrastructure.\n\n\ud83d\udccc **NOTE:**\n- All latency metrics in this dashboard are reported in seconds.\n- Since the OS image is pulled directly into the `virt-launcher` pod\u2019s local directory (typically on the node\u2019s root disk), no DataVolumes or PVCs are created or bound for this scenario.",
         "mode": "markdown"
       },
       "pluginVersion": "12.1.0",
@@ -3441,6 +3431,20 @@
   "tags": [],
   "templating": {
     "list": [
+      {
+        "current": {},
+        "description": "Elasticsearch datasource used by all panels",
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_ELASTICSEARCH",
+        "options": [],
+        "query": "elasticsearch",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
       {
         "allowCustomValue": false,
         "current": {},


### PR DESCRIPTION
Type of change
Refactor
Description
Add a Grafana datasource template variable (DS_ELASTICSEARCH) to all virt workload dashboards so the Elasticsearch datasource can be selected at runtime instead of relying on the export __inputs placeholder.

Changes:

Add a DS_ELASTICSEARCH datasource template variable to all 8 dashboards under dashboards/virt-dashboards/
Keep existing panel and query references using ${DS_ELASTICSEARCH}
Remove the __inputs section now that the datasource is a proper dashboard variable
Affected dashboards:

Virt-capacity-benchmark
Virt-clone
Virt-clone-multi
Virt-density
Virt-ephemeral-restart
Virt-migration
Virt-parallel
Virt-udn-density

