### PR TITLE
Cudn http

### DIFF
--- a/cmd/config/cudn-density/cudn-density.yml
+++ b/cmd/config/cudn-density/cudn-density.yml
@@ -220,7 +220,6 @@ jobs:
         inputVars:
           namespaces_per_cudn: {{.NAMESPACES_PER_CUDN}}
 
-
       - objectTemplate: np-allow-app-ingress.yml
         replicas: 1
         churn: false
@@ -236,10 +235,8 @@ jobs:
           id: 2
         inputVars:
           namespaces_per_cudn: {{.NAMESPACES_PER_CUDN}}
-          {{ if .HTTP_SERVER_ADDRESS }}
           httpServerIP: "{{.HTTP_SERVER_IP}}"
           httpServerPort: "{{.HTTP_SERVER_PORT}}"
-          {{ end }}
 
       - objectTemplate: egressfirewall.yml
         replicas: 1
@@ -248,9 +245,7 @@ jobs:
           id: 2
         inputVars:
           nodeGwMap: '{{ if .GATEWAY_CHECK }}{{.NODE_GW_MAP}}{{ end }}'
-          {{ if .HTTP_SERVER_ADDRESS }}
           httpServerIP: "{{.HTTP_SERVER_IP}}"
-          {{ end }}
 
       - objectTemplate: resourcequota.yml
         replicas: 1

--- a/cmd/config/cudn-density/cudn-density.yml
+++ b/cmd/config/cudn-density/cudn-density.yml
@@ -121,6 +121,13 @@ jobs:
           base: {{.INCREMENTAL_EXP_BASE}}
 {{ end }}
 {{ end }}
+{{ if .HTTP_SERVER_ADDRESS }}
+    hooks:
+      - cmd: ["bash", "cudn_nginx.sh", "setup", "{{.HTTP_SERVER_ADDRESS}}"]
+        when: beforeJobExecution
+      - cmd: ["bash", "cudn_nginx.sh", "cleanup"]
+        when: afterJobExecution
+{{ end }}
     jobPause: {{.JOB_PAUSE}}
     metricsClosing: afterJobPause
     cleanup: false
@@ -228,6 +235,8 @@ jobs:
           id: 2
         inputVars:
           namespaces_per_cudn: {{.NAMESPACES_PER_CUDN}}
+          httpServerIP: "{{.HTTP_SERVER_IP}}"
+          httpServerPort: "{{.HTTP_SERVER_PORT}}"
 
       - objectTemplate: egressfirewall.yml
         replicas: 1
@@ -272,6 +281,8 @@ jobs:
           id: 2
         inputVars:
           podReplicas: 1
+          httpServerAddress: "{{.HTTP_SERVER_ADDRESS}}"
+          httpLoadTestRate: {{.HTTP_LOAD_TEST_RATE}}
 
       - objectTemplate: deployment-client.yml
         replicas: 1

--- a/cmd/config/cudn-density/cudn-density.yml
+++ b/cmd/config/cudn-density/cudn-density.yml
@@ -123,9 +123,9 @@ jobs:
 {{ end }}
 {{ if .HTTP_SERVER_ADDRESS }}
     hooks:
-      - cmd: ["bash", "cudn_nginx.sh", "setup", "{{.HTTP_SERVER_ADDRESS}}"]
+      - cmd: ["./cudn_nginx.sh", "setup", "{{.HTTP_SERVER_ADDRESS}}"]
         when: beforeJobExecution
-      - cmd: ["bash", "cudn_nginx.sh", "cleanup"]
+      - cmd: ["./cudn_nginx.sh", "cleanup"]
         when: afterJobExecution
 {{ end }}
     jobPause: {{.JOB_PAUSE}}
@@ -220,6 +220,7 @@ jobs:
         inputVars:
           namespaces_per_cudn: {{.NAMESPACES_PER_CUDN}}
 
