### PR TITLE
Add VM cloning support to virt-parallel and virt-capacity-benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -813,6 +813,15 @@ Some storage classes have limitations requiring the test to skip some parts. All
 - `--skip-snapshot-job` - Skip the VM snapshot job. Use when snapshots are not supported or not needed
 - `--skip-migration-job` - Skip the migration job. Use when e.g. `RWX` `accessMode` is not supported
 
+#### VM Image Source
+
+By default, VMs are created directly from container disk images pulled from the registry. For testing storage cloning performance or reducing registry load, VMs can be cloned from a base image:
+
+- `--use-base-image` - Create a base `DataVolume` from the container image, then clone all VMs from it (default: false)
+- `--use-snapshot` - When using `--use-base-image`, clone from `VolumeSnapshot` instead of direct `PVC` clone (default: true)
+
+When `--use-base-image` is enabled, the workflow creates a base `DataVolume`, optionally creates a `VolumeSnapshot`, then clones all VMs from the snapshot or `PVC`. This reduces registry pulls and enables storage cloning performance testing.
+
 #### Cleanup
 
 Since the test is expected to run until failure, it is designed to keep all allocated resources to allow investigating the failure.
@@ -880,6 +889,15 @@ Some storage classes have limitations requiring the test to skip some parts. All
 - `--skip-restart-job` - Skip the VM restart job. Use when you want to test without VM restarts
 - `--skip-snapshot-job` - Skip the VM snapshot job. Use when snapshots are not supported or not needed
 - `--skip-migration-job` - Skip the migration job. Use when e.g. `RWX` `accessMode` is not supported
+
+#### VM Image Source
+
+By default, VMs are created directly from container disk images pulled from the registry. For testing storage cloning performance or reducing registry load, VMs can be cloned from a base image:
+
+- `--use-base-image` - Create a base `DataVolume` from the container image, then clone all VMs from it (default: false)
+- `--use-snapshot` - When using `--use-base-image`, clone from `VolumeSnapshot` instead of direct `PVC` clone (default: true)
+
+When `--use-base-image` is enabled, the workflow creates a base `DataVolume`, optionally creates a `VolumeSnapshot`, then clones all VMs from the snapshot or `PVC`. This reduces registry pulls and enables storage cloning performance testing.
 
 #### Cleanup
 

--- a/cmd/config/virt-capacity-benchmark/templates/baseImageDataSource.yml
+++ b/cmd/config/virt-capacity-benchmark/templates/baseImageDataSource.yml
@@ -1,0 +1,15 @@
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataSource
+metadata:
+  name: {{ .baseDataSourceName }}
+spec:
+  source:
+    {{ if .useSnapshot }}
+    snapshot:
+      name: {{ .baseDataSourceSnapshotName }}
+      namespace: {{ .baseDataSourceSnapshotNamespace }}
+    {{ else }}
+    pvc:
+      name: {{ .baseDataSourcePVCName }}
+      namespace: {{ .baseDataSourcePVCNamespace }}
+    {{ end }}

--- a/cmd/config/virt-capacity-benchmark/templates/baseImageDataVolume.yml
+++ b/cmd/config/virt-capacity-benchmark/templates/baseImageDataVolume.yml
@@ -1,0 +1,19 @@
+---
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: {{ .baseDataVolumeName }}
+  annotations:
+    cdi.kubevirt.io/storage.bind.immediate.requested: "true"
+spec:
+  source:
+    registry:
+      url: {{ .baseDataVolumeUrl }}
+  storage:
+    accessModes:
+    - {{ .accessMode }}
+    resources:
+      requests:
+        storage: {{ .baseDataVolumeSize }}
+    storageClassName: {{ .storageClassName }}
+...

--- a/cmd/config/virt-capacity-benchmark/templates/baseImageDataVolumeSnapshot.yml
+++ b/cmd/config/virt-capacity-benchmark/templates/baseImageDataVolumeSnapshot.yml
@@ -1,0 +1,8 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: {{ .baseVolumeSnapshotName }}
+spec:
+  volumeSnapshotClassName: {{ .volumeSnapshotClassName }}
+  source:
+    persistentVolumeClaimName: {{ .baseVolumeSnapshotPVCName }}

--- a/cmd/config/virt-capacity-benchmark/templates/vm.yml
+++ b/cmd/config/virt-capacity-benchmark/templates/vm.yml
@@ -23,9 +23,16 @@ spec:
         {{ $key }}: {{ $value }}
       {{end}}
     spec:
