### PR TITLE
Ensure annotation-churn respects --qps and --burst settings

### DIFF
--- a/cmd/config/annotation-churn/annotation-churn.yml
+++ b/cmd/config/annotation-churn/annotation-churn.yml
@@ -43,6 +43,8 @@ jobs:
   - name: churn-patch
     jobType: patch
     jobIterations: {{.PATCH_ROUNDS}}
+    qps: {{.QPS}}
+    burst: {{.BURST}}
     namespacedIterations: true
     namespace: etcd-churn
     jobPause: 1s


### PR DESCRIPTION
## Type of change

- Bug fix

## Description

Previously, the churn-patch job in the etcd-density annotation-churn workload ignored --qps and --burst setting specified on the command line. This resulted in annotations being churned at a maximum of 5 per second (the default QPS).

## Related Tickets & Documents

- Closes #521