+
       - objectTemplate: np-allow-app-ingress.yml
         replicas: 1
         churn: false
@@ -235,8 +236,10 @@ jobs:
           id: 2
         inputVars:
           namespaces_per_cudn: {{.NAMESPACES_PER_CUDN}}
+          {{ if .HTTP_SERVER_ADDRESS }}
           httpServerIP: "{{.HTTP_SERVER_IP}}"
           httpServerPort: "{{.HTTP_SERVER_PORT}}"
+          {{ end }}
 
       - objectTemplate: egressfirewall.yml
         replicas: 1
@@ -245,6 +248,9 @@ jobs:
           id: 2
         inputVars:
           nodeGwMap: '{{ if .GATEWAY_CHECK }}{{.NODE_GW_MAP}}{{ end }}'
+          {{ if .HTTP_SERVER_ADDRESS }}
+          httpServerIP: "{{.HTTP_SERVER_IP}}"
+          {{ end }}
 
       - objectTemplate: resourcequota.yml
         replicas: 1
@@ -282,7 +288,6 @@ jobs:
         inputVars:
           podReplicas: 1
           httpServerAddress: "{{.HTTP_SERVER_ADDRESS}}"
-          httpLoadTestRate: {{.HTTP_LOAD_TEST_RATE}}
 
       - objectTemplate: deployment-client.yml
         replicas: 1

--- a/cmd/config/cudn-density/deployment-app.yml
+++ b/cmd/config/cudn-density/deployment-app.yml
@@ -33,8 +33,20 @@ spec:
               - key: node-role.kubernetes.io/workload
                 operator: DoesNotExist
       containers:
-      - name: sampleapp
+      - name: hloader
+        {{ if .httpServerAddress }}
+        image: quay.io/cloud-bulldozer/hloader:latest
+        command:
+          - "/bin/sh"
+          - "-c"
+          - |
+            while true; do
+              hloader --url http://{{.httpServerAddress}} --rate {{.httpLoadTestRate}} --duration 1m
+            done
+        {{ else }}
         image: quay.io/cloud-bulldozer/sampleapp:latest
+        command: ["sleep", "infinity"]
+        {{ end }}
         resources:
           requests:
             memory: "10Mi"

--- a/cmd/config/cudn-density/deployment-app.yml
+++ b/cmd/config/cudn-density/deployment-app.yml
@@ -39,8 +39,10 @@ spec:
         {{ if .httpServerAddress }}
         readinessProbe:
           exec:
-            command: ["/bin/sh", "-c", "curl -f -sS http://{{.httpServerAddress}}/1024.html"]
+            command: ["curl -f -sS http://{{.httpServerAddress}}/1024.html"]
           periodSeconds: 1
+          timeoutSeconds: 5
+          failureThreshold: 1
         {{ end }}
         resources:
           requests:

--- a/cmd/config/cudn-density/deployment-app.yml
+++ b/cmd/config/cudn-density/deployment-app.yml
@@ -33,19 +33,14 @@ spec:
               - key: node-role.kubernetes.io/workload
                 operator: DoesNotExist
       containers:
-      - name: hloader
-        {{ if .httpServerAddress }}
-        image: quay.io/cloud-bulldozer/hloader:latest
-        command:
-          - "/bin/sh"
-          - "-c"
-          - |
-            while true; do
-              hloader --url http://{{.httpServerAddress}} --rate {{.httpLoadTestRate}} --duration 1m
-            done
-        {{ else }}
-        image: quay.io/cloud-bulldozer/sampleapp:latest
+      - name: sampleapp
+        image: quay.io/cloud-bulldozer/curl:latest
         command: ["sleep", "infinity"]
+        {{ if .httpServerAddress }}
+        readinessProbe:
+          exec:
+            command: ["/bin/sh", "-c", "curl -f -sS http://{{.httpServerAddress}}/1024.html"]
+          periodSeconds: 1
         {{ end }}
         resources:
           requests:

