### PR TITLE
Node-density-fill

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,12 @@ The workloads of this family create a single namespace with a set of pods, deplo
 
 This workload is meant to fill with pause pods all the worker nodes from the cluster. It can be customized with the following flags. This workload is usually used to measure the Pod's ready latency KPI.
 
+By default it creates one Pod object per iteration so that kube-burner can drive creation QPS. `--fill-percent` adds a `node-density-fill` job that then tops the nodes matching `--selector` up to that percentage of their aggregated allocatable pod capacity. That job uses a single iteration and splits the pods across multiple Deployments, capped by `--pods-per-deployment` (default 1000).
+
+```console
+kube-burner-ocp node-density --fill-percent=80
+```
+
 ### node-density-cni
 
 It creates two deployments, a client/curl and a server/nxing, and 1 service backed by the previous server pods. The client application has configured an startup probe that makes requests to the previous service every second with a timeout of 600s.
@@ -1853,7 +1859,7 @@ It is possible to customize any of the above workload configurations by extracti
 ```console
 $ kube-burner-ocp node-density --extract
 $ ls
-alerts.yml  metrics.yml  node-density.yml  pod.yml  metrics-report.yml
+alerts.yml  metrics.yml  node-density.yml  pod.yml  deployment.yml  metrics-report.yml
 $ vi node-density.yml                               # Perform modifications accordingly
 $ kube-burner-ocp node-density --pods-per-node=100  # Run workload
 ```

--- a/cmd/config/event-storm/event-storm.yml
+++ b/cmd/config/event-storm/event-storm.yml
@@ -47,9 +47,9 @@ jobs:
       - cmd: ["create-event-storm.sh", "etcd-event-storm", "{{.EVENT_ITERATIONS}}", "{{.EVENT_REPLICAS}}", "{{.STORM_WORKERS}}"]
         when: beforeJobExecution
         background: true
-      - cmd: ["/bin/sh", "-c", "sleep {{.STORM_DELAY}}"]
+      - cmd: ["sleep {{.STORM_DELAY}}"]
         when: beforeJobExecution
-      - cmd: ["/bin/sh", "-c", "oc delete namespace etcd-event-storm --ignore-not-found=true --force --grace-period=0"]
+      - cmd: ["oc delete namespace etcd-event-storm --ignore-not-found=true --force --grace-period=0"]
         when: afterJobExecution
         background: true
     objects:

--- a/cmd/config/node-density/deployment.yml
+++ b/cmd/config/node-density/deployment.yml
@@ -1,0 +1,40 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    app: pause
+  name: {{.JobName}}-{{.Iteration}}-{{.Replica}}
+spec:
+  replicas: {{.podReplicas}}
+  selector:
+    matchLabels:
+      name: {{.JobName}}-{{.Iteration}}-{{.Replica}}
+      app: pause
+  template:
+    metadata:
+      labels:
+        name: {{.JobName}}-{{.Iteration}}-{{.Replica}}
+        app: pause
+    spec:
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: pause
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution: {{.nodeSelector|toJson}}
+      tolerations:
+      - key: os
+        value: Windows
+        effect: NoSchedule
+      containers:
+      - image: {{.containerImage}}
+        name: node-density
+        resources:
+          requests:
+            memory: "10Mi"
+            cpu: "10m"
+        imagePullPolicy: IfNotPresent

--- a/cmd/config/node-density/node-density.yml
+++ b/cmd/config/node-density/node-density.yml
@@ -52,8 +52,12 @@ metricsEndpoints:
 {{ end }}
 
 jobs:
+{{ if gt .JOB_ITERATIONS 0 }}
   - name: node-density
     namespace: node-density
+    {{ if .FILL_PERCENT }}
+    gc: true
+    {{ end }}
     jobIterations: {{.JOB_ITERATIONS}}
     qps: {{.QPS}}
     burst: {{.BURST}}
