### PR TITLE
Add static MAC binding workaround for cudn-density (OCPBUGS-85627)

### DIFF
--- a/cmd/config/cudn-density/cudn-density.yml
+++ b/cmd/config/cudn-density/cudn-density.yml
@@ -44,6 +44,37 @@ metricsEndpoints:
 {{ end }}
 
 jobs:
+{{ if .OCPBUGS_85627_WORKAROUND }}
+  - name: cudn-density-workaround
+    namespace: redhat-ocpbugs-85627-wa
+    jobIterations: 1
+    qps: 20
+    burst: 20
+    namespacedIterations: false
+    preCreateNamespaces: true
+    waitWhenFinished: true
+    skipIndexing: true
+    cleanup: false
+    jobPause: 1m
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+    objects:
+      - objectTemplate: workaround-sa.yml
+        replicas: 1
+
+      - objectTemplate: workaround-rolebinding.yml
+        replicas: 1
+
+      - objectTemplate: workaround-secret.yml
+        replicas: 1
+
+      - objectTemplate: workaround-daemonset.yml
+        replicas: 1
+{{ end }}
+
   - name: cudn-density
     namespace: cudn-density
     jobIterations: {{.JOB_ITERATIONS}}
@@ -278,4 +309,17 @@ jobs:
       - kind: ClusterUserDefinedNetwork
         apiVersion: k8s.ovn.org/v1
         labelSelector: {kube-burner.io/job: cudn-density}
+
+{{ if .OCPBUGS_85627_WORKAROUND }}
+  - name: cudn-density-cleanup-workaround
+    jobType: delete
+    waitForDeletion: true
+    qps: 20
+    burst: 20
+    skipIndexing: true
+    objects:
+      - kind: Namespace
+        apiVersion: v1
+        labelSelector: {kube-burner.io/job: cudn-density-workaround}
+{{ end }}
 {{ end }}

--- a/cmd/config/cudn-density/cudn-density.yml
+++ b/cmd/config/cudn-density/cudn-density.yml
@@ -2,6 +2,7 @@
 global:
   gc: {{.GC}}
   gcMetrics: {{.GC_METRICS}}
+  deletionStrategy: {{.DELETION_STRATEGY}}
 {{ if .PPROF }}
   measurements:
     - name: pprof

--- a/cmd/config/cudn-density/workaround-daemonset.yml
+++ b/cmd/config/cudn-density/workaround-daemonset.yml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: redhat-ocpbugs-85627
+spec:
+  selector:
+    matchLabels:
+      app: redhat-ocpbugs-85627
+  template:
+    metadata:
+      labels:
+        app: redhat-ocpbugs-85627
+    spec:
+      serviceAccountName: redhat-ocpbugs-85627-sa
+      containers:
+      - name: script-runner
+        image: registry.access.redhat.com/ubi9/ubi:latest
+        args:
+        - /bin/bash
+        - -c
+        - |
+          while true ; do
+            bash /tmp/redhat-ocpbugs-85627-script.sh || exit 1
+            sleep 5
+          done
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /host
+          name: host
+        - mountPath: /tmp/redhat-ocpbugs-85627-script.sh
+          name: script
+          subPath: redhat-ocpbugs-85627-script.sh
+        resources:
+          requests:
+            cpu: 10m
+            memory: 300Mi
+      volumes:
+      - name: host
+        hostPath:
+          path: /
+          type: ''
+      - name: script
+        secret:
+          defaultMode: 365
+          secretName: redhat-ocpbugs-85627-script

--- a/cmd/config/cudn-density/workaround-rolebinding.yml
+++ b/cmd/config/cudn-density/workaround-rolebinding.yml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:openshift:scc:redhat-ocpbugs-85627-privileged-scc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: redhat-ocpbugs-85627-sa

--- a/cmd/config/cudn-density/workaround-sa.yml
+++ b/cmd/config/cudn-density/workaround-sa.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redhat-ocpbugs-85627-sa

