### PR TITLE
Change Layer2 CUDN CIDR from /19 to /24 to support more CUDNs

### DIFF
--- a/cmd/config/cudn-density/cudn-l2.yml
+++ b/cmd/config/cudn-density/cudn-l2.yml
@@ -2,13 +2,19 @@
 #   - AWS VPC (10.0.0.0/16), OCP pod network (10.128.0.0/14)
 #   - OVN-K internals (100.64.0.0/16 join, 100.88.0.0/16 transit)
 #
-# Adjust CIDR prefix and perBlock to match your cluster size and CUDN count:
+# Layer2 uses a flat network (no per-node subnet splitting), so "Max nodes"
+# is unlimited — the only constraint is total pod IPs fitting in the CIDR.
 #
-#   CIDR prefix | perBlock | Max nodes | Max CUDNs
-#   /16         | 1        | 1024      | 124
-#   /17         | 2        | 512       | 248
-#   /18         | 4        | 256       | 496
-#   /19         | 8        | 128       | 992
+#   CIDR prefix | perBlock | IPs/CUDN | Max CUDNs
+#   /16         | 1        | 65534    | 124
+#   /17         | 2        | 32766    | 248
+#   /18         | 4        | 16382    | 496
+#   /19         | 8        | 8190     | 992
+#   /20         | 16       | 4094     | 1984
+#   /21         | 32       | 2046     | 3968
+#   /22         | 64       | 1022     | 7936
+#   /23         | 128      | 510      | 15872
+#   /24         | 256      | 254      | 31744
 apiVersion: k8s.ovn.org/v1
 kind: ClusterUserDefinedNetwork
 metadata:
@@ -29,10 +35,10 @@ spec:
     - key: kubernetes.io/metadata.name
       operator: In
       values: {{$nsNames}}
-  {{- $perBlock := 8 }}
+  {{- $perBlock := 256 }}
   {{- $secondOctet := add 132 (div $.Iteration $perBlock) }}
-  {{- $thirdOctet := mul (mod $.Iteration $perBlock) 32 }}
-  {{- $cudnCidr := printf "10.%d.%d.0/19" $secondOctet $thirdOctet }}
+  {{- $thirdOctet := mod $.Iteration $perBlock }}
+  {{- $cudnCidr := printf "10.%d.%d.0/24" $secondOctet $thirdOctet }}
   network:
     topology: Layer2
     layer2:


### PR DESCRIPTION
Layer2 uses a flat network with no per-node subnet splitting, so a /24 (254 IPs) is sufficient for pod addressing. This increases the max CUDN count from 992 to 31,744, fixing CIDR overflow errors when running 1000+ CUDNs.

Assisted-by: Claude