--- a/cmd/config/cudn-density/deployment-app.yml
+++ b/cmd/config/cudn-density/deployment-app.yml
@@ -39,7 +39,10 @@ spec:
         {{ if .httpServerAddress }}
         readinessProbe:
           exec:
-            command: ["curl -f -sS http://{{.httpServerAddress}}/1024.html"]
+            command:
+            - "/bin/sh"
+            - "-c"
+            - "curl -f -sS http://{{.httpServerAddress}}/1024.html"
           periodSeconds: 1
           timeoutSeconds: 5
           failureThreshold: 1

--- a/cmd/config/cudn-density/egressfirewall.yml
+++ b/cmd/config/cudn-density/egressfirewall.yml
@@ -39,6 +39,12 @@ spec:
     {{- end }}
   {{- end }}
 {{ end }}
+{{ if .httpServerIP }}
+  # HTTP server
+  - type: Allow
+    to:
+      cidrSelector: {{.httpServerIP}}/32
+{{ end }}
   # Cluster DNS
   - type: Allow
     to:

--- a/cmd/config/cudn-density/np-allow-app-egress.yml
+++ b/cmd/config/cudn-density/np-allow-app-egress.yml
@@ -41,6 +41,14 @@ spec:
       port: http
     - protocol: TCP
       port: https
+  {{ if .httpServerIP }}
+  - to:
+    - ipBlock:
+        cidr: {{.httpServerIP}}/32
+    ports:
+    - protocol: TCP
+      port: {{.httpServerPort}}
+  {{ end }}
   # Allow DNS resolution
   - to: []
     ports:

--- a/cmd/config/scripts/cudn_nginx.sh
+++ b/cmd/config/scripts/cudn_nginx.sh
@@ -12,7 +12,7 @@ case "$ACTION" in
       exit 1
     fi
     echo "Setting up nginx HTTP server on ${HTTP_SERVER_ADDRESS}..."
-    podman rm -f "$CONTAINER_NAME" 2>/dev/null || true
+    podman rm -f -t 0 "$CONTAINER_NAME" 2>/dev/null || true
     podman run -d --name "$CONTAINER_NAME" -p "${HTTP_SERVER_ADDRESS}:8080" quay.io/cloud-bulldozer/nginx:latest
     echo "nginx HTTP server is running on ${HTTP_SERVER_ADDRESS}"
     ;;
@@ -27,6 +27,6 @@ esac
 
 cleanup() {
   echo "Cleaning up nginx HTTP server..."
-  podman rm -f "$CONTAINER_NAME" 2>/dev/null || true
+  podman rm -f -t 0 "$CONTAINER_NAME" 2>/dev/null || true
   echo "nginx HTTP server cleaned up"
 }

--- a/cmd/config/scripts/cudn_nginx.sh
+++ b/cmd/config/scripts/cudn_nginx.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 ACTION=${1:-""}
 HTTP_SERVER_ADDRESS=${2:-""}
 CONTAINER_NAME="cudn-nginx"

--- a/cmd/config/scripts/cudn_nginx.sh
+++ b/cmd/config/scripts/cudn_nginx.sh
@@ -6,6 +6,12 @@ ACTION=${1:-""}
 HTTP_SERVER_ADDRESS=${2:-""}
 CONTAINER_NAME="cudn-nginx"
 
+cleanup() {
+  echo "Cleaning up nginx HTTP server..."
+  podman rm -f -t 0 "$CONTAINER_NAME" 2>/dev/null || true
+  echo "nginx HTTP server cleaned up"
+}
+
 case "$ACTION" in
   setup)
     cleanup
@@ -14,7 +20,6 @@ case "$ACTION" in
       exit 1
     fi
     echo "Setting up nginx HTTP server on ${HTTP_SERVER_ADDRESS}..."