+      {{- if .useBaseImage }}
+      sourceRef:
+        kind: DataSource
+        name: base-image
+        namespace: {{ .namespace }}
+      {{- else }}
       source:
         registry:
           url: "docker://{{ .rootDiskImage }}"
+      {{- end }}
       storage:
         accessModes:
         - {{ $accessMode }}

--- a/cmd/config/virt-capacity-benchmark/virt-capacity-benchmark.yml
+++ b/cmd/config/virt-capacity-benchmark/virt-capacity-benchmark.yml
@@ -47,6 +47,84 @@ jobs:
   - kind: Namespace
     labelSelector:
       {{ $testNamespacesLabelKey }}: {{ $testNamespacesLabelValue }}
+
+{{ if .useBaseImage }}
+# Create base image - only in iteration 0
+- name: create-base-image-dv
+  jobType: create
+  jobIterations: 1
+  qps: 20
+  burst: 20
+  namespacedIterations: false
+  namespace: {{ $nsName }}
+  namespaceLabels:
+    {{ $testNamespacesLabelKey }}: {{ $testNamespacesLabelValue }}
+  verifyObjects: true
+  errorOnVerify: true
+  waitWhenFinished: false
+  podWait: true
+  maxWaitTimeout: 30m
+  jobPause: 10s
+  cleanup: false
+  defaultMissingKeysWithZero: true
+  objects:
+  - objectTemplate: templates/baseImageDataVolume.yml
+    replicas: 1
+    inputVars:
+      baseDataVolumeName: base-image
+      baseDataVolumeUrl: "docker://{{.VM_IMAGE}}"
+      storageClassName: {{ .storageClassName }}
+      baseDataVolumeSize: {{ $rootVolumeSizeStr }}
+      accessMode: {{ .skipMigrationJob | ternary "ReadWriteOnce" "ReadWriteMany"}}
+    waitOptions:
+      customStatusPaths:
+      - key: '(.conditions.[] | select(.type == "Ready")).status'
+        value: "True"
+
+- name: create-base-image-datasource
+  jobType: create
+  jobIterations: 1
+  qps: 20
+  burst: 20
+  namespacedIterations: false
+  namespace: {{ $nsName }}
+  namespaceLabels:
+    {{ $testNamespacesLabelKey }}: {{ $testNamespacesLabelValue }}
+  verifyObjects: true
+  errorOnVerify: true
+  waitWhenFinished: false
+  podWait: false
+  maxWaitTimeout: 30m
+  jobPause: 10s
+  cleanup: false
+  defaultMissingKeysWithZero: true
+  objects:
+  {{ if .useSnapshot }}
+  - objectTemplate: templates/baseImageDataVolumeSnapshot.yml
+    replicas: 1
+    inputVars:
+      baseVolumeSnapshotName: base-image
+      volumeSnapshotClassName: {{ .volumeSnapshotClassName }}
+      baseVolumeSnapshotPVCName: base-image
+    waitOptions:
+      customStatusPaths:
+      - key: '.readyToUse | tostring'
+        value: "true"
+  {{ end }}
+  - objectTemplate: templates/baseImageDataSource.yml
+    replicas: 1
+    inputVars:
+      baseDataSourceName: base-image
+      baseDataSourcePVCName: base-image
+      baseDataSourcePVCNamespace: {{ $nsName }}
+      baseDataSourceSnapshotName: base-image
+      baseDataSourceSnapshotNamespace: {{ $nsName }}
+      useSnapshot: {{ .useSnapshot }}
+    waitOptions:
+      customStatusPaths:
+      - key: '(.conditions.[] | select(.type == "Ready")).status'
+        value: "True"
+{{ end }}
 {{ end }}
 
 - name: create-vms-{{ .counter }}
@@ -101,6 +179,8 @@ jobs:
       vmCPU: {{.VM_CPU}}
       vmMemory: {{.VM_MEMORY}}
       storageClassName: {{ .storageClassName }}
+      namespace: {{ $nsName }}
+      useBaseImage: {{ .useBaseImage }}
       vmLabels:
         {{ $jobCounterLabelKey }}: {{ $jobCounterLabelValue }}
       rootVolumeLabels:

--- a/cmd/config/virt-parallel/templates/baseImageDataSource.yml
+++ b/cmd/config/virt-parallel/templates/baseImageDataSource.yml
@@ -1,0 +1,15 @@
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataSource
+metadata:
+  name: {{ .baseDataSourceName }}
+spec:
+  source:
+    {{ if .useSnapshot }}
+    snapshot:
+      name: {{ .baseDataSourceSnapshotName }}
+      namespace: {{ .baseDataSourceSnapshotNamespace }}
+    {{ else }}
+    pvc:
+      name: {{ .baseDataSourcePVCName }}
+      namespace: {{ .baseDataSourcePVCNamespace }}
+    {{ end }}

