### PR TITLE
[PERFSCALE-5477] Enabling PPROF collection for Kubelet and CRIO components in cluster-density-v2 workload

### DIFF
--- a/cmd/config/cluster-density-v2/cluster-density-v2.yml
+++ b/cmd/config/cluster-density-v2/cluster-density-v2.yml
@@ -15,6 +15,8 @@ global:
     - name: pprof
       pprofInterval: {{.PPROF_INTERVAL}}
       pprofDirectory: pprof-data
+      nodeAffinity:
+        node-role.kubernetes.io/worker: ""
       pprofTargets:
       - name: ovnkube-controller-heap
         namespace: "openshift-ovn-kubernetes"
@@ -32,6 +34,16 @@ global:
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-control-plane}
         url: http://localhost:29108/debug/pprof/profile?seconds=60
+      - name: kubelet-heap
+        url: https://${HOSTNAME}:10250/debug/pprof/heap
+      - name: kubelet-cpu
+        url: https://${HOSTNAME}:10250/debug/pprof/profile?seconds=60
+      - name: crio-heap
+        url: http://localhost/debug/pprof/heap
+        unixSocketPath: /var/run/crio/crio.sock
+      - name: crio-cpu
+        url: http://localhost/debug/pprof/profile?seconds=60
+        unixSocketPath: /var/run/crio/crio.sock
 {{ end }}
 {{ if .SVC_LATENCY }}
     - name: serviceLatency

--- a/cmd/config/cluster-density-v2/cluster-density-v2.yml
+++ b/cmd/config/cluster-density-v2/cluster-density-v2.yml
@@ -11,13 +11,16 @@ global:
           metric: P99
           threshold: {{.POD_READY_THRESHOLD}}
 {{ end }}
-{{ if .PPROF }}
+{{ if or .PPROF .PPROF_KUBELET .PPROF_CRIO }}
     - name: pprof
       pprofInterval: {{.PPROF_INTERVAL}}
       pprofDirectory: pprof-data
+{{ if or .PPROF_KUBELET .PPROF_CRIO }}
       nodeAffinity:
         node-role.kubernetes.io/worker: ""
+{{ end }}
       pprofTargets:
+{{ if .PPROF }}
       - name: ovnkube-controller-heap
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-node}
@@ -34,16 +37,21 @@ global:
         namespace: "openshift-ovn-kubernetes"
         labelSelector: {app: ovnkube-control-plane}
         url: http://localhost:29108/debug/pprof/profile?seconds=60
+{{ end }}
+{{ if .PPROF_KUBELET }}
       - name: kubelet-heap
         url: https://${HOSTNAME}:10250/debug/pprof/heap
       - name: kubelet-cpu
         url: https://${HOSTNAME}:10250/debug/pprof/profile?seconds=60
+{{ end }}
+{{ if .PPROF_CRIO }}
       - name: crio-heap
         url: http://localhost/debug/pprof/heap
         unixSocketPath: /var/run/crio/crio.sock
       - name: crio-cpu
         url: http://localhost/debug/pprof/profile?seconds=60
         unixSocketPath: /var/run/crio/crio.sock
+{{ end }}
 {{ end }}
 {{ if .SVC_LATENCY }}
     - name: serviceLatency

--- a/pkg/workloads/cluster-density.go
+++ b/pkg/workloads/cluster-density.go
@@ -35,7 +35,7 @@ import (
 // NewClusterDensity holds cluster-density workload
 func NewClusterDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 	var iterations, churnPercent, churnCycles int
-	var svcLatency, pprof bool
+	var svcLatency, pprof, pprofKubelet, pprofCrio bool
 	var churnDelay, churnDuration, pprofInterval time.Duration
 	var deletionStrategy, churnMode, selector string
 	var podReadyThreshold time.Duration
@@ -106,6 +106,8 @@ func NewClusterDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Comm
 			AdditionalVars["NODE_SELECTOR"] = string(nodeSelectorJson)
 			AdditionalVars["PPROF"] = pprof
 			AdditionalVars["PPROF_INTERVAL"] = pprofInterval.String()
+			AdditionalVars["PPROF_KUBELET"] = pprofKubelet
+			AdditionalVars["PPROF_CRIO"] = pprofCrio
 			AdditionalVars["CHURN_CYCLES"] = churnCycles
 			AdditionalVars["CHURN_DURATION"] = churnDuration
 			AdditionalVars["CHURN_DELAY"] = churnDelay
@@ -126,6 +128,8 @@ func NewClusterDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Comm
 	cmd.Flags().IntVar(&iterations, "iterations", 0, fmt.Sprintf("%v iterations", variant))
 	cmd.Flags().BoolVar(&pprof, "pprof", false, "Enable pprof collection")
 	cmd.Flags().DurationVar(&pprofInterval, "pprof-interval", 0, "Interval between pprof collections")
+	cmd.Flags().BoolVar(&pprofKubelet, "pprof-kubelet", false, "Enable pprof collection for kubelet")
+	cmd.Flags().BoolVar(&pprofCrio, "pprof-crio", false, "Enable pprof collection for CRI-O")
 	cmd.Flags().IntVar(&churnCycles, "churn-cycles", 0, "Churn cycles to execute")
 	cmd.Flags().DurationVar(&churnDuration, "churn-duration", 0, "Churn duration")
 	cmd.Flags().DurationVar(&churnDelay, "churn-delay", 2*time.Minute, "Time to wait between each churn")


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->

- New feature


## Description

To collect CPU and Memory Profiling data for Kubelet and CRIO components on worker nodes while executing the cluster-density-v2 workload.

## Related Tickets & Documents

- Related Issue #
- Closes #

