### PR TITLE
Set runOnce to false for berserker

### DIFF
--- a/cmd/config/berserker-load/berserker-load.yml
+++ b/cmd/config/berserker-load/berserker-load.yml
@@ -56,11 +56,9 @@ jobs:
 
       - objectTemplate: berserker-sa.yml
         replicas: 1
-        runOnce: true
 
       - objectTemplate: berserker-scc-rolebinding.yml
         replicas: 1
-        runOnce: true
 
       - objectTemplate: {{ (env "BERSERKER_CONFIGMAP_TEMPLATE") | default "berserker-configmap.yml" }}
         replicas: 1


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->

- Refactor
- New feature
- Bug fix
- Optimization
- Documentation
- CI

## Description

Setting `runOnce: true` means that the ServiceAccount and RoleBinding are created only in the first namespace. That means that it is not possible to create pods in berserker namespaces other than the first namespace.

This bug was introduced in https://github.com/kube-burner/kube-burner-ocp/pull/484

## Testing

When the above PR was merged, the testing had not been finished for the latest version.

There is another PR at https://github.com/openshift/release/pull/77737, which uses the built in berserker load, for a performance and scale test in OpenshiftCI. That PR is still in draft form and needs to be cleaned up, but it is able to test if the the changes here are working properly. It has confirmed that the built in berserker load can be used in the performance and scale tests. https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/77737/rehearse-77737-pull-ci-stackrox-stackrox-master-perf-scale-berserker-scale-test/2086164050844061696 

## Related Tickets & Documents

- Related Issue # https://github.com/kube-burner/kube-burner-ocp/pull/484
- Closes #