--- a/cmd/config/virt-parallel/templates/baseImageDataVolume.yml
+++ b/cmd/config/virt-parallel/templates/baseImageDataVolume.yml
@@ -1,0 +1,19 @@
+---
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: {{ .baseDataVolumeName }}
+  annotations:
+    cdi.kubevirt.io/storage.bind.immediate.requested: "true"
+spec:
+  source:
+    registry:
+      url: {{ .baseDataVolumeUrl }}
+  storage:
+    accessModes:
+    - {{ .accessMode }}
+    resources:
+      requests:
+        storage: {{ .baseDataVolumeSize }}
+    storageClassName: {{ .storageClassName }}
+...

--- a/cmd/config/virt-parallel/templates/baseImageDataVolumeSnapshot.yml
+++ b/cmd/config/virt-parallel/templates/baseImageDataVolumeSnapshot.yml
@@ -1,0 +1,8 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: {{ .baseVolumeSnapshotName }}
+spec:
+  volumeSnapshotClassName: {{ .volumeSnapshotClassName }}
+  source:
+    persistentVolumeClaimName: {{ .baseVolumeSnapshotPVCName }}

--- a/cmd/config/virt-parallel/templates/vm.yml
+++ b/cmd/config/virt-parallel/templates/vm.yml
@@ -23,9 +23,16 @@ spec:
         {{ $key }}: {{ $value }}
       {{end}}
     spec:
+      {{- if .useBaseImage }}
+      sourceRef:
+        kind: DataSource
+        name: base-image
+        namespace: {{ .namespace }}
+      {{- else }}
       source:
         registry:
           url: "docker://{{ .rootDiskImage }}"
+      {{- end }}
       storage:
         accessModes:
         - {{ $accessMode }}

--- a/cmd/config/virt-parallel/virt-parallel.yml
+++ b/cmd/config/virt-parallel/virt-parallel.yml
@@ -47,6 +47,84 @@ jobs:
   - kind: Namespace
     labelSelector:
       {{ $testNamespacesLabelKey }}: {{ $testNamespacesLabelValue }}
+
+{{ if .useBaseImage }}
+# Create base image - only in counter 0
+- name: {{ $testName }}-create-base-image-dv
+  jobType: create
+  jobIterations: 1
+  qps: 20
+  burst: 20
+  namespacedIterations: false
+  namespace: {{ $nsName }}
+  namespaceLabels:
+    {{ $testNamespacesLabelKey }}: {{ $testNamespacesLabelValue }}
+  verifyObjects: true
+  errorOnVerify: true
+  waitWhenFinished: false
+  podWait: true
+  maxWaitTimeout: 30m
+  jobPause: 10s
+  cleanup: false
+  defaultMissingKeysWithZero: true
+  objects:
+  - objectTemplate: templates/baseImageDataVolume.yml
+    replicas: 1
+    inputVars:
+      baseDataVolumeName: base-image
+      baseDataVolumeUrl: "docker://{{.VM_IMAGE}}"
+      storageClassName: {{ .storageClassName }}
+      baseDataVolumeSize: {{ $rootVolumeSizeStr }}
+      accessMode: {{ .skipMigrationJob | ternary "ReadWriteOnce" "ReadWriteMany"}}
+    waitOptions:
+      customStatusPaths:
+      - key: '(.conditions.[] | select(.type == "Ready")).status'
+        value: "True"
+
+- name: {{ $testName }}-create-base-image-datasource
+  jobType: create
+  jobIterations: 1
+  qps: 20
+  burst: 20
+  namespacedIterations: false
+  namespace: {{ $nsName }}
+  namespaceLabels:
+    {{ $testNamespacesLabelKey }}: {{ $testNamespacesLabelValue }}
+  verifyObjects: true
+  errorOnVerify: true
+  waitWhenFinished: false
+  podWait: false
+  maxWaitTimeout: 30m
+  jobPause: 10s
+  cleanup: false
+  defaultMissingKeysWithZero: true
+  objects:
+  {{ if .useSnapshot }}
+  - objectTemplate: templates/baseImageDataVolumeSnapshot.yml
+    replicas: 1
+    inputVars:
+      baseVolumeSnapshotName: base-image
+      volumeSnapshotClassName: {{ .volumeSnapshotClassName }}
+      baseVolumeSnapshotPVCName: base-image
+    waitOptions:
+      customStatusPaths:
+      - key: '.readyToUse | tostring'
+        value: "true"
+  {{ end }}
+  - objectTemplate: templates/baseImageDataSource.yml
+    replicas: 1
+    inputVars:
+      baseDataSourceName: base-image
+      baseDataSourcePVCName: base-image
+      baseDataSourcePVCNamespace: {{ $nsName }}
+      baseDataSourceSnapshotName: base-image
+      baseDataSourceSnapshotNamespace: {{ $nsName }}
+      useSnapshot: {{ .useSnapshot }}
+    waitOptions:
+      customStatusPaths:
+      - key: '(.conditions.[] | select(.type == "Ready")).status'
+        value: "True"
+{{ end }}
 {{ end }}
 
 - name: {{ $testName }}-create-vms-{{ .counter }}