@@ -78,5 +82,31 @@ jobs:
       - objectTemplate: pod.yml
         replicas: 1
         inputVars:
-          containerImage: registry.k8s.io/pause:3.1
+          containerImage: "{{.CONTAINER_IMAGE}}"
           nodeSelector: {{.NODE_SELECTOR}}
+{{ end }}
+
+{{ if gt .FILL_PERCENT 0 }}
+  - name: node-density-fill
+    namespace: node-density-fill
+    jobIterations: 1
+    namespacedIterations: false
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    podWait: false
+    waitWhenFinished: true
+    preLoadImages: true
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+    objects:
+
+      - objectTemplate: deployment.yml
+        replicas: {{.DEPLOYMENT_REPLICAS}}
+        inputVars:
+          containerImage: "{{.CONTAINER_IMAGE}}"
+          nodeSelector: {{.NODE_SELECTOR}}
+          podReplicas: {{.POD_REPLICAS}}
+{{ end }}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.25.9
 
 require (
-	github.com/cloud-bulldozer/go-commons/v2 v2.3.8
+	github.com/cloud-bulldozer/go-commons/v2 v2.3.9
 	github.com/google/uuid v1.6.0
 	github.com/kube-burner/kube-burner/v2 v2.8.2
 	github.com/openshift/api v0.0.0-20260408160412-464776f95207

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,8 @@ github.com/chzyer/readline v1.5.1/go.mod h1:Eh+b79XXUwfKfcPLepksvw2tcLE/Ct21YObk
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloud-bulldozer/go-commons/v2 v2.3.8 h1:q9HdNFTnlbCdA6/y6UGd1jg0HImd6j8K4y9CFFrzQsg=
-github.com/cloud-bulldozer/go-commons/v2 v2.3.8/go.mod h1:UJt/nJdrpuSQjWNQyou1OmDP1DEFHZx7frNxnNawloY=
+github.com/cloud-bulldozer/go-commons/v2 v2.3.9 h1:XcbKuxXsKIgzxlbfcupi2kG/6XR7lG3m7sjPoVT6mRA=
+github.com/cloud-bulldozer/go-commons/v2 v2.3.9/go.mod h1:UJt/nJdrpuSQjWNQyou1OmDP1DEFHZx7frNxnNawloY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=

--- a/pkg/workloads/node-density.go
+++ b/pkg/workloads/node-density.go
@@ -15,7 +15,6 @@
 package workloads
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -26,7 +25,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -34,7 +32,7 @@ import (
 func NewNodeDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Command {
 	var rc int
 	var metricsProfiles []string
-	var iterationsPerNamespace, podsPerNode, churnCycles, churnPercent, numSriovs int
+	var iterationsPerNamespace, podsPerNode, churnCycles, churnPercent, numSriovs, fillPercent, podsPerDeployment int
 	var podReadyThreshold, churnDuration, churnDelay, probesPeriod, pprofInterval time.Duration
 	var containerImage, deletionStrategy, churnMode, selector, perfProfile, sriovNetworkName string
 	var namespacedIterations, pprof, svcLatency bool
@@ -46,16 +44,18 @@ func NewNodeDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Command
 		Short:        fmt.Sprintf("Runs %v workload", variant),
 		SilenceUsage: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			kubeClientProvider := config.NewKubeClientProvider("", "")
-			clientSet, _ := kubeClientProvider.ClientSet(0, 0)
-			nodes, err := clientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: selector})
+			if fillPercent != 0 && (fillPercent < 1 || fillPercent > 100) {
+				log.Fatal("fill-percent must be between 1 and 100")
+			}
+			nodeResources, err := wh.MetadataAgent.GetAggregatedNodeResources(selector)
 			if err != nil {
 				log.Fatal(err.Error())
 			}
-			if len(nodes.Items) == 0 {
-				log.Fatalf("No nodes found with the selector: %s", selector)
+			if nodeResources.NodeCount == 0 {
+				log.Fatalf("No ready schedulable nodes found with the selector: %s", selector)
 			}
-			totalPods := len(nodes.Items) * podsPerNode
+			log.Infof("Aggregated allocatable resources for selector %q: nodes=%d cpu=%dm memory=%dKi pods=%d",
+				selector, nodeResources.NodeCount, nodeResources.CPUMilliCores, nodeResources.MemoryBytes/1024, nodeResources.PodCapacity)
 			podCount, err := wh.MetadataAgent.GetCurrentPodCount(selector)
 			if err != nil {
 				log.Fatal(err.Error())
@@ -105,10 +105,26 @@ func NewNodeDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Command
 				log.Fatal(err.Error())
 			}
 			AdditionalVars["NODE_SELECTOR"] = string(nodeSelectorJson)
+			totalPods := nodeResources.NodeCount * podsPerNode
+			jobIterations := max(totalPods-podCount, 0)
 			if variant == "node-density" {
-				AdditionalVars["JOB_ITERATIONS"] = totalPods - podCount
+				AdditionalVars["JOB_ITERATIONS"] = jobIterations
 			} else {
-				AdditionalVars["JOB_ITERATIONS"] = (totalPods - podCount) / 2
+				AdditionalVars["JOB_ITERATIONS"] = jobIterations / 2
+			}
+			if variant == "node-density" && fillPercent > 0 {
+				if podsPerDeployment < 1 {
+					log.Fatal("pods-per-deployment must be at least 1")
+				}
+				fillReplicas := nodeDensityFillReplicas(nodeResources.PodCapacity, fillPercent, podCount+jobIterations)
+				deployments, podsPerDeployment := nodeDensityFillLayout(fillReplicas, podsPerDeployment)
+				if deployments > 0 {
+					log.Infof("Filling selected nodes to %d%% of pod capacity: creating %d deployments with %d pods each (%d total, target %d)",
+						fillPercent, deployments, podsPerDeployment, deployments*podsPerDeployment, fillReplicas)
+					AdditionalVars["DEPLOYMENT_REPLICAS"] = deployments
+					AdditionalVars["POD_REPLICAS"] = podsPerDeployment
+					AdditionalVars["FILL_PERCENT"] = fillPercent
+				}
 			}
 			setMetrics(cmd, metricsProfiles)
 			rc = RunWorkload(cmd, wh, cmd.Name()+".yml")
@@ -130,6 +146,8 @@ func NewNodeDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Command
 	case "node-density":
 		cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 0, "Pod ready timeout threshold")
 		cmd.Flags().StringVar(&containerImage, "container-image", "gcr.io/google_containers/pause:3.1", "Container image")
+		cmd.Flags().IntVar(&fillPercent, "fill-percent", 0, "Percentage of aggregated allocatable pod capacity to fill on nodes matching --selector. Creates Deployments in a single job iteration")
+		cmd.Flags().IntVar(&podsPerDeployment, "max-pods-per-deployment", 1000, "Maximum pods per Deployment when using --fill-percent")
 	case "node-density-heavy":
 		cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 0, "Pod ready timeout threshold")
 		cmd.Flags().DurationVar(&probesPeriod, "probes-period", 10*time.Second, "Perf app readiness/liveness probes period")