--- a/cmd/config/cudn-density/workaround-secret.yml
+++ b/cmd/config/cudn-density/workaround-secret.yml
@@ -1,0 +1,94 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redhat-ocpbugs-85627-script
+type: Opaque
+stringData:
+  redhat-ocpbugs-85627-script.sh: |
+    #!/bin/bash
+
+    ## This script is maintained by Red Hat OpenShift support
+    ## For the unique scope to workaround https://redhat.atlassian.net/browse/OCPBUGS-85627
+
+    ## This script is executed in a privileged pod which mounts the root of the node under /host
+    ## The goal is to inject static MAC bindings for all the known hosts in the L2 network
+    ## The bindings are added into all rtoe ports of every OVN GatewayRouter
+    ## Execution:
+    ## 1) identify default router and its MAC address, must be on br-ex
+    ## 2) verify a static mac binding for the default router exists if not create it
+    ## 3) identify all the known hosts in the same L2 network and create the binding if not exist
+    ## 4) execute a final verification
+
+    RUNCRICTL="chroot /host /usr/bin/crictl"
+    NORTHDC=$(${RUNCRICTL} ps --name northd --state Running -q 2>/dev/null)
+    EXECC="${RUNCRICTL} exec ${NORTHDC}"
+
+    REVERT="${1:-false}"
+
+    if [[ ${NORTHDC} == "" ]] ;then
+      echo "$(date +%FT%T.%Z) ERROR: Impossible to continue: Northd container is not running."
+      exit 1
+    fi
+
+    nodehostname=$(${EXECC} uname -n)
+    GR="GR_${nodehostname}"
+
+    if [[ -z ${nodehostname} ]];then
+      echo "$(date +%FT%T.%Z) ERROR: Impossible to continue: Something is wrong while executing uname commands in the northd container."
+      exit 1
+    fi
+
+    routerIP=$(${EXECC} ip route list dev br-ex default |cut -d' ' -f3)
+    routerMAC=$(${EXECC} ip neigh get ${routerIP} dev br-ex |cut -d' ' -f5)
+
+    if [[ -z ${routerIP} ]] || [[ -z ${routerMAC} ]];then
+      echo "$(date +%FT%T.%Z) ERROR: Impossible to continue: Something is wrong while executing ip commands in the northd container."
+      exit 1
+    fi
+
+    LRPORTS=$(${EXECC} ovn-nbctl --columns=name --bare find logical_router_port | grep rtoe-GR)
+
+    COUNT=1
+
+    for port in ${LRPORTS} ; do
+      ${EXECC} ovn-nbctl --bare --columns=mac find static_mac_binding logical_port=${port} ip=${routerIP} |grep -q ${routerMAC}
+      if [[ $? -gt 0 ]] && [[ ${REVERT} != "revert" ]]; then
+        echo "$(date +%FT%T.%Z) CHANGING: Add Mac binding to port ${port} for ${routerIP} because not present."
+        ${EXECC} ovn-nbctl --may-exist --wait=sb static-mac-binding-add ${port} ${routerIP} ${routerMAC}
+      elif [[ ${REVERT} == "revert" ]] && [[ $(${EXECC} ovn-nbctl --bare --columns=ip find static_mac_binding logical_port=${port} ip=${routerIP} |grep ${routerIP} |wc -l) -gt 0 ]];then
+        echo "$(date +%FT%T.%Z) REVERTING: removing static-mac-binding from port ${port} for ${routerIP}"
+        ${EXECC} ovn-nbctl --wait=sb --if-exists static-mac-binding-del ${port} ${routerIP}
+      fi
+    done
+
+    NEIGHBORS=$(${EXECC} ip neigh show $(${EXECC} ip -f inet -br a s br-ex |awk '{print $3}') |grep -v ${routerIP} |grep -v "FAILED" |awk '{print $1" "$5}')
+
+    while read ip mac ; do
+      for port in ${LRPORTS} ; do
+        ${EXECC} ovn-nbctl --bare --columns=mac find static_mac_binding logical_port=${port} ip=${ip} |grep -q ${mac}
+        if [[ $? -gt 0 ]] && [[ ${REVERT} != "revert" ]]; then
+          echo "$(date +%FT%T.%Z) CHANGING: Add Mac binding to port ${port} for ${ip} because not present."
+          ${EXECC} ovn-nbctl --may-exist --wait=sb static-mac-binding-add ${port} ${ip} ${mac}
+        elif [[ ${REVERT} == "revert" ]] && [[ $(${EXECC} ovn-nbctl --bare --columns=ip find static_mac_binding logical_port=${port} ip=${ip} |grep ${ip} |wc -l) -gt 0 ]];then
+          echo "$(date +%FT%T.%Z) REVERTING: removing static-mac-binding from port ${port} for ${ip}"
+          ${EXECC} ovn-nbctl --wait=sb --if-exists static-mac-binding-del ${port} ${ip}
+        fi
+      done
+    done <<< "${NEIGHBORS}"
+
+    ODMACUID=$(${EXECC} ovn-nbctl --bare --columns=_uuid find static_mac_binding override_dynamic_mac=false |grep -v '^$')
+    if [[ ${REVERT} != "revert" ]] && [[ -n ${ODMACUID} ]];then
+      echo "$(date +%FT%T.%Z) CHANGING: Found $(wc -l <<< "${ODMACUID}") static_mac_binding with override_dynamic_mac=false, changing them..."
+      while read uid ; do
+        ${EXECC} ovn-nbctl set Static_MAC_Binding ${uid} override_dynamic_mac=true
+      done <<< "${ODMACUID}"
+    fi
+
+    COUNT=$(( $COUNT + $(wc -l <<< "${NEIGHBORS}") ))
+
+    TOTLRPORTS=$(${EXECC} ovn-nbctl --columns=name --bare find logical_router_port | grep rtoe-GR |wc -l)
+    TOTBIND=$(${EXECC} ovn-nbctl --bare --columns=mac find static_mac_binding  |grep -Ecv "^$|0a:58:a9")
+    [[ ${REVERT} == "revert" ]] && echo "$(date +%FT%T.%Z) In REVERT mode. VERIFICATION: total bindings ${TOTBIND} (expected 0)"
+    [[ ${REVERT} != "revert" ]] && echo "$(date +%FT%T.%Z) VERIFICATION: total bindings ${TOTBIND} (expected $((${COUNT} * ${TOTLRPORTS})))"
+
+    exit 0