-    podman rm -f -t 0 "$CONTAINER_NAME" 2>/dev/null || true
     podman run -d --name "$CONTAINER_NAME" -p "${HTTP_SERVER_ADDRESS}:8080" quay.io/cloud-bulldozer/nginx:latest
     echo "nginx HTTP server is running on ${HTTP_SERVER_ADDRESS}"
     ;;
@@ -26,9 +31,3 @@ case "$ACTION" in
     exit 1
     ;;
 esac
-
-cleanup() {
-  echo "Cleaning up nginx HTTP server..."
-  podman rm -f -t 0 "$CONTAINER_NAME" 2>/dev/null || true
-  echo "nginx HTTP server cleaned up"
-}

--- a/cmd/config/scripts/cudn_nginx.sh
+++ b/cmd/config/scripts/cudn_nginx.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+ACTION=${1:-""}
+HTTP_SERVER_ADDRESS=${2:-""}
+CONTAINER_NAME="cudn-nginx"
+
+case "$ACTION" in
+  setup)
+    cleanup
+    if [[ -z "$HTTP_SERVER_ADDRESS" ]]; then
+      echo "ERROR: HTTP_SERVER_ADDRESS (ip:port) is required as second argument"
+      exit 1
+    fi
+    echo "Setting up nginx HTTP server on ${HTTP_SERVER_ADDRESS}..."
+    podman rm -f "$CONTAINER_NAME" 2>/dev/null || true
+    podman run -d --name "$CONTAINER_NAME" -p "${HTTP_SERVER_ADDRESS}:8080" quay.io/cloud-bulldozer/nginx:latest
+    echo "nginx HTTP server is running on ${HTTP_SERVER_ADDRESS}"
+    ;;
+  cleanup)
+    cleanup
+    ;;
+  *)
+    echo "Usage: $0 {setup|cleanup} [ip:port]"
+    exit 1
+    ;;
+esac
+
+cleanup() {
+  echo "Cleaning up nginx HTTP server..."
+  podman rm -f "$CONTAINER_NAME" 2>/dev/null || true
+  echo "nginx HTTP server cleaned up"
+}