@@ -146,4 +164,26 @@ func NewNodeDensity(wh *workloads.WorkloadHelper, variant string) *cobra.Command
 	cmd.Flags().IntVar(&iterationsPerNamespace, "iterations-per-namespace", 1000, "Iterations per namespace")
 	cmd.Flags().StringVar(&selector, "selector", workerNodeSelector, "Node selector")
 	return cmd
+}
+
+// nodeDensityFillReplicas returns the number of pod replicas needed to reach fillPercent of
+// aggregated allocatable pod capacity, accounting for pods already running on the selected nodes.
+func nodeDensityFillReplicas(podCapacity int64, fillPercent, currentPods int) int {
+	targetPods := int(podCapacity * int64(fillPercent) / 100)
+	replicas := targetPods - currentPods
+	if replicas < 0 {
+		return 0
+	}
+	return replicas
+}
+
+// nodeDensityFillLayout splits fillReplicas across Deployments so that each Deployment stays
+// within maxPodsPerDeployment and the total pod count never exceeds fillReplicas.
+func nodeDensityFillLayout(fillReplicas, maxPodsPerDeployment int) (deployments, podsPerDeployment int) {
+	if fillReplicas <= 0 {
+		return 0, 0
+	}
+	deployments = (fillReplicas + maxPodsPerDeployment - 1) / maxPodsPerDeployment
+	podsPerDeployment = fillReplicas / deployments
+	return deployments, podsPerDeployment
 }