--- a/pkg/workloads/cudn-density.go
+++ b/pkg/workloads/cudn-density.go
@@ -100,6 +100,7 @@ func getNodeGatewayMap() string {
 func NewCudnDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 	var churnPercent, churnCycles, iterations, namespacesPerCudn, cudnsPerRA, incrementalStepSize int
 	var incrementalExpBase float64
+	var deletionStrategy string
 	var l3, pprof, gatewayCheck, bgp, ocpbugs85627Workaround bool
 	var churnDelay, churnDuration, podReadyThreshold, pprofInterval, jobPause, incrementalStepDelay time.Duration
 	var churnMode, incrementalPattern string
@@ -181,6 +182,7 @@ func NewCudnDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 			AdditionalVars["GATEWAY_CHECK"] = gatewayCheck
 			AdditionalVars["BGP"] = bgp
 			AdditionalVars["OCPBUGS_85627_WORKAROUND"] = ocpbugs85627Workaround
+			AdditionalVars["DELETION_STRATEGY"] = deletionStrategy
 			if gatewayCheck {
 				AdditionalVars["NODE_GW_MAP"] = getNodeGatewayMap()
 			}
@@ -211,6 +213,7 @@ func NewCudnDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().Float64Var(&incrementalExpBase, "incremental-exp-base", 2.0, "Base for exponential incremental pattern (must be > 1.0)")
 	cmd.Flags().BoolVar(&gatewayCheck, "gateway-check", false, "Enable default gateway reachability check from each namespace")
 	cmd.Flags().BoolVar(&ocpbugs85627Workaround, "static-mac-binding-workaround", false, "Deploy OCPBUGS-85627 static MAC binding workaround DaemonSet before creating CUDNs")
+	cmd.Flags().StringVar(&deletionStrategy, "deletion-strategy", config.DefaultDeletionStrategy, "GC deletion mode, default deletes entire namespaces and gvr deletes objects within namespaces before deleting the parent namespace")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
 	cmd.MarkFlagRequired("iterations")
 	return cmd

--- a/pkg/workloads/cudn-density.go
+++ b/pkg/workloads/cudn-density.go
@@ -100,7 +100,7 @@ func getNodeGatewayMap() string {
 func NewCudnDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 	var churnPercent, churnCycles, iterations, namespacesPerCudn, cudnsPerRA, incrementalStepSize int
 	var incrementalExpBase float64
-	var l3, pprof, gatewayCheck, bgp bool
+	var l3, pprof, gatewayCheck, bgp, ocpbugs85627Workaround bool
 	var churnDelay, churnDuration, podReadyThreshold, pprofInterval, jobPause, incrementalStepDelay time.Duration
 	var churnMode, incrementalPattern string
 	var metricsProfiles []string
@@ -180,6 +180,7 @@ func NewCudnDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 			AdditionalVars["INCREMENTAL_EXP_BASE"] = incrementalExpBase
 			AdditionalVars["GATEWAY_CHECK"] = gatewayCheck
 			AdditionalVars["BGP"] = bgp
+			AdditionalVars["OCPBUGS_85627_WORKAROUND"] = ocpbugs85627Workaround
 			if gatewayCheck {
 				AdditionalVars["NODE_GW_MAP"] = getNodeGatewayMap()
 			}
@@ -209,6 +210,7 @@ func NewCudnDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().StringVar(&incrementalPattern, "incremental-pattern", "linear", "Incremental load pattern: linear or exponential")
 	cmd.Flags().Float64Var(&incrementalExpBase, "incremental-exp-base", 2.0, "Base for exponential incremental pattern (must be > 1.0)")
 	cmd.Flags().BoolVar(&gatewayCheck, "gateway-check", false, "Enable default gateway reachability check from each namespace")
+	cmd.Flags().BoolVar(&ocpbugs85627Workaround, "static-mac-binding-workaround", false, "Deploy OCPBUGS-85627 static MAC binding workaround DaemonSet before creating CUDNs")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
 	cmd.MarkFlagRequired("iterations")
 	return cmd


### PR DESCRIPTION
## Summary
- **This is a temporary patchset** — the workaround should be removed once OCPBUGS-85627 is fixed upstream
- Adds `--static-mac-binding-workaround` flag to `cudn-density` that deploys a privileged DaemonSet to inject static OVN MAC bindings on all nodes before CUDN creation
- Works around [OCPBUGS-85627](https://redhat.atlassian.net/browse/OCPBUGS-85627) where dynamic MAC bindings can cause connectivity issues in CUDN environments
- The workaround runs as a separate kube-burner job (with SA, RoleBinding, Secret, and DaemonSet) before the main cudn-density job, and is cleaned up automatically during GC
- The flag value is automatically tracked in indexed `SummaryMetadata.workloadFlags`, so runs with/without the workaround can be distinguished in dashboards
- Also adds `--deletion-strategy` flag to cudn-density (missing compared to other workloads)

## Test plan
- [x] Run `cudn-density --iterations 5 --static-mac-binding-workaround` — workaround DaemonSet created (24/24 pods ready), CUDNs created successfully (rc 0)
- [x] Run `cudn-density --iterations 5 --gc=true` without workaround flag — no workaround resources created, GC works (rc 0)
- [x] Run `cudn-density --iterations 5 --gc=true --deletion-strategy=gvr` — GVR deletion works (rc 0)
- [ ] Verify workaround flag value appears in indexed metadata for run comparison