### PR TITLE
Add node-selector flag to virt workloads

### DIFF
--- a/cmd/config/virt-capacity-benchmark/templates/vm.yml
+++ b/cmd/config/virt-capacity-benchmark/templates/vm.yml
@@ -54,12 +54,9 @@ spec:
   runStrategy: RerunOnFailure
   template:
     spec:
-      {{- if .nodeSelector }}
-      nodeSelector:
-      {{- range $key, $value := .nodeSelector }}
-        {{ $key }}: {{ $value }}
-      {{- end }}
-      {{- end }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution: {{.NODE_SELECTOR|toJson}}
       accessCredentials:
       - sshPublicKey:
           propagationMethod:

--- a/cmd/config/virt-capacity-benchmark/templates/vm.yml
+++ b/cmd/config/virt-capacity-benchmark/templates/vm.yml
@@ -54,6 +54,12 @@ spec:
   runStrategy: RerunOnFailure
   template:
     spec:
+      {{- if .nodeSelector }}
+      nodeSelector:
+      {{- range $key, $value := .nodeSelector }}
+        {{ $key }}: {{ $value }}
+      {{- end }}
+      {{- end }}
       accessCredentials:
       - sshPublicKey:
           propagationMethod:

--- a/cmd/config/virt-capacity-benchmark/virt-capacity-benchmark.yml
+++ b/cmd/config/virt-capacity-benchmark/virt-capacity-benchmark.yml
@@ -117,10 +117,7 @@ jobs:
       - {{ . }}
       {{ end }}
       accessMode: {{ .skipMigrationJob | ternary "ReadWriteOnce" "ReadWriteMany"}}
-      nodeSelector:
-      {{- range $key, $value := .nodeSelector }}
-        {{ $key }}: {{ $value }}
-      {{- end }}
+      NODE_SELECTOR: {{ .NODE_SELECTOR }}
 
 {{ if not .skipResizeJob }}
 - name: resize-volumes-{{ .counter }}

--- a/cmd/config/virt-capacity-benchmark/virt-capacity-benchmark.yml
+++ b/cmd/config/virt-capacity-benchmark/virt-capacity-benchmark.yml
@@ -117,6 +117,10 @@ jobs:
       - {{ . }}
       {{ end }}
       accessMode: {{ .skipMigrationJob | ternary "ReadWriteOnce" "ReadWriteMany"}}
+      nodeSelector:
+      {{- range $key, $value := .nodeSelector }}
+        {{ $key }}: {{ $value }}
+      {{- end }}
 
 {{ if not .skipResizeJob }}
 - name: resize-volumes-{{ .counter }}

--- a/cmd/config/virt-clone-multi/templates/vm.yml
+++ b/cmd/config/virt-clone-multi/templates/vm.yml
@@ -39,6 +39,12 @@ spec:
   runStrategy: RerunOnFailure
   template:
     spec:
+      {{- if .nodeSelector }}
+      nodeSelector:
+      {{- range $key, $value := .nodeSelector }}
+        {{ $key }}: {{ $value }}
+      {{- end }}
+      {{- end }}
       accessCredentials:
       - sshPublicKey:
           propagationMethod:

--- a/cmd/config/virt-clone-multi/templates/vm.yml
+++ b/cmd/config/virt-clone-multi/templates/vm.yml
@@ -39,12 +39,9 @@ spec:
   runStrategy: RerunOnFailure
   template:
     spec:
-      {{- if .nodeSelector }}
-      nodeSelector:
-      {{- range $key, $value := .nodeSelector }}
-        {{ $key }}: {{ $value }}
-      {{- end }}
-      {{- end }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution: {{.NODE_SELECTOR|toJson}}
       accessCredentials:
       - sshPublicKey:
           propagationMethod:

--- a/cmd/config/virt-clone-multi/virt-clone-multi.yml
+++ b/cmd/config/virt-clone-multi/virt-clone-multi.yml
@@ -85,10 +85,7 @@ jobs:
       sshPublicKeySecret: {{ $sshPublicKeySecretName }}
       accessMode: {{ .accessMode }}
       dataVolumeCounters: []
-      nodeSelector:
-      {{- range $key, $value := .nodeSelector }}
-        {{ $key }}: {{ $value }}
-      {{- end }}
+      NODE_SELECTOR: {{ .NODE_SELECTOR }}
 
 # Stop all N base VMs
 - name: {{ $testName }}-stop-vm

--- a/cmd/config/virt-clone-multi/virt-clone-multi.yml
+++ b/cmd/config/virt-clone-multi/virt-clone-multi.yml
@@ -85,6 +85,10 @@ jobs:
       sshPublicKeySecret: {{ $sshPublicKeySecretName }}
       accessMode: {{ .accessMode }}
       dataVolumeCounters: []
+      nodeSelector:
+      {{- range $key, $value := .nodeSelector }}
+        {{ $key }}: {{ $value }}
+      {{- end }}
 
 # Stop all N base VMs
 - name: {{ $testName }}-stop-vm

--- a/cmd/config/virt-clone-multi/virt-clone-multi.yml
+++ b/cmd/config/virt-clone-multi/virt-clone-multi.yml
@@ -200,6 +200,7 @@ jobs:
       iterationsPerNamespace: {{ .iterations }}
       storageClassName: {{ .storageClassName }}
       accessMode: {{ .accessMode }}
+      NODE_SELECTOR: {{ .NODE_SELECTOR }}
       dataVolumeCounters:
       {{ range .dataVolumeCounters }}
       - {{ . }}

--- a/cmd/config/virt-clone/templates/vm.yml
+++ b/cmd/config/virt-clone/templates/vm.yml
@@ -37,12 +37,9 @@ spec:
   runStrategy: RerunOnFailure
   template:
     spec:
-      {{- if .nodeSelector }}
-      nodeSelector:
-      {{- range $key, $value := .nodeSelector }}
-        {{ $key }}: {{ $value }}
-      {{- end }}
-      {{- end }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution: {{.NODE_SELECTOR|toJson}}
       accessCredentials:
       - sshPublicKey:
           propagationMethod:

--- a/cmd/config/virt-clone/templates/vm.yml
+++ b/cmd/config/virt-clone/templates/vm.yml
@@ -37,6 +37,12 @@ spec:
   runStrategy: RerunOnFailure
   template:
     spec:
+      {{- if .nodeSelector }}
+      nodeSelector:
+      {{- range $key, $value := .nodeSelector }}
+        {{ $key }}: {{ $value }}
+      {{- end }}
+      {{- end }}
       accessCredentials:
       - sshPublicKey:
           propagationMethod:

--- a/cmd/config/virt-clone/virt-clone.yml
+++ b/cmd/config/virt-clone/virt-clone.yml
@@ -91,10 +91,7 @@ jobs:
       sshPublicKeySecret: {{ $sshPublicKeySecretName }}
       accessMode: {{ .accessMode }}
       dataVolumeCounters: []
-      nodeSelector:
-      {{- range $key, $value := .nodeSelector }}
-        {{ $key }}: {{ $value }}
-      {{- end }}
+      NODE_SELECTOR: {{ .NODE_SELECTOR }}
 
 - name: stop-vm
   jobType: kubevirt

--- a/cmd/config/virt-clone/virt-clone.yml
+++ b/cmd/config/virt-clone/virt-clone.yml
@@ -239,6 +239,7 @@ jobs:
       storageClassName: {{ .storageClassName }}
       sshPublicKeySecret: {{ $sshPublicKeySecretName }}
       accessMode: {{ .accessMode }}
+      NODE_SELECTOR: {{ .NODE_SELECTOR }}
       dataVolumeCounters:
       {{ range .dataVolumeCounters }}
       - {{ . }}

--- a/cmd/config/virt-clone/virt-clone.yml
+++ b/cmd/config/virt-clone/virt-clone.yml
@@ -91,6 +91,10 @@ jobs:
       sshPublicKeySecret: {{ $sshPublicKeySecretName }}
       accessMode: {{ .accessMode }}
       dataVolumeCounters: []
+      nodeSelector:
+      {{- range $key, $value := .nodeSelector }}
+        {{ $key }}: {{ $value }}
+      {{- end }}
 
 - name: stop-vm
   jobType: kubevirt

--- a/cmd/config/virt-density/virt-density.yml
+++ b/cmd/config/virt-density/virt-density.yml
@@ -90,6 +90,10 @@ jobs:
           vmImage: {{.VM_IMAGE}}
           vmCPU: {{.VM_CPU}}
           vmMemory: {{.VM_MEMORY}}
+          nodeSelector:
+          {{- range $key, $value := .nodeSelector }}
+            {{ $key }}: {{ $value }}
+          {{- end }}
 {{ else }}
       - objectTemplate: vm-nomnt.yml
         replicas: 1
@@ -97,5 +101,9 @@ jobs:
           vmImage: {{.VM_IMAGE}}
           vmCPU: {{.VM_CPU}}
           vmMemory: {{.VM_MEMORY}}
+          nodeSelector:
+          {{- range $key, $value := .nodeSelector }}
+            {{ $key }}: {{ $value }}
+          {{- end }}
 {{ end }}
 {{ end }}

--- a/cmd/config/virt-density/virt-density.yml
+++ b/cmd/config/virt-density/virt-density.yml
@@ -90,10 +90,7 @@ jobs:
           vmImage: {{.VM_IMAGE}}
           vmCPU: {{.VM_CPU}}
           vmMemory: {{.VM_MEMORY}}
-          nodeSelector:
-          {{- range $key, $value := .nodeSelector }}
-            {{ $key }}: {{ $value }}
-          {{- end }}
+          NODE_SELECTOR: {{ .NODE_SELECTOR }}
 {{ else }}
       - objectTemplate: vm-nomnt.yml
         replicas: 1
@@ -101,9 +98,6 @@ jobs:
           vmImage: {{.VM_IMAGE}}
           vmCPU: {{.VM_CPU}}
           vmMemory: {{.VM_MEMORY}}
-          nodeSelector:
-          {{- range $key, $value := .nodeSelector }}
-            {{ $key }}: {{ $value }}
-          {{- end }}
+          NODE_SELECTOR: {{ .NODE_SELECTOR }}
 {{ end }}
 {{ end }}

--- a/cmd/config/virt-density/vm-nomnt.yml
+++ b/cmd/config/virt-density/vm-nomnt.yml
@@ -9,12 +9,9 @@ spec:
       labels:
         kubevirt.io/os: fedora
     spec:
-      {{- if .nodeSelector }}
-      nodeSelector:
-      {{- range $key, $value := .nodeSelector }}
-        {{ $key }}: {{ $value }}
-      {{- end }}
-      {{- end }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution: {{.NODE_SELECTOR|toJson}}
       terminationGracePeriodSeconds: 0
       domain:
         cpu:

--- a/cmd/config/virt-density/vm-nomnt.yml
+++ b/cmd/config/virt-density/vm-nomnt.yml
@@ -9,6 +9,12 @@ spec:
       labels:
         kubevirt.io/os: fedora
     spec:
+      {{- if .nodeSelector }}
+      nodeSelector:
+      {{- range $key, $value := .nodeSelector }}
+        {{ $key }}: {{ $value }}
+      {{- end }}
+      {{- end }}
       terminationGracePeriodSeconds: 0
       domain:
         cpu:

--- a/cmd/config/virt-density/vm.yml
+++ b/cmd/config/virt-density/vm.yml
@@ -9,12 +9,9 @@ spec:
       labels:
         kubevirt.io/os: fedora
     spec:
-      {{- if .nodeSelector }}
-      nodeSelector:
-      {{- range $key, $value := .nodeSelector }}
-        {{ $key }}: {{ $value }}
-      {{- end }}
-      {{- end }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution: {{.NODE_SELECTOR|toJson}}
       terminationGracePeriodSeconds: 0
       domain:
         cpu:

--- a/cmd/config/virt-density/vm.yml
+++ b/cmd/config/virt-density/vm.yml
@@ -9,6 +9,12 @@ spec:
       labels:
         kubevirt.io/os: fedora
     spec:
+      {{- if .nodeSelector }}
+      nodeSelector:
+      {{- range $key, $value := .nodeSelector }}
+        {{ $key }}: {{ $value }}
+      {{- end }}
+      {{- end }}
       terminationGracePeriodSeconds: 0
       domain:
         cpu:

--- a/cmd/config/virt-ephemeral-restart/templates/vm.yml
+++ b/cmd/config/virt-ephemeral-restart/templates/vm.yml
@@ -25,6 +25,12 @@ spec:
   runStrategy: RerunOnFailure
   template:
     spec:
+      {{- if .nodeSelector }}
+      nodeSelector:
+      {{- range $key, $value := .nodeSelector }}
+        {{ $key }}: {{ $value }}
+      {{- end }}
+      {{- end }}
       accessCredentials:
       - sshPublicKey:
           propagationMethod:

--- a/cmd/config/virt-ephemeral-restart/templates/vm.yml
+++ b/cmd/config/virt-ephemeral-restart/templates/vm.yml
@@ -25,12 +25,9 @@ spec:
   runStrategy: RerunOnFailure
   template:
     spec:
-      {{- if .nodeSelector }}
-      nodeSelector:
-      {{- range $key, $value := .nodeSelector }}
-        {{ $key }}: {{ $value }}
-      {{- end }}
-      {{- end }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution: {{.NODE_SELECTOR|toJson}}
       accessCredentials:
       - sshPublicKey:
           propagationMethod:

--- a/cmd/config/virt-ephemeral-restart/virt-ephemeral-restart.yml
+++ b/cmd/config/virt-ephemeral-restart/virt-ephemeral-restart.yml
@@ -164,6 +164,10 @@ jobs:
       storageClassName: {{ .storageClassName }}
       sshPublicKeySecret: {{ $sshPublicKeySecretName }}
       accessMode: {{ .accessMode }}
+      nodeSelector:
+      {{- range $key, $value := .nodeSelector }}
+        {{ $key }}: {{ $value }}
+      {{- end }}
 
 - name: stop-ephemeral-vms
   jobType: kubevirt

--- a/cmd/config/virt-ephemeral-restart/virt-ephemeral-restart.yml
+++ b/cmd/config/virt-ephemeral-restart/virt-ephemeral-restart.yml
@@ -164,10 +164,7 @@ jobs:
       storageClassName: {{ .storageClassName }}
       sshPublicKeySecret: {{ $sshPublicKeySecretName }}
       accessMode: {{ .accessMode }}
-      nodeSelector:
-      {{- range $key, $value := .nodeSelector }}
-        {{ $key }}: {{ $value }}
-      {{- end }}
+      NODE_SELECTOR: {{ .NODE_SELECTOR }}
 
 - name: stop-ephemeral-vms
   jobType: kubevirt

--- a/cmd/config/virt-parallel/templates/vm.yml
+++ b/cmd/config/virt-parallel/templates/vm.yml
@@ -54,12 +54,9 @@ spec:
   runStrategy: RerunOnFailure
   template:
     spec:
-      {{- if .nodeSelector }}
-      nodeSelector:
-      {{- range $key, $value := .nodeSelector }}
-        {{ $key }}: {{ $value }}
-      {{- end }}
-      {{- end }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution: {{.NODE_SELECTOR|toJson}}
       accessCredentials:
       - sshPublicKey:
           propagationMethod:

--- a/cmd/config/virt-parallel/templates/vm.yml
+++ b/cmd/config/virt-parallel/templates/vm.yml
@@ -54,6 +54,12 @@ spec:
   runStrategy: RerunOnFailure
   template:
     spec:
+      {{- if .nodeSelector }}
+      nodeSelector:
+      {{- range $key, $value := .nodeSelector }}
+        {{ $key }}: {{ $value }}
+      {{- end }}
+      {{- end }}
       accessCredentials:
       - sshPublicKey:
           propagationMethod:

--- a/cmd/config/virt-parallel/virt-parallel.yml
+++ b/cmd/config/virt-parallel/virt-parallel.yml
@@ -117,6 +117,10 @@ jobs:
       - {{ . }}
       {{ end }}
       accessMode: {{ .skipMigrationJob | ternary "ReadWriteOnce" "ReadWriteMany"}}
+      nodeSelector:
+      {{- range $key, $value := .nodeSelector }}
+        {{ $key }}: {{ $value }}
+      {{- end }}
 
 {{ if not .skipResizeJob }}
 - name: {{ $testName }}-resize-volumes-{{ .counter }}

--- a/cmd/config/virt-parallel/virt-parallel.yml
+++ b/cmd/config/virt-parallel/virt-parallel.yml
@@ -117,10 +117,7 @@ jobs:
       - {{ . }}
       {{ end }}
       accessMode: {{ .skipMigrationJob | ternary "ReadWriteOnce" "ReadWriteMany"}}
-      nodeSelector:
-      {{- range $key, $value := .nodeSelector }}
-        {{ $key }}: {{ $value }}
-      {{- end }}
+      NODE_SELECTOR: {{ .NODE_SELECTOR }}
 
 {{ if not .skipResizeJob }}
 - name: {{ $testName }}-resize-volumes-{{ .counter }}

--- a/cmd/config/virt-udn-density/virt-cudn-density.yml
+++ b/cmd/config/virt-udn-density/virt-cudn-density.yml
@@ -116,6 +116,7 @@ jobs:
           vmImage: {{.VM_IMAGE}}
           vmCPU: {{.VM_CPU}}
           vmMemory: {{.VM_MEMORY}}
+          NODE_SELECTOR: {{ .NODE_SELECTOR }}
       - objectTemplate: vm-server.yml
         replicas: 1
         inputVars:
@@ -123,3 +124,4 @@ jobs:
           vmImage: {{.VM_IMAGE}}
           vmCPU: {{.VM_CPU}}
           vmMemory: {{.VM_MEMORY}}
+          NODE_SELECTOR: {{ .NODE_SELECTOR }}

--- a/cmd/config/virt-udn-density/virt-udn-density.yml
+++ b/cmd/config/virt-udn-density/virt-udn-density.yml
@@ -120,10 +120,7 @@ jobs:
           vmImage: {{.VM_IMAGE}}
           vmCPU: {{.VM_CPU}}
           vmMemory: {{.VM_MEMORY}}
-          nodeSelector:
-          {{- range $key, $value := .nodeSelector }}
-            {{ $key }}: {{ $value }}
-          {{- end }}
+          NODE_SELECTOR: {{ .NODE_SELECTOR }}
       - objectTemplate: vm-server.yml
         replicas: 1
         inputVars:
@@ -131,7 +128,4 @@ jobs:
           vmImage: {{.VM_IMAGE}}
           vmCPU: {{.VM_CPU}}
           vmMemory: {{.VM_MEMORY}}
-          nodeSelector:
-          {{- range $key, $value := .nodeSelector }}
-            {{ $key }}: {{ $value }}
-          {{- end }}
+          NODE_SELECTOR: {{ .NODE_SELECTOR }}

--- a/cmd/config/virt-udn-density/virt-udn-density.yml
+++ b/cmd/config/virt-udn-density/virt-udn-density.yml
@@ -120,6 +120,10 @@ jobs:
           vmImage: {{.VM_IMAGE}}
           vmCPU: {{.VM_CPU}}
           vmMemory: {{.VM_MEMORY}}
+          nodeSelector:
+          {{- range $key, $value := .nodeSelector }}
+            {{ $key }}: {{ $value }}
+          {{- end }}
       - objectTemplate: vm-server.yml
         replicas: 1
         inputVars:
@@ -127,3 +131,7 @@ jobs:
           vmImage: {{.VM_IMAGE}}
           vmCPU: {{.VM_CPU}}
           vmMemory: {{.VM_MEMORY}}
+          nodeSelector:
+          {{- range $key, $value := .nodeSelector }}
+            {{ $key }}: {{ $value }}
+          {{- end }}

--- a/cmd/config/virt-udn-density/vm-client.yml
+++ b/cmd/config/virt-udn-density/vm-client.yml
@@ -12,6 +12,12 @@ spec:
         kubevirt.io/os: fedora
         app: client
     spec:
+      {{- if .nodeSelector }}
+      nodeSelector:
+      {{- range $key, $value := .nodeSelector }}
+        {{ $key }}: {{ $value }}
+      {{- end }}
+      {{- end }}
       terminationGracePeriodSeconds: 0
       domain:
         cpu:

--- a/cmd/config/virt-udn-density/vm-client.yml
+++ b/cmd/config/virt-udn-density/vm-client.yml
@@ -12,12 +12,9 @@ spec:
         kubevirt.io/os: fedora
         app: client
     spec:
-      {{- if .nodeSelector }}
-      nodeSelector:
-      {{- range $key, $value := .nodeSelector }}
-        {{ $key }}: {{ $value }}
-      {{- end }}
-      {{- end }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution: {{.NODE_SELECTOR|toJson}}
       terminationGracePeriodSeconds: 0
       domain:
         cpu:

--- a/cmd/config/virt-udn-density/vm-server.yml
+++ b/cmd/config/virt-udn-density/vm-server.yml
@@ -12,6 +12,12 @@ spec:
         kubevirt.io/os: fedora
         app: nginx
     spec:
+      {{- if .nodeSelector }}
+      nodeSelector:
+      {{- range $key, $value := .nodeSelector }}
+        {{ $key }}: {{ $value }}
+      {{- end }}
+      {{- end }}
       terminationGracePeriodSeconds: 0
       domain:
         cpu:

--- a/cmd/config/virt-udn-density/vm-server.yml
+++ b/cmd/config/virt-udn-density/vm-server.yml
@@ -12,12 +12,9 @@ spec:
         kubevirt.io/os: fedora
         app: nginx
     spec:
-      {{- if .nodeSelector }}
-      nodeSelector:
-      {{- range $key, $value := .nodeSelector }}
-        {{ $key }}: {{ $value }}
-      {{- end }}
-      {{- end }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution: {{.NODE_SELECTOR|toJson}}
       terminationGracePeriodSeconds: 0
       domain:
         cpu:

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -45,12 +45,15 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
 	kubeBurnerTestNameLabelKey = "kube-burner.io/test-name"
+	// WorkerNodeSelector is the default node selector for workloads targeting worker nodes
+	WorkerNodeSelector = "node-role.kubernetes.io/worker=,node-role.kubernetes.io/infra!=,node-role.kubernetes.io/workload!="
 )
 
 var (
@@ -163,24 +166,44 @@ func generateLoopCounterSlice(length, startValue int) []string {
 	return counter
 }
 
-// parseNodeSelector parses a comma-separated string of key=value pairs into a map
-func parseNodeSelector(nodeSelectorStr string) map[string]string {
-	nodeSelector := make(map[string]string)
-	if nodeSelectorStr == "" {
-		return nodeSelector
+// buildNodeSelectorJSON converts a Kubernetes label selector string to a NodeSelector JSON string
+// that can be used in pod affinity specifications. The selector string uses the standard Kubernetes
+// label selector format (e.g., "node-role.kubernetes.io/worker=,node-role.kubernetes.io/infra!=").
+func buildNodeSelectorJSON(selector string) (string, error) {
+	var nodeSelector v1.NodeSelector
+	var matchExpressions []v1.NodeSelectorRequirement
+
+	labelSelector, err := labels.Parse(selector)
+	if err != nil {
+		return "", err
 	}
 
-	pairs := strings.Split(nodeSelectorStr, ",")
-	for _, pair := range pairs {
-		kv := strings.SplitN(strings.TrimSpace(pair), "=", 2)
-		if len(kv) == 2 {
-			nodeSelector[strings.TrimSpace(kv[0])] = strings.TrimSpace(kv[1])
-		} else {
-			log.Fatalf("Invalid node-selector format: %s. Expected key=value", pair)
+	reqList, _ := labelSelector.Requirements()
+	for _, req := range reqList {
+		matchExpression := v1.NodeSelectorRequirement{
+			Key: req.Key(),
 		}
+		// Even with a nil value, the list is not empty, so we need to check its value
+		if req.Values().List()[0] == "" {
+			if req.Operator() == "=" {
+				matchExpression.Operator = v1.NodeSelectorOpExists
+			} else if req.Operator() == "!=" {
+				matchExpression.Operator = v1.NodeSelectorOpDoesNotExist
+			}
+		} else {
+			matchExpression.Operator = v1.NodeSelectorOpIn
+			matchExpression.Values = req.Values().List()
+		}
+		matchExpressions = append(matchExpressions, matchExpression)
 	}
-	log.Infof("Node selector: %v", nodeSelector)
-	return nodeSelector
+
+	nodeSelector.NodeSelectorTerms = []v1.NodeSelectorTerm{{MatchExpressions: matchExpressions}}
+	nodeSelectorJSON, err := json.Marshal(nodeSelector)
+	if err != nil {
+		return "", err
+	}
+
+	return string(nodeSelectorJSON), nil
 }
 
 // addWorkloadFlagsToMetadata adds all flag values from the command to SummaryMetadata

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -163,6 +163,26 @@ func generateLoopCounterSlice(length, startValue int) []string {
 	return counter
 }
 
+// parseNodeSelector parses a comma-separated string of key=value pairs into a map
+func parseNodeSelector(nodeSelectorStr string) map[string]string {
+	nodeSelector := make(map[string]string)
+	if nodeSelectorStr == "" {
+		return nodeSelector
+	}
+
+	pairs := strings.Split(nodeSelectorStr, ",")
+	for _, pair := range pairs {
+		kv := strings.SplitN(strings.TrimSpace(pair), "=", 2)
+		if len(kv) == 2 {
+			nodeSelector[strings.TrimSpace(kv[0])] = strings.TrimSpace(kv[1])
+		} else {
+			log.Fatalf("Invalid node-selector format: %s. Expected key=value", pair)
+		}
+	}
+	log.Infof("Node selector: %v", nodeSelector)
+	return nodeSelector
+}
+
 // addWorkloadFlagsToMetadata adds all flag values from the command to SummaryMetadata
 func addWorkloadFlagsToMetadata(cmd *cobra.Command, wh *workloads.WorkloadHelper) {
 	workloadFlags := make(map[string]string)

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -184,7 +184,8 @@ func buildNodeSelectorJSON(selector string) (string, error) {
 			Key: req.Key(),
 		}
 		// Even with a nil value, the list is not empty, so we need to check its value
-		if req.Values().List()[0] == "" {
+		values := req.Values().List()
+		if len(values) == 0 || values[0] == "" {
 			if req.Operator() == "=" {
 				matchExpression.Operator = v1.NodeSelectorOpExists
 			} else if req.Operator() == "!=" {
@@ -192,7 +193,7 @@ func buildNodeSelectorJSON(selector string) (string, error) {
 			}
 		} else {
 			matchExpression.Operator = v1.NodeSelectorOpIn
-			matchExpression.Values = req.Values().List()
+			matchExpression.Values = values
 		}
 		matchExpressions = append(matchExpressions, matchExpression)
 	}

--- a/pkg/workloads/node-density.go
+++ b/pkg/workloads/node-density.go
@@ -16,7 +16,6 @@ package workloads
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"time"
@@ -25,9 +24,7 @@ import (
 	"github.com/kube-burner/kube-burner/v2/pkg/workloads"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 )
 
 // NewNodeDensity holds node-density workload
@@ -38,9 +35,6 @@ func NewNodeDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Command
 	var podReadyThreshold, churnDuration, churnDelay, probesPeriod, pprofInterval time.Duration
 	var containerImage, deletionStrategy, churnMode, selector, perfProfile, sriovNetworkName string
 	var namespacedIterations, pprof, svcLatency bool
-	var nodeSelector corev1.NodeSelector
-	var matchExpressions []corev1.NodeSelectorRequirement
-	const workerNodeSelector = "node-role.kubernetes.io/worker=,node-role.kubernetes.io/infra!=,node-role.kubernetes.io/workload!="
 	cmd := &cobra.Command{
 		Use:          variant,
 		Short:        fmt.Sprintf("Runs %v workload", variant),
@@ -60,29 +54,10 @@ func NewNodeDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Command
 			if err != nil {
 				log.Fatal(err.Error())
 			}
-			labelSelector, err := labels.Parse(selector)
+			nodeSelectorJSON, err := buildNodeSelectorJSON(selector)
 			if err != nil {
 				log.Fatal(err.Error())
 			}
-			reqList, _ := labelSelector.Requirements()
-			for _, req := range reqList {
-				matchExpression := corev1.NodeSelectorRequirement{
-					Key: req.Key(),
-				}
-				// Even with a nil value, the list is not empty, so we need to check its value
-				if req.Values().List()[0] == "" {
-					if req.Operator() == "=" {
-						matchExpression.Operator = corev1.NodeSelectorOpExists
-					} else if req.Operator() == "!=" {
-						matchExpression.Operator = corev1.NodeSelectorOpDoesNotExist
-					}
-				} else {
-					matchExpression.Operator = corev1.NodeSelectorOpIn
-					matchExpression.Values = req.Values().List()
-				}
-				matchExpressions = append(matchExpressions, matchExpression)
-			}
-			nodeSelector.NodeSelectorTerms = []corev1.NodeSelectorTerm{{MatchExpressions: matchExpressions}}
 			AdditionalVars["CHURN_CYCLES"] = churnCycles
 			AdditionalVars["CHURN_DURATION"] = churnDuration
 			AdditionalVars["CHURN_DELAY"] = churnDelay
@@ -100,11 +75,7 @@ func NewNodeDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Command
 			AdditionalVars["PERF_PROFILE"] = perfProfile
 			AdditionalVars["NUM_SRIOVS"] = numSriovs
 			AdditionalVars["SRIOV_NETWORK_NAME"] = sriovNetworkName
-			nodeSelectorJson, err := json.Marshal(nodeSelector)
-			if err != nil {
-				log.Fatal(err.Error())
-			}
-			AdditionalVars["NODE_SELECTOR"] = string(nodeSelectorJson)
+			AdditionalVars["NODE_SELECTOR"] = nodeSelectorJSON
 			if variant == "node-density" {
 				AdditionalVars["JOB_ITERATIONS"] = totalPods - podCount
 			} else {
@@ -144,6 +115,6 @@ func NewNodeDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Command
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
 	cmd.Flags().BoolVar(&namespacedIterations, "namespaced-iterations", true, "Namespaced iterations")
 	cmd.Flags().IntVar(&iterationsPerNamespace, "iterations-per-namespace", 1000, "Iterations per namespace")
-	cmd.Flags().StringVar(&selector, "selector", workerNodeSelector, "Node selector")
+	cmd.Flags().StringVar(&selector, "selector", WorkerNodeSelector, "Node selector")
 	return cmd
 }

--- a/pkg/workloads/virt-capacity-benchmark.go
+++ b/pkg/workloads/virt-capacity-benchmark.go
@@ -52,7 +52,7 @@ func NewVirtCapacityBenchmark(wh *workloads.WorkloadHelper) *cobra.Command {
 	var skipResizeJob bool
 	var skipRestartJob bool
 	var skipSnapshotJob bool
-	var nodeSelectorStr string
+	var selector string
 	var metricsProfiles []string
 	var cleanup bool
 	var rc int
@@ -127,7 +127,10 @@ func NewVirtCapacityBenchmark(wh *workloads.WorkloadHelper) *cobra.Command {
 				log.Infof("skipSnapshotJob is set to true")
 			}
 
-			nodeSelector := parseNodeSelector(nodeSelectorStr)
+			nodeSelectorJSON, err := buildNodeSelectorJSON(selector)
+			if err != nil {
+				log.Fatal(err.Error())
+			}
 
 			wh.SummaryMetadata["OCPVirtualizationVersion"], err = wh.MetadataAgent.GetOCPVirtualizationVersion()
 			if err != nil {
@@ -145,7 +148,7 @@ func NewVirtCapacityBenchmark(wh *workloads.WorkloadHelper) *cobra.Command {
 			AdditionalVars["skipResizeJob"] = skipResizeJob
 			AdditionalVars["skipRestartJob"] = skipRestartJob
 			AdditionalVars["skipSnapshotJob"] = skipSnapshotJob
-			AdditionalVars["nodeSelector"] = nodeSelector
+			AdditionalVars["NODE_SELECTOR"] = nodeSelectorJSON
 			AdditionalVars["VM_IMAGE"] = vmImage
 			AdditionalVars["VM_CPU"] = vmCPU
 			AdditionalVars["VM_MEMORY"] = vmMemory
@@ -188,9 +191,13 @@ func NewVirtCapacityBenchmark(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().IntVar(&minimalVolumeSize, "min-vol-size", 0, "Minimal volume size - use when enforced or overridden by the StorageClass")
 	cmd.Flags().IntVar(&minimalVolumeIncreaseSize, "min-vol-inc-size", 0, "Minimal volume increment size - use when enforced or overridden by the StorageClass")
 	cmd.Flags().BoolVar(&skipResizeJob, "skip-resize-job", false, "Skip the resize propagation check - For now use when values are propagated in a base of 10 instead of 2")
+<<<<<<< HEAD
 	cmd.Flags().BoolVar(&skipRestartJob, "skip-restart-job", false, "Skip the VM restart job")
 	cmd.Flags().BoolVar(&skipSnapshotJob, "skip-snapshot-job", false, "Skip the VM snapshot job")
 	cmd.Flags().StringVar(&nodeSelectorStr, "node-selector", "", "Node selector labels (comma-separated key=value pairs, e.g., topology.kubernetes.io/zone=us-east-1a,disktype=ssd)")
+=======
+	cmd.Flags().StringVar(&selector, "selector", WorkerNodeSelector, "Node selector")
+>>>>>>> fffefc67 (Signed-off-by: Daniel Dominguez <ddomingu@redhat.com>)
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics-aggregated.yml"}, "Comma separated list of metrics profiles to use")
 	cmd.Flags().BoolVar(&cleanup, "cleanup", false, "Cleanup resources created by previous runs")
 	return cmd

--- a/pkg/workloads/virt-capacity-benchmark.go
+++ b/pkg/workloads/virt-capacity-benchmark.go
@@ -52,6 +52,7 @@ func NewVirtCapacityBenchmark(wh *workloads.WorkloadHelper) *cobra.Command {
 	var skipResizeJob bool
 	var skipRestartJob bool
 	var skipSnapshotJob bool
+	var nodeSelectorStr string
 	var metricsProfiles []string
 	var cleanup bool
 	var rc int
@@ -125,6 +126,9 @@ func NewVirtCapacityBenchmark(wh *workloads.WorkloadHelper) *cobra.Command {
 			if skipSnapshotJob {
 				log.Infof("skipSnapshotJob is set to true")
 			}
+
+			nodeSelector := parseNodeSelector(nodeSelectorStr)
+
 			wh.SummaryMetadata["OCPVirtualizationVersion"], err = wh.MetadataAgent.GetOCPVirtualizationVersion()
 			if err != nil {
 				log.Warnf("Failed to get OCP Virtualization version: %v", err)
@@ -141,6 +145,7 @@ func NewVirtCapacityBenchmark(wh *workloads.WorkloadHelper) *cobra.Command {
 			AdditionalVars["skipResizeJob"] = skipResizeJob
 			AdditionalVars["skipRestartJob"] = skipRestartJob
 			AdditionalVars["skipSnapshotJob"] = skipSnapshotJob
+			AdditionalVars["nodeSelector"] = nodeSelector
 			AdditionalVars["VM_IMAGE"] = vmImage
 			AdditionalVars["VM_CPU"] = vmCPU
 			AdditionalVars["VM_MEMORY"] = vmMemory
@@ -185,6 +190,7 @@ func NewVirtCapacityBenchmark(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().BoolVar(&skipResizeJob, "skip-resize-job", false, "Skip the resize propagation check - For now use when values are propagated in a base of 10 instead of 2")
 	cmd.Flags().BoolVar(&skipRestartJob, "skip-restart-job", false, "Skip the VM restart job")
 	cmd.Flags().BoolVar(&skipSnapshotJob, "skip-snapshot-job", false, "Skip the VM snapshot job")
+	cmd.Flags().StringVar(&nodeSelectorStr, "node-selector", "", "Node selector labels (comma-separated key=value pairs, e.g., topology.kubernetes.io/zone=us-east-1a,disktype=ssd)")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics-aggregated.yml"}, "Comma separated list of metrics profiles to use")
 	cmd.Flags().BoolVar(&cleanup, "cleanup", false, "Cleanup resources created by previous runs")
 	return cmd

--- a/pkg/workloads/virt-capacity-benchmark.go
+++ b/pkg/workloads/virt-capacity-benchmark.go
@@ -191,13 +191,9 @@ func NewVirtCapacityBenchmark(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().IntVar(&minimalVolumeSize, "min-vol-size", 0, "Minimal volume size - use when enforced or overridden by the StorageClass")
 	cmd.Flags().IntVar(&minimalVolumeIncreaseSize, "min-vol-inc-size", 0, "Minimal volume increment size - use when enforced or overridden by the StorageClass")
 	cmd.Flags().BoolVar(&skipResizeJob, "skip-resize-job", false, "Skip the resize propagation check - For now use when values are propagated in a base of 10 instead of 2")
-<<<<<<< HEAD
 	cmd.Flags().BoolVar(&skipRestartJob, "skip-restart-job", false, "Skip the VM restart job")
 	cmd.Flags().BoolVar(&skipSnapshotJob, "skip-snapshot-job", false, "Skip the VM snapshot job")
-	cmd.Flags().StringVar(&nodeSelectorStr, "node-selector", "", "Node selector labels (comma-separated key=value pairs, e.g., topology.kubernetes.io/zone=us-east-1a,disktype=ssd)")
-=======
 	cmd.Flags().StringVar(&selector, "selector", WorkerNodeSelector, "Node selector")
->>>>>>> fffefc67 (Signed-off-by: Daniel Dominguez <ddomingu@redhat.com>)
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics-aggregated.yml"}, "Comma separated list of metrics profiles to use")
 	cmd.Flags().BoolVar(&cleanup, "cleanup", false, "Cleanup resources created by previous runs")
 	return cmd

--- a/pkg/workloads/virt-clone-multi.go
+++ b/pkg/workloads/virt-clone-multi.go
@@ -50,6 +50,7 @@ func NewVirtCloneMulti(wh *workloads.WorkloadHelper) *cobra.Command {
 	var volumeAccessMode string
 	var jobIterationDelay time.Duration
 	var testNamespaceBaseName string
+	var nodeSelectorStr string
 	var metricsProfiles []string
 	var cleanup bool
 	var rc int
@@ -99,6 +100,8 @@ func NewVirtCloneMulti(wh *workloads.WorkloadHelper) *cobra.Command {
 			log.Infof("Using Storage Class [%s], VolumeSnapshotClass [%s]", storageClassName, volumeSnapshotClassName)
 			log.Infof("Use Snapshot: %t", useSnapshot)
 
+			nodeSelector := parseNodeSelector(nodeSelectorStr)
+
 			AdditionalVars["privateKey"] = privateKeyPath
 			AdditionalVars["publicKey"] = publicKeyPath
 			AdditionalVars["storageClassName"] = storageClassName
@@ -111,6 +114,7 @@ func NewVirtCloneMulti(wh *workloads.WorkloadHelper) *cobra.Command {
 			AdditionalVars["jobIterationDelay"] = jobIterationDelay
 			AdditionalVars["dataVolumeCounters"] = generateLoopCounterSlice(dataVolumeCount, 1)
 			AdditionalVars["testNamespaceBaseName"] = testNamespaceBaseName
+			AdditionalVars["nodeSelector"] = nodeSelector
 			AdditionalVars["VM_IMAGE"] = vmImage
 			AdditionalVars["VM_CPU"] = vmCPU
 			AdditionalVars["VM_MEMORY"] = vmMemory
@@ -138,6 +142,7 @@ func NewVirtCloneMulti(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().StringVar(&volumeAccessMode, "access-mode", "RWX", "Access mode for the created volumes - RO, RWO, RWX")
 	cmd.Flags().DurationVar(&jobIterationDelay, "job-iteration-delay", 1*time.Minute, "Delay between namespace iterations")
 	cmd.Flags().StringVarP(&testNamespaceBaseName, "namespace", "n", virtCloneMultiTestName, "Base namespace name for the test")
+	cmd.Flags().StringVar(&nodeSelectorStr, "node-selector", "", "Node selector labels (comma-separated key=value pairs, e.g., topology.kubernetes.io/zone=us-east-1a,disktype=ssd)")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics-aggregated.yml"}, "Comma separated list of metrics profiles to use")
 	cmd.Flags().BoolVar(&cleanup, "cleanup", false, "Cleanup resources created by previous runs")
 

--- a/pkg/workloads/virt-clone-multi.go
+++ b/pkg/workloads/virt-clone-multi.go
@@ -50,7 +50,7 @@ func NewVirtCloneMulti(wh *workloads.WorkloadHelper) *cobra.Command {
 	var volumeAccessMode string
 	var jobIterationDelay time.Duration
 	var testNamespaceBaseName string
-	var nodeSelectorStr string
+	var selector string
 	var metricsProfiles []string
 	var cleanup bool
 	var rc int
@@ -100,7 +100,10 @@ func NewVirtCloneMulti(wh *workloads.WorkloadHelper) *cobra.Command {
 			log.Infof("Using Storage Class [%s], VolumeSnapshotClass [%s]", storageClassName, volumeSnapshotClassName)
 			log.Infof("Use Snapshot: %t", useSnapshot)
 
-			nodeSelector := parseNodeSelector(nodeSelectorStr)
+			nodeSelectorJSON, err := buildNodeSelectorJSON(selector)
+			if err != nil {
+				log.Fatal(err.Error())
+			}
 
 			AdditionalVars["privateKey"] = privateKeyPath
 			AdditionalVars["publicKey"] = publicKeyPath
@@ -114,7 +117,7 @@ func NewVirtCloneMulti(wh *workloads.WorkloadHelper) *cobra.Command {
 			AdditionalVars["jobIterationDelay"] = jobIterationDelay
 			AdditionalVars["dataVolumeCounters"] = generateLoopCounterSlice(dataVolumeCount, 1)
 			AdditionalVars["testNamespaceBaseName"] = testNamespaceBaseName
-			AdditionalVars["nodeSelector"] = nodeSelector
+			AdditionalVars["NODE_SELECTOR"] = nodeSelectorJSON
 			AdditionalVars["VM_IMAGE"] = vmImage
 			AdditionalVars["VM_CPU"] = vmCPU
 			AdditionalVars["VM_MEMORY"] = vmMemory
@@ -142,7 +145,7 @@ func NewVirtCloneMulti(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().StringVar(&volumeAccessMode, "access-mode", "RWX", "Access mode for the created volumes - RO, RWO, RWX")
 	cmd.Flags().DurationVar(&jobIterationDelay, "job-iteration-delay", 1*time.Minute, "Delay between namespace iterations")
 	cmd.Flags().StringVarP(&testNamespaceBaseName, "namespace", "n", virtCloneMultiTestName, "Base namespace name for the test")
-	cmd.Flags().StringVar(&nodeSelectorStr, "node-selector", "", "Node selector labels (comma-separated key=value pairs, e.g., topology.kubernetes.io/zone=us-east-1a,disktype=ssd)")
+	cmd.Flags().StringVar(&selector, "selector", WorkerNodeSelector, "Node selector")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics-aggregated.yml"}, "Comma separated list of metrics profiles to use")
 	cmd.Flags().BoolVar(&cleanup, "cleanup", false, "Cleanup resources created by previous runs")
 

--- a/pkg/workloads/virt-clone.go
+++ b/pkg/workloads/virt-clone.go
@@ -55,6 +55,7 @@ func NewVirtClone(wh *workloads.WorkloadHelper) *cobra.Command {
 	var jobIterationDelay time.Duration
 	var verifyMaxWaitTime time.Duration
 	var dataVolumeCount int
+	var nodeSelectorStr string
 	var cleanup bool
 	var rc int
 	cmd := &cobra.Command{
@@ -89,6 +90,9 @@ func NewVirtClone(wh *workloads.WorkloadHelper) *cobra.Command {
 			if err != nil {
 				log.Warnf("Failed to get OCP Virtualization version: %v", err)
 			}
+
+			nodeSelector := parseNodeSelector(nodeSelectorStr)
+
 			AdditionalVars["privateKey"] = privateKeyPath
 			AdditionalVars["publicKey"] = publicKeyPath
 			AdditionalVars["VM_IMAGE"] = vmImage
@@ -104,6 +108,7 @@ func NewVirtClone(wh *workloads.WorkloadHelper) *cobra.Command {
 			AdditionalVars["jobIterationDelay"] = jobIterationDelay
 			AdditionalVars["verifyMaxWaitTime"] = verifyMaxWaitTime
 			AdditionalVars["dataVolumeCounters"] = generateLoopCounterSlice(dataVolumeCount, 1)
+			AdditionalVars["nodeSelector"] = nodeSelector
 
 			setMetrics(cmd, metricsProfiles)
 			rc = RunWorkload(cmd, wh, cmd.Name()+".yml")
@@ -126,6 +131,7 @@ func NewVirtClone(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().DurationVar(&jobIterationDelay, "job-iteration-delay", 0, "Delay between job iterations")
 	cmd.Flags().DurationVar(&verifyMaxWaitTime, "verify-max-wait-time", 1*time.Hour, "Max wait time for clone creation waiting")
 	cmd.Flags().IntVar(&dataVolumeCount, "data-volume-count", virtCloneDefaultDataVolumeCount, "Number of data volumes per VM")
+	cmd.Flags().StringVar(&nodeSelectorStr, "node-selector", "", "Node selector labels (comma-separated key=value pairs, e.g., topology.kubernetes.io/zone=us-east-1a,disktype=ssd)")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
 	cmd.Flags().BoolVar(&cleanup, "cleanup", false, "Cleanup resources created by previous runs")
 	return cmd

--- a/pkg/workloads/virt-clone.go
+++ b/pkg/workloads/virt-clone.go
@@ -55,7 +55,7 @@ func NewVirtClone(wh *workloads.WorkloadHelper) *cobra.Command {
 	var jobIterationDelay time.Duration
 	var verifyMaxWaitTime time.Duration
 	var dataVolumeCount int
-	var nodeSelectorStr string
+	var selector string
 	var cleanup bool
 	var rc int
 	cmd := &cobra.Command{
@@ -91,7 +91,10 @@ func NewVirtClone(wh *workloads.WorkloadHelper) *cobra.Command {
 				log.Warnf("Failed to get OCP Virtualization version: %v", err)
 			}
 
-			nodeSelector := parseNodeSelector(nodeSelectorStr)
+			nodeSelectorJSON, err := buildNodeSelectorJSON(selector)
+			if err != nil {
+				log.Fatal(err.Error())
+			}
 
 			AdditionalVars["privateKey"] = privateKeyPath
 			AdditionalVars["publicKey"] = publicKeyPath
@@ -108,7 +111,7 @@ func NewVirtClone(wh *workloads.WorkloadHelper) *cobra.Command {
 			AdditionalVars["jobIterationDelay"] = jobIterationDelay
 			AdditionalVars["verifyMaxWaitTime"] = verifyMaxWaitTime
 			AdditionalVars["dataVolumeCounters"] = generateLoopCounterSlice(dataVolumeCount, 1)
-			AdditionalVars["nodeSelector"] = nodeSelector
+			AdditionalVars["NODE_SELECTOR"] = nodeSelectorJSON
 
 			setMetrics(cmd, metricsProfiles)
 			rc = RunWorkload(cmd, wh, cmd.Name()+".yml")
@@ -131,7 +134,7 @@ func NewVirtClone(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().DurationVar(&jobIterationDelay, "job-iteration-delay", 0, "Delay between job iterations")
 	cmd.Flags().DurationVar(&verifyMaxWaitTime, "verify-max-wait-time", 1*time.Hour, "Max wait time for clone creation waiting")
 	cmd.Flags().IntVar(&dataVolumeCount, "data-volume-count", virtCloneDefaultDataVolumeCount, "Number of data volumes per VM")
-	cmd.Flags().StringVar(&nodeSelectorStr, "node-selector", "", "Node selector labels (comma-separated key=value pairs, e.g., topology.kubernetes.io/zone=us-east-1a,disktype=ssd)")
+	cmd.Flags().StringVar(&selector, "selector", WorkerNodeSelector, "Node selector")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
 	cmd.Flags().BoolVar(&cleanup, "cleanup", false, "Cleanup resources created by previous runs")
 	return cmd

--- a/pkg/workloads/virt-density.go
+++ b/pkg/workloads/virt-density.go
@@ -44,6 +44,7 @@ func NewVirtDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 	var vmiRunningThreshold time.Duration
 	var namespacedIterations, mounts, sshCheck bool
 	var churnDelay, churnDuration time.Duration
+	var nodeSelectorStr string
 	var metricsProfiles []string
 	var cleanup bool
 	var sshKeyPairPath string
@@ -80,6 +81,8 @@ func NewVirtDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 				AdditionalVars["publicKey"] = publicKeyPath
 			}
 
+			nodeSelector := parseNodeSelector(nodeSelectorStr)
+
 			AdditionalVars["JOB_ITERATIONS"] = totalVMs - vmCount
 			AdditionalVars["VMI_RUNNING_THRESHOLD"] = vmiRunningThreshold
 			AdditionalVars["VM_IMAGE"] = vmImage
@@ -95,6 +98,7 @@ func NewVirtDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 			AdditionalVars["DELETION_STRATEGY"] = deletionStrategy
 			AdditionalVars["MOUNTS"] = mounts
 			AdditionalVars["SSH_CHECK"] = sshCheck
+			AdditionalVars["nodeSelector"] = nodeSelector
 			setMetrics(cmd, metricsProfiles)
 			AddVirtMetadata(wh, vmImage, "", "")
 			rc = RunWorkload(cmd, wh, cmd.Name()+".yml")
@@ -120,6 +124,7 @@ func NewVirtDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().DurationVar(&churnDelay, "churn-delay", 2*time.Minute, "Time to wait between each churn")
 	cmd.Flags().IntVar(&churnPercent, "churn-percent", 10, "Percentage of job iterations that kube-burner will churn each round")
 	cmd.Flags().StringVar(&churnMode, "churn-mode", string(config.ChurnObjects), "Either namespaces, to churn entire namespaces or objects, to churn individual objects")
+	cmd.Flags().StringVar(&nodeSelectorStr, "node-selector", "", "Node selector labels (comma-separated key=value pairs, e.g., topology.kubernetes.io/zone=us-east-1a,disktype=ssd)")
 	cmd.Flags().BoolVar(&cleanup, "cleanup", false, "Cleanup resources created by previous runs")
 	return cmd
 }

--- a/pkg/workloads/virt-density.go
+++ b/pkg/workloads/virt-density.go
@@ -44,7 +44,7 @@ func NewVirtDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 	var vmiRunningThreshold time.Duration
 	var namespacedIterations, mounts, sshCheck bool
 	var churnDelay, churnDuration time.Duration
-	var nodeSelectorStr string
+	var selector string
 	var metricsProfiles []string
 	var cleanup bool
 	var sshKeyPairPath string
@@ -81,7 +81,10 @@ func NewVirtDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 				AdditionalVars["publicKey"] = publicKeyPath
 			}
 
-			nodeSelector := parseNodeSelector(nodeSelectorStr)
+			nodeSelectorJSON, err := buildNodeSelectorJSON(selector)
+			if err != nil {
+				log.Fatal(err.Error())
+			}
 
 			AdditionalVars["JOB_ITERATIONS"] = totalVMs - vmCount
 			AdditionalVars["VMI_RUNNING_THRESHOLD"] = vmiRunningThreshold
@@ -98,7 +101,7 @@ func NewVirtDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 			AdditionalVars["DELETION_STRATEGY"] = deletionStrategy
 			AdditionalVars["MOUNTS"] = mounts
 			AdditionalVars["SSH_CHECK"] = sshCheck
-			AdditionalVars["nodeSelector"] = nodeSelector
+			AdditionalVars["NODE_SELECTOR"] = nodeSelectorJSON
 			setMetrics(cmd, metricsProfiles)
 			AddVirtMetadata(wh, vmImage, "", "")
 			rc = RunWorkload(cmd, wh, cmd.Name()+".yml")
@@ -124,7 +127,7 @@ func NewVirtDensity(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().DurationVar(&churnDelay, "churn-delay", 2*time.Minute, "Time to wait between each churn")
 	cmd.Flags().IntVar(&churnPercent, "churn-percent", 10, "Percentage of job iterations that kube-burner will churn each round")
 	cmd.Flags().StringVar(&churnMode, "churn-mode", string(config.ChurnObjects), "Either namespaces, to churn entire namespaces or objects, to churn individual objects")
-	cmd.Flags().StringVar(&nodeSelectorStr, "node-selector", "", "Node selector labels (comma-separated key=value pairs, e.g., topology.kubernetes.io/zone=us-east-1a,disktype=ssd)")
+	cmd.Flags().StringVar(&selector, "selector", WorkerNodeSelector, "Node selector")
 	cmd.Flags().BoolVar(&cleanup, "cleanup", false, "Cleanup resources created by previous runs")
 	return cmd
 }

--- a/pkg/workloads/virt-ephemeral-restart.go
+++ b/pkg/workloads/virt-ephemeral-restart.go
@@ -48,6 +48,7 @@ func NewVirtEphemeralRestart(wh *workloads.WorkloadHelper) *cobra.Command {
 	var testNamespace string
 	var metricsProfiles []string
 	var volumeAccessMode string
+	var nodeSelectorStr string
 	var cleanup bool
 	var rc int
 	cmd := &cobra.Command{
@@ -82,6 +83,9 @@ func NewVirtEphemeralRestart(wh *workloads.WorkloadHelper) *cobra.Command {
 			if err != nil {
 				log.Warnf("Failed to get OCP Virtualization version: %v", err)
 			}
+
+			nodeSelector := parseNodeSelector(nodeSelectorStr)
+
 			AdditionalVars["privateKey"] = privateKeyPath
 			AdditionalVars["publicKey"] = publicKeyPath
 			AdditionalVars["storageClassName"] = storageClassName
@@ -90,6 +94,7 @@ func NewVirtEphemeralRestart(wh *workloads.WorkloadHelper) *cobra.Command {
 			AdditionalVars["vmsPerIteration"] = vmsPerIteration
 			AdditionalVars["accessMode"] = accessModeTranslator[volumeAccessMode]
 			AdditionalVars["vmGroups"] = generateLoopCounterSlice(iterations, 0)
+			AdditionalVars["nodeSelector"] = nodeSelector
 			AdditionalVars["VM_IMAGE"] = vmImage
 			AdditionalVars["VM_CPU"] = vmCPU
 			AdditionalVars["VM_MEMORY"] = vmMemory
@@ -111,6 +116,7 @@ func NewVirtEphemeralRestart(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().StringVar(&vmCPU, "vm-cpu", "1", "Number of CPU cores for the VM")
 	cmd.Flags().StringVar(&vmMemory, "vm-memory", "512Mi", "Amount of memory for the VM")
 	cmd.Flags().StringVar(&volumeAccessMode, "access-mode", "RWX", "Access mode for the created volumes - RO, RWO, RWX")
+	cmd.Flags().StringVar(&nodeSelectorStr, "node-selector", "", "Node selector labels (comma-separated key=value pairs, e.g., topology.kubernetes.io/zone=us-east-1a,disktype=ssd)")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
 	cmd.Flags().BoolVar(&cleanup, "cleanup", false, "Cleanup resources created by previous runs")
 	return cmd

--- a/pkg/workloads/virt-ephemeral-restart.go
+++ b/pkg/workloads/virt-ephemeral-restart.go
@@ -48,7 +48,7 @@ func NewVirtEphemeralRestart(wh *workloads.WorkloadHelper) *cobra.Command {
 	var testNamespace string
 	var metricsProfiles []string
 	var volumeAccessMode string
-	var nodeSelectorStr string
+	var selector string
 	var cleanup bool
 	var rc int
 	cmd := &cobra.Command{
@@ -84,7 +84,10 @@ func NewVirtEphemeralRestart(wh *workloads.WorkloadHelper) *cobra.Command {
 				log.Warnf("Failed to get OCP Virtualization version: %v", err)
 			}
 
-			nodeSelector := parseNodeSelector(nodeSelectorStr)
+			nodeSelectorJSON, err := buildNodeSelectorJSON(selector)
+			if err != nil {
+				log.Fatal(err.Error())
+			}
 
 			AdditionalVars["privateKey"] = privateKeyPath
 			AdditionalVars["publicKey"] = publicKeyPath
@@ -94,7 +97,7 @@ func NewVirtEphemeralRestart(wh *workloads.WorkloadHelper) *cobra.Command {
 			AdditionalVars["vmsPerIteration"] = vmsPerIteration
 			AdditionalVars["accessMode"] = accessModeTranslator[volumeAccessMode]
 			AdditionalVars["vmGroups"] = generateLoopCounterSlice(iterations, 0)
-			AdditionalVars["nodeSelector"] = nodeSelector
+			AdditionalVars["NODE_SELECTOR"] = nodeSelectorJSON
 			AdditionalVars["VM_IMAGE"] = vmImage
 			AdditionalVars["VM_CPU"] = vmCPU
 			AdditionalVars["VM_MEMORY"] = vmMemory
@@ -116,7 +119,7 @@ func NewVirtEphemeralRestart(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().StringVar(&vmCPU, "vm-cpu", "1", "Number of CPU cores for the VM")
 	cmd.Flags().StringVar(&vmMemory, "vm-memory", "512Mi", "Amount of memory for the VM")
 	cmd.Flags().StringVar(&volumeAccessMode, "access-mode", "RWX", "Access mode for the created volumes - RO, RWO, RWX")
-	cmd.Flags().StringVar(&nodeSelectorStr, "node-selector", "", "Node selector labels (comma-separated key=value pairs, e.g., topology.kubernetes.io/zone=us-east-1a,disktype=ssd)")
+	cmd.Flags().StringVar(&selector, "selector", WorkerNodeSelector, "Node selector")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
 	cmd.Flags().BoolVar(&cleanup, "cleanup", false, "Cleanup resources created by previous runs")
 	return cmd

--- a/pkg/workloads/virt-parallel.go
+++ b/pkg/workloads/virt-parallel.go
@@ -54,7 +54,7 @@ func NewVirtParallel(wh *workloads.WorkloadHelper) *cobra.Command {
 	var skipResizeJob bool
 	var skipRestartJob bool
 	var skipSnapshotJob bool
-	var nodeSelectorStr string
+	var selector string
 	var metricsProfiles []string
 	var cleanup bool
 	var rc int
@@ -129,7 +129,10 @@ func NewVirtParallel(wh *workloads.WorkloadHelper) *cobra.Command {
 				log.Infof("skipSnapshotJob is set to true")
 			}
 
-			nodeSelector := parseNodeSelector(nodeSelectorStr)
+			nodeSelectorJSON, err := buildNodeSelectorJSON(selector)
+			if err != nil {
+				log.Fatal(err.Error())
+			}
 
 			AdditionalVars["privateKey"] = privateKeyPath
 			AdditionalVars["publicKey"] = publicKeyPath
@@ -144,7 +147,7 @@ func NewVirtParallel(wh *workloads.WorkloadHelper) *cobra.Command {
 			AdditionalVars["skipResizeJob"] = skipResizeJob
 			AdditionalVars["skipRestartJob"] = skipRestartJob
 			AdditionalVars["skipSnapshotJob"] = skipSnapshotJob
-			AdditionalVars["nodeSelector"] = nodeSelector
+			AdditionalVars["NODE_SELECTOR"] = nodeSelectorJSON
 			AdditionalVars["VM_IMAGE"] = vmImage
 			AdditionalVars["VM_CPU"] = vmCPU
 			AdditionalVars["VM_MEMORY"] = vmMemory
@@ -201,7 +204,7 @@ func NewVirtParallel(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().BoolVar(&skipResizeJob, "skip-resize-job", false, "Skip the resize propagation check - For now use when values are propagated in a base of 10 instead of 2")
 	cmd.Flags().BoolVar(&skipRestartJob, "skip-restart-job", false, "Skip the VM restart job")
 	cmd.Flags().BoolVar(&skipSnapshotJob, "skip-snapshot-job", false, "Skip the VM snapshot job")
-	cmd.Flags().StringVar(&nodeSelectorStr, "node-selector", "", "Node selector labels (comma-separated key=value pairs, e.g., topology.kubernetes.io/zone=us-east-1a,disktype=ssd)")
+	cmd.Flags().StringVar(&selector, "selector", WorkerNodeSelector, "Node selector")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics-aggregated.yml"}, "Comma separated list of metrics profiles to use")
 	cmd.Flags().BoolVar(&cleanup, "cleanup", false, "Cleanup resources created by previous runs")
 	return cmd

--- a/pkg/workloads/virt-parallel.go
+++ b/pkg/workloads/virt-parallel.go
@@ -54,6 +54,7 @@ func NewVirtParallel(wh *workloads.WorkloadHelper) *cobra.Command {
 	var skipResizeJob bool
 	var skipRestartJob bool
 	var skipSnapshotJob bool
+	var nodeSelectorStr string
 	var metricsProfiles []string
 	var cleanup bool
 	var rc int
@@ -128,6 +129,8 @@ func NewVirtParallel(wh *workloads.WorkloadHelper) *cobra.Command {
 				log.Infof("skipSnapshotJob is set to true")
 			}
 
+			nodeSelector := parseNodeSelector(nodeSelectorStr)
+
 			AdditionalVars["privateKey"] = privateKeyPath
 			AdditionalVars["publicKey"] = publicKeyPath
 			AdditionalVars["vmCount"] = fmt.Sprint(initialVms)
@@ -141,6 +144,7 @@ func NewVirtParallel(wh *workloads.WorkloadHelper) *cobra.Command {
 			AdditionalVars["skipResizeJob"] = skipResizeJob
 			AdditionalVars["skipRestartJob"] = skipRestartJob
 			AdditionalVars["skipSnapshotJob"] = skipSnapshotJob
+			AdditionalVars["nodeSelector"] = nodeSelector
 			AdditionalVars["VM_IMAGE"] = vmImage
 			AdditionalVars["VM_CPU"] = vmCPU
 			AdditionalVars["VM_MEMORY"] = vmMemory
@@ -197,6 +201,7 @@ func NewVirtParallel(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().BoolVar(&skipResizeJob, "skip-resize-job", false, "Skip the resize propagation check - For now use when values are propagated in a base of 10 instead of 2")
 	cmd.Flags().BoolVar(&skipRestartJob, "skip-restart-job", false, "Skip the VM restart job")
 	cmd.Flags().BoolVar(&skipSnapshotJob, "skip-snapshot-job", false, "Skip the VM snapshot job")
+	cmd.Flags().StringVar(&nodeSelectorStr, "node-selector", "", "Node selector labels (comma-separated key=value pairs, e.g., topology.kubernetes.io/zone=us-east-1a,disktype=ssd)")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics-aggregated.yml"}, "Comma separated list of metrics profiles to use")
 	cmd.Flags().BoolVar(&cleanup, "cleanup", false, "Cleanup resources created by previous runs")
 	return cmd

--- a/pkg/workloads/virt-udn-density.go
+++ b/pkg/workloads/virt-udn-density.go
@@ -38,7 +38,7 @@ func NewVirtUDNDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Comm
 	var churnPercent, churnCycles int
 	var l3, pprof bool
 	var churnDelay, churnDuration time.Duration
-	var deletionStrategy, vmImage, bindingMethod, churnMode, vmCPU, vmMemory, nodeSelectorStr string
+	var deletionStrategy, vmImage, bindingMethod, churnMode, vmCPU, vmMemory, selector string
 	var cleanup bool
 	var rc int
 	cmd := &cobra.Command{
@@ -85,7 +85,11 @@ func NewVirtUDNDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Comm
 			AdditionalVars["ENABLE_LAYER_3"] = l3
 			AdditionalVars["PPROF"] = pprof
 			AdditionalVars["PPROF_INTERVAL"] = pprofInterval.String()
-			AdditionalVars["nodeSelector"] = parseNodeSelector(nodeSelectorStr)
+			nodeSelectorJSON, err := buildNodeSelectorJSON(selector)
+			if err != nil {
+				log.Fatal(err.Error())
+			}
+			AdditionalVars["NODE_SELECTOR"] = nodeSelectorJSON
 			if l3 {
 				log.Info("Layer 3 is enabled")
 				AddVirtMetadata(wh, vmImage, "layer3", bindingMethod)
@@ -116,7 +120,7 @@ func NewVirtUDNDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Comm
 	cmd.Flags().BoolVar(&pprof, "pprof", false, "Enable pprof collection")
 	cmd.Flags().DurationVar(&pprofInterval, "pprof-interval", 0, "Interval between pprof collections")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
-	cmd.Flags().StringVar(&nodeSelectorStr, "node-selector", "", "Node selector labels (comma-separated key=value pairs, e.g., topology.kubernetes.io/zone=us-east-1a,disktype=ssd)")
+	cmd.Flags().StringVar(&selector, "selector", WorkerNodeSelector, "Node selector")
 	cmd.Flags().BoolVar(&cleanup, "cleanup", false, "Cleanup resources created by previous runs")
 	if variant == "virt-cudn-density" {
 		cmd.Annotations = map[string]string{"configDir": "virt-udn-density"}

--- a/pkg/workloads/virt-udn-density.go
+++ b/pkg/workloads/virt-udn-density.go
@@ -38,7 +38,7 @@ func NewVirtUDNDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Comm
 	var churnPercent, churnCycles int
 	var l3, pprof bool
 	var churnDelay, churnDuration time.Duration
-	var deletionStrategy, vmImage, bindingMethod, churnMode, vmCPU, vmMemory string
+	var deletionStrategy, vmImage, bindingMethod, churnMode, vmCPU, vmMemory, nodeSelectorStr string
 	var cleanup bool
 	var rc int
 	cmd := &cobra.Command{
@@ -85,6 +85,7 @@ func NewVirtUDNDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Comm
 			AdditionalVars["ENABLE_LAYER_3"] = l3
 			AdditionalVars["PPROF"] = pprof
 			AdditionalVars["PPROF_INTERVAL"] = pprofInterval.String()
+			AdditionalVars["nodeSelector"] = parseNodeSelector(nodeSelectorStr)
 			if l3 {
 				log.Info("Layer 3 is enabled")
 				AddVirtMetadata(wh, vmImage, "layer3", bindingMethod)
@@ -115,6 +116,7 @@ func NewVirtUDNDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Comm
 	cmd.Flags().BoolVar(&pprof, "pprof", false, "Enable pprof collection")
 	cmd.Flags().DurationVar(&pprofInterval, "pprof-interval", 0, "Interval between pprof collections")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics.yml"}, "Comma separated list of metrics profiles to use")
+	cmd.Flags().StringVar(&nodeSelectorStr, "node-selector", "", "Node selector labels (comma-separated key=value pairs, e.g., topology.kubernetes.io/zone=us-east-1a,disktype=ssd)")
 	cmd.Flags().BoolVar(&cleanup, "cleanup", false, "Cleanup resources created by previous runs")
 	if variant == "virt-cudn-density" {
 		cmd.Annotations = map[string]string{"configDir": "virt-udn-density"}


### PR DESCRIPTION
## Type of change

- New feature

## Description

Adds `--node-selector` flag to 7 virt workloads (virt-density, virt-udn-density, virt-capacity-benchmark, virt-parallel, virt-clone, virt-clone-multi, virt-ephemeral-restart).
  
Useful for targeting specific nodes or zones during testing. Accepts comma-separated key=value pairs, e.g., `--node-selector "topology.kubernetes.io/zone=us-east-1a"` or `--node-selector "test-zone=zone-a,disktype=ssd"` for multiple labels.