@@ -101,6 +179,8 @@ jobs:
       vmCPU: {{.VM_CPU}}
       vmMemory: {{.VM_MEMORY}}
       storageClassName: {{ .storageClassName }}
+      namespace: {{ $nsName }}
+      useBaseImage: {{ .useBaseImage }}
       vmLabels:
         {{ $jobCounterLabelKey }}: {{ $jobCounterLabelValue }}
       rootVolumeLabels:

--- a/pkg/workloads/virt-capacity-benchmark.go
+++ b/pkg/workloads/virt-capacity-benchmark.go
@@ -53,6 +53,8 @@ func NewVirtCapacityBenchmark(wh *workloads.WorkloadHelper) *cobra.Command {
 	var skipRestartJob bool
 	var skipSnapshotJob bool
 	var selector string
+	var useBaseImage bool
+	var useSnapshot bool
 	var metricsProfiles []string
 	var cleanup bool
 	var rc int
@@ -89,6 +91,7 @@ func NewVirtCapacityBenchmark(wh *workloads.WorkloadHelper) *cobra.Command {
 					}
 				}
 			}
+
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if cleanup {
@@ -126,6 +129,9 @@ func NewVirtCapacityBenchmark(wh *workloads.WorkloadHelper) *cobra.Command {
 			if skipSnapshotJob {
 				log.Infof("skipSnapshotJob is set to true")
 			}
+			if useBaseImage {
+				log.Infof("useBaseImage is set to true")
+			}
 
 			nodeSelectorJSON, err := buildNodeSelectorJSON(selector)
 			if err != nil {
@@ -149,6 +155,8 @@ func NewVirtCapacityBenchmark(wh *workloads.WorkloadHelper) *cobra.Command {
 			AdditionalVars["skipRestartJob"] = skipRestartJob
 			AdditionalVars["skipSnapshotJob"] = skipSnapshotJob
 			AdditionalVars["NODE_SELECTOR"] = nodeSelectorJSON
+			AdditionalVars["useBaseImage"] = useBaseImage
+			AdditionalVars["useSnapshot"] = useSnapshot
 			AdditionalVars["VM_IMAGE"] = vmImage
 			AdditionalVars["VM_CPU"] = vmCPU
 			AdditionalVars["VM_MEMORY"] = vmMemory
@@ -160,6 +168,13 @@ func NewVirtCapacityBenchmark(wh *workloads.WorkloadHelper) *cobra.Command {
 				storageClassName := storageClasses[counter%len(storageClasses)]
 				log.Infof("Running loop %d with Storage Class [%s]", counter, storageClassName)
 				AdditionalVars["storageClassName"] = storageClassName
+
+				// Get volumeSnapshotClassName if useBaseImage is enabled
+				var volumeSnapshotClassName string
+				if useBaseImage {
+					_, volumeSnapshotClassName = getStorageAndSnapshotClasses(storageClassName, useSnapshot, cmd.Flags().Lookup("use-snapshot").Changed)
+				}
+				AdditionalVars["volumeSnapshotClassName"] = volumeSnapshotClassName
 
 				os.Setenv("counter", fmt.Sprint(counter))
 				rc = RunWorkload(cmd, wh, cmd.Name()+".yml")
@@ -194,6 +209,8 @@ func NewVirtCapacityBenchmark(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().BoolVar(&skipRestartJob, "skip-restart-job", false, "Skip the VM restart job")
 	cmd.Flags().BoolVar(&skipSnapshotJob, "skip-snapshot-job", false, "Skip the VM snapshot job")
 	cmd.Flags().StringVar(&selector, "selector", WorkerNodeSelector, "Node selector")
+	cmd.Flags().BoolVar(&useBaseImage, "use-base-image", false, "Create a base image and clone VMs from it instead of using container disk per VM")
+	cmd.Flags().BoolVar(&useSnapshot, "use-snapshot", true, "Clone from snapshot - only applies when --use-base-image=true")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics-aggregated.yml"}, "Comma separated list of metrics profiles to use")
 	cmd.Flags().BoolVar(&cleanup, "cleanup", false, "Cleanup resources created by previous runs")
 	return cmd

--- a/pkg/workloads/virt-parallel.go
+++ b/pkg/workloads/virt-parallel.go
@@ -55,6 +55,8 @@ func NewVirtParallel(wh *workloads.WorkloadHelper) *cobra.Command {
 	var skipRestartJob bool
 	var skipSnapshotJob bool
 	var selector string
+	var useBaseImage bool
+	var useSnapshot bool
 	var metricsProfiles []string
 	var cleanup bool
 	var rc int
@@ -91,6 +93,7 @@ func NewVirtParallel(wh *workloads.WorkloadHelper) *cobra.Command {
 					}
 				}
 			}
+
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if cleanup {
@@ -128,6 +131,9 @@ func NewVirtParallel(wh *workloads.WorkloadHelper) *cobra.Command {
 			if skipSnapshotJob {
 				log.Infof("skipSnapshotJob is set to true")
 			}
+			if useBaseImage {
+				log.Infof("useBaseImage is set to true")
+			}
 
 			nodeSelectorJSON, err := buildNodeSelectorJSON(selector)
 			if err != nil {
@@ -148,6 +154,8 @@ func NewVirtParallel(wh *workloads.WorkloadHelper) *cobra.Command {
 			AdditionalVars["skipRestartJob"] = skipRestartJob
 			AdditionalVars["skipSnapshotJob"] = skipSnapshotJob
 			AdditionalVars["NODE_SELECTOR"] = nodeSelectorJSON
+			AdditionalVars["useBaseImage"] = useBaseImage
+			AdditionalVars["useSnapshot"] = useSnapshot
 			AdditionalVars["VM_IMAGE"] = vmImage
 			AdditionalVars["VM_CPU"] = vmCPU
 			AdditionalVars["VM_MEMORY"] = vmMemory
@@ -162,6 +170,13 @@ func NewVirtParallel(wh *workloads.WorkloadHelper) *cobra.Command {
 				log.Infof("Running loop %d with Storage Class [%s]", counter, storageClassName)
 				AdditionalVars["storageClassName"] = storageClassName
 				AdditionalVars["vmCount"] = vmCount
+
+				// Get volumeSnapshotClassName if useBaseImage is enabled
+				var volumeSnapshotClassName string
+				if useBaseImage {
+					_, volumeSnapshotClassName = getStorageAndSnapshotClasses(storageClassName, useSnapshot, cmd.Flags().Lookup("use-snapshot").Changed)
+				}
+				AdditionalVars["volumeSnapshotClassName"] = volumeSnapshotClassName
 
 				// Randomly select a node for migration
 				if !skipMigrationJob {
@@ -205,6 +220,8 @@ func NewVirtParallel(wh *workloads.WorkloadHelper) *cobra.Command {
 	cmd.Flags().BoolVar(&skipRestartJob, "skip-restart-job", false, "Skip the VM restart job")
 	cmd.Flags().BoolVar(&skipSnapshotJob, "skip-snapshot-job", false, "Skip the VM snapshot job")
 	cmd.Flags().StringVar(&selector, "selector", WorkerNodeSelector, "Node selector")
+	cmd.Flags().BoolVar(&useBaseImage, "use-base-image", false, "Create a base image and clone VMs from it instead of using container disk per VM")
+	cmd.Flags().BoolVar(&useSnapshot, "use-snapshot", true, "Clone from snapshot - only applies when --use-base-image=true")
 	cmd.Flags().StringSliceVar(&metricsProfiles, "metrics-profile", []string{"metrics-aggregated.yml"}, "Comma separated list of metrics profiles to use")
 	cmd.Flags().BoolVar(&cleanup, "cleanup", false, "Cleanup resources created by previous runs")
 	return cmd


### PR DESCRIPTION
## Type of change

- New feature

## Description

Enable VM creation from base images instead of direct container disk pulls. New flags allow testing storage cloning performance and reducing registry load:
  - `--use-base-image`: Clone VMs from a base `DataVolume`
  - `--use-snapshot`: Clone from `VolumeSnapshot` or direct PVC clone

The workflow creates a base `DataVolume` from the container image, optionally creates a `VolumeSnapshot`, then clones all VMs from the snapshot or PVC.