--- a/pkg/workloads/node-density_test.go
+++ b/pkg/workloads/node-density_test.go
@@ -1,0 +1,169 @@
+package workloads
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"text/template"
+)
+
+func TestNodeDensityFillReplicas(t *testing.T) {
+	tests := []struct {
+		name        string
+		podCapacity int64
+		fillPercent int
+		currentPods int
+		want        int
+	}{
+		{name: "empty cluster at 80 percent", podCapacity: 250, fillPercent: 80, currentPods: 0, want: 200},
+		{name: "subtracts already running pods", podCapacity: 250, fillPercent: 80, currentPods: 50, want: 150},
+		{name: "already at or above target", podCapacity: 250, fillPercent: 50, currentPods: 200, want: 0},
+		{name: "full capacity", podCapacity: 500, fillPercent: 100, currentPods: 10, want: 490},
+		{name: "truncates toward zero", podCapacity: 3, fillPercent: 50, currentPods: 0, want: 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := nodeDensityFillReplicas(tc.podCapacity, tc.fillPercent, tc.currentPods)
+			if got != tc.want {
+				t.Fatalf("nodeDensityFillReplicas(%d, %d, %d) = %d, want %d",
+					tc.podCapacity, tc.fillPercent, tc.currentPods, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNodeDensityFillLayout(t *testing.T) {
+	tests := []struct {
+		name                  string
+		fillReplicas          int
+		maxPodsPerDeployment  int
+		wantDeployments       int
+		wantPodsPerDeployment int
+	}{
+		{name: "exact multiple", fillReplicas: 2000, maxPodsPerDeployment: 1000, wantDeployments: 2, wantPodsPerDeployment: 1000},
+		{name: "does not round up past fill target", fillReplicas: 2500, maxPodsPerDeployment: 1000, wantDeployments: 3, wantPodsPerDeployment: 833},
+		{name: "below cap uses one deployment", fillReplicas: 500, maxPodsPerDeployment: 1000, wantDeployments: 1, wantPodsPerDeployment: 500},
+		{name: "just over one cap", fillReplicas: 1001, maxPodsPerDeployment: 1000, wantDeployments: 2, wantPodsPerDeployment: 500},
+		{name: "zero fill", fillReplicas: 0, maxPodsPerDeployment: 1000, wantDeployments: 0, wantPodsPerDeployment: 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			deployments, podsPerDeployment := nodeDensityFillLayout(tc.fillReplicas, tc.maxPodsPerDeployment)
+			if deployments != tc.wantDeployments || podsPerDeployment != tc.wantPodsPerDeployment {
+				t.Fatalf("nodeDensityFillLayout(%d, %d) = (%d, %d), want (%d, %d)",
+					tc.fillReplicas, tc.maxPodsPerDeployment, deployments, podsPerDeployment,
+					tc.wantDeployments, tc.wantPodsPerDeployment)
+			}
+			if deployments*podsPerDeployment > tc.fillReplicas {
+				t.Fatalf("layout created %d pods, exceeding fill target %d",
+					deployments*podsPerDeployment, tc.fillReplicas)
+			}
+			if podsPerDeployment > tc.maxPodsPerDeployment {
+				t.Fatalf("layout used %d pods per deployment, exceeding cap %d",
+					podsPerDeployment, tc.maxPodsPerDeployment)
+			}
+		})
+	}
+}
+
+func TestNodeDensityTemplateFillPercentAddsFillJob(t *testing.T) {
+	rendered := renderNodeDensityTemplate(t, nodeDensityTemplateData(map[string]any{
+		"FILL_PERCENT":        80,
+		"DEPLOYMENT_REPLICAS": 3,
+		"POD_REPLICAS":        40,
+	}))
+	if !strings.Contains(rendered, "name: node-density-fill") {
+		t.Fatal("expected fill-percent to add the node-density-fill job")
+	}
+	if !strings.Contains(rendered, "jobIterations: 1") {
+		t.Fatal("expected node-density-fill to use a single iteration")
+	}
+	if !strings.Contains(rendered, "namespacedIterations: false") {
+		t.Fatal("expected node-density-fill to disable namespaced iterations")
+	}
+	if !strings.Contains(rendered, "objectTemplate: deployment.yml") {
+		t.Fatal("expected node-density-fill to create a deployment")
+	}
+	if !strings.Contains(rendered, "replicas: 3") {
+		t.Fatal("expected node-density-fill to create multiple deployments")
+	}
+	if !strings.Contains(rendered, "podReplicas: 40") {
+		t.Fatal("expected deployment podReplicas to be rendered")
+	}
+}
+
+func TestNodeDensityTemplateDefaultUsesPodJob(t *testing.T) {
+	rendered := renderNodeDensityTemplate(t, nodeDensityTemplateData(nil))
+	if !strings.Contains(rendered, "name: node-density\n") && !strings.Contains(rendered, "name: node-density\r\n") {
+		if !strings.Contains(rendered, "- name: node-density") {
+			t.Fatal("expected default config to include the node-density job")
+		}
+	}
+	if !strings.Contains(rendered, "objectTemplate: pod.yml") {
+		t.Fatal("expected default job to create bare pods")
+	}
+	if strings.Contains(rendered, "name: node-density-fill") {
+		t.Fatal("did not expect node-density-fill when fill-percent is unset")
+	}
+	if strings.Contains(rendered, "objectTemplate: deployment.yml") {
+		t.Fatal("did not expect a deployment when fill-percent is unset")
+	}
+	if !strings.Contains(rendered, "jobIterations: 42") {
+		t.Fatal("expected default job to use JOB_ITERATIONS")
+	}
+}
+
+func nodeDensityTemplateData(overrides map[string]any) map[string]any {
+	data := map[string]any{
+		"ALERTS":                   "",
+		"BURST":                    5,
+		"CHURN_CYCLES":             0,
+		"CHURN_DELAY":              "2m0s",
+		"CHURN_DURATION":           "0s",
+		"CHURN_MODE":               "objects",
+		"CHURN_PERCENT":            10,
+		"CONTAINER_IMAGE":          "registry.k8s.io/pause:3.1",
+		"DELETION_STRATEGY":        "gvr",
+		"ES_INDEX":                 "",
+		"ES_SERVER":                "",
+		"FILL_PERCENT":             0,
+		"GC":                       true,
+		"GC_METRICS":               false,
+		"ITERATIONS_PER_NAMESPACE": 1000,
+		"JOB_ITERATIONS":           42,
+		"LOCAL_INDEXING":           false,
+		"METRICS":                  "metrics.yml",
+		"NAMESPACED_ITERATIONS":    true,
+		"NODE_SELECTOR":            `{"nodeSelectorTerms":[]}`,
+		"POD_READY_THRESHOLD":      0,
+		"POD_REPLICAS":             0,
+		"DEPLOYMENT_REPLICAS":      0,
+		"PPROF":                    false,
+		"QPS":                      5,
+		"UUID":                     "test-uuid",
+	}
+	for key, value := range overrides {
+		data[key] = value
+	}
+	return data
+}
+
+func renderNodeDensityTemplate(t *testing.T, data map[string]any) string {
+	t.Helper()
+	templatePath := filepath.Join("..", "..", "cmd", "config", "node-density", "node-density.yml")
+	templateBytes, err := os.ReadFile(templatePath)
+	if err != nil {
+		t.Fatalf("failed to read template: %v", err)
+	}
+	tmpl, err := template.New("node-density").Option("missingkey=error").Parse(string(templateBytes))
+	if err != nil {
+		t.Fatalf("failed to parse template: %v", err)
+	}
+	var output bytes.Buffer
+	if err := tmpl.Execute(&output, data); err != nil {
+		t.Fatalf("failed to render template: %v", err)
+	}
+	return output.String()
+}


### PR DESCRIPTION
This pull request adds a new "fill percent" mode. The main feature allows users to fill nodes to a specified percentage of their allocatable pod capacity using deployments, making it easier to simulate high-density pod scenarios. 

**Node-density fill percent feature:**

* Added a `--fill-percent` flag to the `node-density` workload, which creates a new `node-density-fill` job to fill nodes up to the specified percentage of their pod capacity using deployments. This includes logic to calculate the required number of deployments and pods per deployment, with a configurable cap via `--max-pods-per-deployment`. [[1]](diffhunk://#diff-49f244d5c58946acb11496227a441c5689bb23f48ee807613844ece24c6b9227L49-R58) [[2]](diffhunk://#diff-49f244d5c58946acb11496227a441c5689bb23f48ee807613844ece24c6b9227R108-R127) [[3]](diffhunk://#diff-49f244d5c58946acb11496227a441c5689bb23f48ee807613844ece24c6b9227R149-R150) [[4]](diffhunk://#diff-49f244d5c58946acb11496227a441c5689bb23f48ee807613844ece24c6b9227R168-R189) [[5]](diffhunk://#diff-b1918eace4752cf2d7e99aa113d7912a67531bf26cce07e9e1c3f643c6fe5d37R55-R60) [[6]](diffhunk://#diff-b1918eace4752cf2d7e99aa113d7912a67531bf26cce07e9e1c3f643c6fe5d37L81-R112) [[7]](diffhunk://#diff-e24d41259bfef71355583839fb938fa9bcc2635f753f80c0a1b27e1c4bc548a0R1-R40)

**Documentation updates:**

* Updated the `README.md` to explain the new fill percent mode, including usage examples and details on how pods are distributed across deployments.
* Updated the example output for extracting and customizing workload configuration files to include the new `deployment.yml` template.

**Configuration and dependency updates:**

* Bumped the `go-commons` dependency to v2.3.9 in `go.mod`.
* Updated the default container image and made it configurable via a flag. [[1]](diffhunk://#diff-b1918eace4752cf2d7e99aa113d7912a67531bf26cce07e9e1c3f643c6fe5d37L81-R112) [[2]](diffhunk://#diff-49f244d5c58946acb11496227a441c5689bb23f48ee807613844ece24c6b9227R149-R150)

**Miscellaneous:**

* Minor code cleanup and simplification in `node-density.go` (removal of unused imports, improved error messages). [[1]](diffhunk://#diff-49f244d5c58946acb11496227a441c5689bb23f48ee807613844ece24c6b9227L18) [[2]](diffhunk://#diff-49f244d5c58946acb11496227a441c5689bb23f48ee807613844ece24c6b9227L29-R35) [[3]](diffhunk://#diff-49f244d5c58946acb11496227a441c5689bb23f48ee807613844ece24c6b9227L49-R58)

These changes collectively make the `node-density` workload more flexible and robust for simulating real-world pod densities in Kubernetes clusters.