### PR TITLE
Fix batch-churn ci issues

### DIFF
--- a/test/test-ocp.bats
+++ b/test/test-ocp.bats
@@ -257,7 +257,7 @@ teardown_file() {
     STORAGE_PARAMETER="--storage-class ${KUBE_BURNER_OCP_STORAGE_CLASS}"
   fi
   run_cmd ${KUBE_BURNER_OCP} virt-capacity-benchmark ${STORAGE_PARAMETER} --max-iterations 2  --data-volume-count 2 --vms 2 --skip-migration-job --skip-resize-job
-  run_cmd kube-burner-ocp virt-capacity-benchmark --cleanup-only
+  run_cmd ${KUBE_BURNER_OCP} virt-capacity-benchmark --cleanup-only
   for iteration in 0 1; do
     check_metric_recorded ./virt-capacity-benchmark/iteration-${iteration} create-vms-${iteration} vmiLatency vmReadyLatency
     check_quantile_recorded ./virt-capacity-benchmark/iteration-${iteration} create-vms-${iteration} vmiLatency VMReady
@@ -277,7 +277,7 @@ teardown_file() {
     STORAGE_PARAMETER="--storage-class ${KUBE_BURNER_OCP_STORAGE_CLASS}"
   fi
   run_cmd ${KUBE_BURNER_OCP} virt-parallel ${STORAGE_PARAMETER} --max-iterations 2 --data-volume-count 2 --initial-vms 2 --increment 2 --skip-migration-job --skip-resize-job
-  run_cmd kube-burner-ocp virt-parallel --cleanup-only
+  run_cmd ${KUBE_BURNER_OCP} virt-parallel --cleanup-only
   for iteration in 0 1; do
     check_metric_recorded ./virt-parallel/iteration-${iteration} virt-parallel-create-vms-${iteration} vmiLatency vmReadyLatency
     check_quantile_recorded ./virt-parallel/iteration-${iteration} virt-parallel-create-vms-${iteration} vmiLatency VMReady
@@ -390,8 +390,9 @@ teardown_file() {
 
 # bats test_tags=workload:batch-churn
 @test "batch-churn: basic execution with churn" {
+  cd ../../cmd/config/batch-churn
   run_cmd ${KUBE_BURNER_OCP} init \
-    -c ../../cmd/config/batch-churn/config.yml \
+    -c config.yml \
     --iterations=2 \
     --churn-cycles=1 \
     --churn-delay=5s \
@@ -413,8 +414,9 @@ teardown_file() {
 
 # bats test_tags=workload:batch-churn
 @test "batch-churn: watcher-spam mode" {
+  cd ../../cmd/config/batch-churn
   run_cmd ${KUBE_BURNER_OCP} init \
-    -c ../../cmd/config/batch-churn/config.yml \
+    -c config.yml \
     --iterations=1 \
     --set WATCHER_MODE=true \
     --set SECRET_WATCHERS=10 \


### PR DESCRIPTION
This pull request makes several updates to the OpenShift Container Platform (OCP) workload test configurations and test scripts. 

**Test script improvements:**

* Updated the test commands in `test/test-ocp.bats` to consistently use the `${KUBE_BURNER_OCP}` environment variable instead of hardcoding the binary name, which ensures the correct binary is always used and improves maintainability. [[1]](diffhunk://#diff-d29afb01f137d0b918709aad0ffb7cfe9c27114fc29cba1c4ff1b5dbfedd1b9aL260-R260) [[2]](diffhunk://#diff-d29afb01f137d0b918709aad0ffb7cfe9c27114fc29cba1c4ff1b5dbfedd1b9aL280-R280)
* Changed the working directory and updated the configuration file path for the `batch-churn` workload tests to use a relative path (`config.yml`), improving portability and script clarity. [[1]](diffhunk://#diff-d29afb01f137d0b918709aad0ffb7cfe9c27114fc29cba1c4ff1b5dbfedd1b9aR393-R395) [[2]](diffhunk://#diff-d29afb01f137d0b918709aad0ffb7cfe9c27114fc29cba1c4ff1b5dbfedd1b9aR417-R419)