--- a/pkg/workloads/cudn-density.go
+++ b/pkg/workloads/cudn-density.go
@@ -99,7 +99,7 @@ func getNodeGatewayMap() string {
 
 // NewCudnDensity holds cudn-density workload
 func NewCudnDensity(wh *workloads.WorkloadHelper) *cobra.Command {
-	var churnPercent, churnCycles, iterations, namespacesPerCudn, cudnsPerRA, incrementalStepSize, httpLoadTestRate int
+	var churnPercent, churnCycles, iterations, namespacesPerCudn, cudnsPerRA, incrementalStepSize int
 	var incrementalExpBase float64
 	var deletionStrategy string
 	var l3, pprof, gatewayCheck, bgp, ocpbugs85627Workaround bool
@@ -190,7 +190,6 @@ func NewCudnDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 			AdditionalVars["OCPBUGS_85627_WORKAROUND"] = ocpbugs85627Workaround
 			AdditionalVars["DELETION_STRATEGY"] = deletionStrategy
 			AdditionalVars["HTTP_SERVER_ADDRESS"] = httpServerAddress
-			AdditionalVars["HTTP_LOAD_TEST_RATE"] = httpLoadTestRate
 			if httpServerAddress != "" {
 				httpServerIP, httpServerPort, _ := net.SplitHostPort(httpServerAddress)
 				AdditionalVars["HTTP_SERVER_IP"] = httpServerIP
@@ -230,8 +229,7 @@ func NewCudnDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().BoolVar(&gatewayCheck, "gateway-check", false, "Enable default gateway reachability check from each namespace")
 	cmd.Flags().BoolVar(&ocpbugs85627Workaround, "static-mac-binding-workaround", false, "Deploy OCPBUGS-85627 static MAC binding workaround DaemonSet before creating CUDNs")
 	cmd.Flags().StringVar(&deletionStrategy, "deletion-strategy", config.DefaultDeletionStrategy, "GC deletion mode, default deletes entire namespaces and gvr deletes objects within namespaces before deleting the parent namespace")
-	cmd.Flags().StringVar(&httpServerAddress, "http-server-address", "", "Deploy nginx on bastion at this ip:port and run hloader HTTP load tests against it")
-	cmd.Flags().IntVar(&httpLoadTestRate, "http-load-test-rate", 10, "Requests per second per hloader pod (0 = unlimited)")
+	cmd.Flags().StringVar(&httpServerAddress, "http-server-address", "", "Deploy nginx on bastion at this ip:port and use it in workload's readiness probes")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
 	cmd.MarkFlagRequired("iterations")
 	return cmd

--- a/pkg/workloads/cudn-density.go
+++ b/pkg/workloads/cudn-density.go
@@ -17,6 +17,7 @@ package workloads
 import (
 	"context"
 	"encoding/json"
+	"net"
 	"os"
 	"time"
 
@@ -98,12 +99,12 @@ func getNodeGatewayMap() string {
 
 // NewCudnDensity holds cudn-density workload
 func NewCudnDensity(wh *workloads.WorkloadHelper) *cobra.Command {
-	var churnPercent, churnCycles, iterations, namespacesPerCudn, cudnsPerRA, incrementalStepSize int
+	var churnPercent, churnCycles, iterations, namespacesPerCudn, cudnsPerRA, incrementalStepSize, httpLoadTestRate int
 	var incrementalExpBase float64
 	var deletionStrategy string
 	var l3, pprof, gatewayCheck, bgp, ocpbugs85627Workaround bool
 	var churnDelay, churnDuration, podReadyThreshold, pprofInterval, jobPause, incrementalStepDelay time.Duration
-	var churnMode, incrementalPattern string
+	var churnMode, incrementalPattern, httpServerAddress string
 	var metricsProfiles []string
 	var rc int
 	cmd := &cobra.Command{
@@ -146,6 +147,11 @@ func NewCudnDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 					log.Fatal("incremental load and churn cannot be used together")
 				}
 			}
+			if httpServerAddress != "" {
+				if _, _, err := net.SplitHostPort(httpServerAddress); err != nil {
+					log.Fatalf("--http-server-address must be in ip:port format, got '%s': %v", httpServerAddress, err)
+				}
+			}
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			setMetrics(cmd, metricsProfiles)
@@ -183,6 +189,16 @@ func NewCudnDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 			AdditionalVars["BGP"] = bgp
 			AdditionalVars["OCPBUGS_85627_WORKAROUND"] = ocpbugs85627Workaround
 			AdditionalVars["DELETION_STRATEGY"] = deletionStrategy
+			AdditionalVars["HTTP_SERVER_ADDRESS"] = httpServerAddress
+			AdditionalVars["HTTP_LOAD_TEST_RATE"] = httpLoadTestRate
+			if httpServerAddress != "" {
+				httpServerIP, httpServerPort, _ := net.SplitHostPort(httpServerAddress)
+				AdditionalVars["HTTP_SERVER_IP"] = httpServerIP
+				AdditionalVars["HTTP_SERVER_PORT"] = httpServerPort
+			} else {
+				AdditionalVars["HTTP_SERVER_IP"] = ""
+				AdditionalVars["HTTP_SERVER_PORT"] = ""
+			}
 			if gatewayCheck {
 				AdditionalVars["NODE_GW_MAP"] = getNodeGatewayMap()
 			}
@@ -214,6 +230,8 @@ func NewCudnDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().BoolVar(&gatewayCheck, "gateway-check", false, "Enable default gateway reachability check from each namespace")
 	cmd.Flags().BoolVar(&ocpbugs85627Workaround, "static-mac-binding-workaround", false, "Deploy OCPBUGS-85627 static MAC binding workaround DaemonSet before creating CUDNs")
 	cmd.Flags().StringVar(&deletionStrategy, "deletion-strategy", config.DefaultDeletionStrategy, "GC deletion mode, default deletes entire namespaces and gvr deletes objects within namespaces before deleting the parent namespace")
+	cmd.Flags().StringVar(&httpServerAddress, "http-server-address", "", "Deploy nginx on bastion at this ip:port and run hloader HTTP load tests against it")
+	cmd.Flags().IntVar(&httpLoadTestRate, "http-load-test-rate", 10, "Requests per second per hloader pod (0 = unlimited)")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
 	cmd.MarkFlagRequired("iterations")
 	return cmd


### PR DESCRIPTION
This pull request adds support for deploying and integrating an external HTTP server (nginx) into the cudn-density workload for readiness and network testing. The main changes introduce a new `--http-server-address` option, update configuration templates to pass the server's IP and port, and ensure network policies and deployments are aware of the HTTP server when enabled.

**HTTP Server Integration**

* Added a new `--http-server-address` CLI flag to `cudn-density` that, when set, deploys an nginx HTTP server at the specified address using the new `cudn_nginx.sh` script. The address is validated to be in `ip:port` format. (`pkg/workloads/cudn-density.go`, `cmd/config/scripts/cudn_nginx.sh`) [[1]](diffhunk://#diff-1a9c80eb6a49d5cd4440269ef1a45e631ce1f9a6f49e897eeceaaeb99c039576L106-R107) [[2]](diffhunk://#diff-1a9c80eb6a49d5cd4440269ef1a45e631ce1f9a6f49e897eeceaaeb99c039576R150-R154) [[3]](diffhunk://#diff-1a9c80eb6a49d5cd4440269ef1a45e631ce1f9a6f49e897eeceaaeb99c039576R192-R200) [[4]](diffhunk://#diff-1a9c80eb6a49d5cd4440269ef1a45e631ce1f9a6f49e897eeceaaeb99c039576R232) [[5]](diffhunk://#diff-573b301c1b50166b80f8d325203aebcaa20db5b770cfa942b9504bc26b2776c9R1-R32)

* The workload configuration (`cudn-density.yml`) now conditionally includes hooks to set up and clean up the nginx server before and after job execution, and passes the HTTP server IP/port variables to relevant templates. [[1]](diffhunk://#diff-05ea7a77d4e30ed7c4e79f071ecec8516905182a7e5062a0c61feadd994d41d3R123-R129) [[2]](diffhunk://#diff-05ea7a77d4e30ed7c4e79f071ecec8516905182a7e5062a0c61feadd994d41d3R239-R242) [[3]](diffhunk://#diff-05ea7a77d4e30ed7c4e79f071ecec8516905182a7e5062a0c61feadd994d41d3R251-R253) [[4]](diffhunk://#diff-05ea7a77d4e30ed7c4e79f071ecec8516905182a7e5062a0c61feadd994d41d3R290)

**Network Policy and Deployment Updates**

* Network policy templates (`np-allow-app-egress.yml`, `egressfirewall.yml`) now allow egress to the HTTP server IP and port when the feature is enabled. [[1]](diffhunk://#diff-618f77009d97048c1965202633b7c4f3054008ab17309b515587ae2ab0e01eaaR44-R51) [[2]](diffhunk://#diff-b0ae82fc8f9bf85f87d919f2529ccce29cc2ffa2878eab115200523acdedbe64R41-R46)

* The sample application deployment (`deployment-app.yml`) switches to a `curl`-based image and, if the HTTP server is set, adds a readiness probe that checks connectivity to the server.

**Minor/Supporting Changes**

* Added Go `net` import to support address parsing.
* Minor whitespace/formatting changes in configuration templates.

These changes make it possible to use an external HTTP server for readiness probes and network policy validation within the cudn-density workload.